### PR TITLE
fix(credits): enable column sorting and default to due_date descending

### DIFF
--- a/frontend/src/pages/credits/components/CreditsTableColumns.tsx
+++ b/frontend/src/pages/credits/components/CreditsTableColumns.tsx
@@ -151,7 +151,6 @@ export const getCreditsColumns = (
     {
       // Number -> Right Align
       accessorKey: "amount",
-      id: "`tabPO Payment Terms`.amount", // Explicit ID for backend sorting
       header: ({ column }) => (
         <div className="flex justify-end">
           <DataTableColumnHeader column={column} title="Due Amount" />
@@ -166,7 +165,6 @@ export const getCreditsColumns = (
     {
       // Date -> Center Align
       accessorKey: "due_date",
-      id: "`tabPO Payment Terms`.due_date", // Explicit ID for backend sorting
       header: ({ column }) => (
         <div className="flex justify-center">
           <DataTableColumnHeader column={column} title="Due Date" />

--- a/frontend/src/pages/credits/hooks/useCredits.ts
+++ b/frontend/src/pages/credits/hooks/useCredits.ts
@@ -124,7 +124,8 @@ export const useCredits = () => {
   }));
 
   // --- Sorting State ---
-  const [sorting, setSorting] = useState<SortingState>([]);
+  // Default to descending due_date (most urgent/overdue items first)
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'due_date', desc: true }]);
 
   // --- Search State ---
   const [searchTerm, setSearchTerm] = useState<string>(
@@ -258,7 +259,7 @@ export const useCredits = () => {
     // Build order_by from sorting state
     const orderBy = sorting.length > 0
       ? `${sorting[0].id} ${sorting[0].desc ? "desc" : "asc"}`
-      : "due_date asc";
+      : "due_date desc";
 
     const payload = {
       status_filter: currentStatus,

--- a/nirmaan_stack/api/credits/get_credits_list.py
+++ b/nirmaan_stack/api/credits/get_credits_list.py
@@ -346,15 +346,16 @@ def _parse_tanstack_filters(filters_json: str) -> list:
 def _build_order_clause(order_by: str) -> str:
     """
     Build SQL ORDER BY clause from user input.
-    Default: due_date ASC
+    Default: due_date DESC (most urgent/overdue items first)
     """
     if not order_by:
-        return 'ORDER BY pt.due_date ASC'
+        return 'ORDER BY pt.due_date DESC'
 
     # Map frontend field names to SQL fields
     field_map = {
         'due_date': 'pt.due_date',
         'amount': 'pt.amount',
+        'total_amount': 'po.total_amount',
         'term_status': 'pt.term_status',
         'creation': 'po.creation',
         'modified': 'pt.modified',


### PR DESCRIPTION
- Remove explicit SQL-style column IDs from amount/due_date columns that didn't match backend field_map
- Add total_amount to backend sorting field_map
- Initialize sorting state with due_date descending (most urgent first)
- Update fallback default sort from ASC to DESC