### PR TITLE
feat: Fix Material Plan sub-category persistence

### DIFF
--- a/frontend/src/pages/projects/components/planning/AddMaterialPlanForm.tsx
+++ b/frontend/src/pages/projects/components/planning/AddMaterialPlanForm.tsx
@@ -349,7 +349,8 @@ export const AddMaterialPlanForm = ({ planNumber, projectId, projectPackages, on
                     deliveryDate: "",
                     isCritical: assocTasks.length > 0 || isLocal,
                     category: assocTasks.length > 0 ? assocTasks[0].category : (isLocal ? selectedCategory : undefined),
-                    task: assocTasks.length > 0 ? assocTasks[0].item_name : (isLocal ? selectedTaskDoc?.item_name : undefined)
+                    task: assocTasks.length > 0 ? assocTasks[0].item_name : (isLocal ? selectedTaskDoc?.item_name : undefined),
+                    subCategory: assocTasks.length > 0 ? assocTasks[0].sub_category : (isLocal ? selectedTaskDoc?.sub_category : undefined)
                 };
             });
             setReviewPlans(plans);
@@ -377,7 +378,8 @@ export const AddMaterialPlanForm = ({ planNumber, projectId, projectPackages, on
                     deliveryDate: "",
                     isCritical: assocTasks.length > 0 || isLocal,
                     category: assocTasks.length > 0 ? assocTasks[0].category : (isLocal ? selectedCategory : undefined),
-                    task: assocTasks.length > 0 ? assocTasks[0].item_name : (isLocal ? selectedTaskDoc?.item_name : undefined)
+                    task: assocTasks.length > 0 ? assocTasks[0].item_name : (isLocal ? selectedTaskDoc?.item_name : undefined),
+                    subCategory: assocTasks.length > 0 ? assocTasks[0].sub_category : (isLocal ? selectedTaskDoc?.sub_category : undefined)
                 };
             });
             setReviewPlans(plans);
@@ -400,13 +402,22 @@ export const AddMaterialPlanForm = ({ planNumber, projectId, projectPackages, on
             }));
             
             try {
+                // Failsafe: if subCategory is missing but we have a task name, try to find it
+                let finalSubCategory = plan.subCategory;
+                if (!finalSubCategory && plan.task && allTasks.length > 0) {
+                     const foundTask = allTasks.find((t: any) => t.item_name === plan.task && (!plan.category || t.critical_po_category === plan.category));
+                     if (foundTask) {
+                         finalSubCategory = foundTask.sub_category;
+                     }
+                }
+
                 await createDoc("Material Delivery Plan", {
                     project: projectId,
                     po_link: plan.poName,
                     package_name: "", // V2: Not used
                     critical_po_category: plan.isCritical ? plan.category : null,
                     critical_po_task: plan.isCritical ? plan.task : null,
-                    critical_po_sub_category: plan.isCritical ? plan.subCategory : null,
+                    critical_po_sub_category: plan.isCritical ? finalSubCategory : null,
                     delivery_date: plan.deliveryDate,
                     po_type: "Existing PO",
                     mp_items: JSON.stringify({ list: minimalItems })

--- a/frontend/src/pages/projects/components/planning/ReviewPlansPage.tsx
+++ b/frontend/src/pages/projects/components/planning/ReviewPlansPage.tsx
@@ -137,7 +137,8 @@ export const ReviewPlansPage: React.FC<ReviewPlansPageProps> = ({
             selectedItems: new Set(), // Reset selection as items changed
             isCritical: isCritical,
             category: assocTasks.length > 0 ? assocTasks[0].category : ((isLocal || isFallback) ? categoryName : undefined),
-            task: assocTasks.length > 0 ? assocTasks[0].item_name : ((isLocal || isFallback) ? taskName : undefined)
+            task: assocTasks.length > 0 ? assocTasks[0].item_name : ((isLocal || isFallback) ? taskName : undefined),
+            subCategory: assocTasks.length > 0 ? assocTasks[0].sub_category : ((isLocal || isFallback) ? allTasks.find(t => t.item_name === taskName)?.sub_category : undefined)
         };
         
         onPlansChange(updatedPlans);


### PR DESCRIPTION
- Correctly populate subCategory in AddMaterialPlanForm during initial POPlan creation.
- Add failsafe in handleSubmitPlans to look up subCategory from allTasks if missing.
- Update ReviewPlansPage to preserve subCategory when switching POs.

Impact:
- Ensures critical_po_sub_category is correctly saved even when the user doesn't manually edit the task in the review page.
- Prevents data loss for Existing PO flows.
- Correctly links the plan to its specific sub-category, enabling better filtering and reporting downstream.