### PR TITLE
feat(assets): split Asset Categories into Project and IT types

### DIFF
--- a/frontend/src/pages/Assets/AssetOverview.tsx
+++ b/frontend/src/pages/Assets/AssetOverview.tsx
@@ -60,6 +60,8 @@ import {
     AlertTriangle,
     Upload,
     Download,
+    Briefcase,
+    Laptop,
 } from 'lucide-react';
 
 import { AssignAssetDialog } from './components/AssignAssetDialog';
@@ -71,6 +73,7 @@ import {
     ASSET_MANAGEMENT_DOCTYPE,
     ASSET_CONDITION_OPTIONS,
     ASSET_CACHE_KEYS,
+    AssetCategoryType,
 } from './assets.constants';
 import { getAssetPermissions } from './utils/permissions';
 
@@ -110,6 +113,16 @@ const conditionColorMap: Record<string, string> = {
     'Fair': 'bg-amber-50 text-amber-700 border-amber-200',
     'Poor': 'bg-orange-50 text-orange-700 border-orange-200',
     'Damaged': 'bg-red-50 text-red-700 border-red-200',
+};
+
+const categoryTypeBadgeClass: Record<AssetCategoryType, string> = {
+    Project: 'bg-blue-50 text-blue-700 border-blue-200',
+    IT: 'bg-purple-50 text-purple-700 border-purple-200',
+};
+
+const categoryTypeIconMap: Record<AssetCategoryType, React.ReactNode> = {
+    Project: <Briefcase className="h-3 w-3 mr-1" />,
+    IT: <Laptop className="h-3 w-3 mr-1" />,
 };
 
 const AssetOverview: React.FC = () => {
@@ -234,7 +247,7 @@ const AssetOverviewContent: React.FC<{ assetId: string }> = ({ assetId }) => {
     const { data: categoryList } = useFrappeGetDocList(
         ASSET_CATEGORY_DOCTYPE,
         {
-            fields: ['name', 'asset_category'],
+            fields: ['name', 'asset_category', 'category_type'],
             orderBy: { field: 'asset_category', order: 'asc' },
             limit: 0,
         },
@@ -248,6 +261,13 @@ const AssetOverviewContent: React.FC<{ assetId: string }> = ({ assetId }) => {
         })) || [],
         [categoryList]
     );
+
+    const currentCategoryType: AssetCategoryType | null = useMemo(() => {
+        if (!asset?.asset_category || !categoryList) return null;
+        const match = (categoryList as any[]).find((c) => c.name === asset.asset_category);
+        const t = match?.category_type;
+        return t === 'Project' || t === 'IT' ? t : null;
+    }, [asset?.asset_category, categoryList]);
 
     const { updateDoc, loading: isUpdating } = useFrappeUpdateDoc();
     const { upload } = useFrappeFileUpload();
@@ -502,7 +522,18 @@ const AssetOverviewContent: React.FC<{ assetId: string }> = ({ assetId }) => {
                                 icon={<Boxes className="h-4 w-4" />}
                                 label="Category"
                                 value={
-                                    <Badge variant="outline">{asset?.asset_category}</Badge>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <Badge variant="outline">{asset?.asset_category}</Badge>
+                                        {currentCategoryType && (
+                                            <Badge
+                                                variant="outline"
+                                                className={`font-medium ${categoryTypeBadgeClass[currentCategoryType]}`}
+                                            >
+                                                {categoryTypeIconMap[currentCategoryType]}
+                                                {currentCategoryType}
+                                            </Badge>
+                                        )}
+                                    </div>
                                 }
                             />
                             <DetailRow

--- a/frontend/src/pages/Assets/AssetsPage.tsx
+++ b/frontend/src/pages/Assets/AssetsPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { useUserData } from '@/hooks/useUserData';
-import { Plus, Boxes, Package, Users, UserX, AlertTriangle, List } from 'lucide-react';
+import { Plus, Boxes, Briefcase, Laptop, Users, UserX, AlertTriangle, List } from 'lucide-react';
 
 import { AssetsSummaryCards } from './components/AssetsSummaryCard';
 import { AssetCategoriesList } from './components/AssetCategoriesList';
@@ -14,49 +14,111 @@ import { AddAssetCategoryDialog } from './components/AddAssetCategoryDialog';
 import { AddAssetDialog } from './components/AddAssetDialog';
 import { useAssetDataRefresh } from './hooks/useAssetDataRefresh';
 import { getAssetPermissions } from './utils/permissions';
+import { AssetCategoryType } from './assets.constants';
+
+type AssetTopTab = 'project' | 'it' | 'categories';
+type AssetSubTab = 'all' | 'assigned' | 'unassigned' | 'pending';
+
+const assetSubTabs: { id: AssetSubTab; label: string; shortLabel: string; icon: React.ComponentType<{ className?: string }> }[] = [
+    { id: 'all', label: 'All', shortLabel: 'All', icon: List },
+    { id: 'assigned', label: 'Assigned', shortLabel: 'Asgn', icon: Users },
+    { id: 'unassigned', label: 'Unassigned', shortLabel: 'Free', icon: UserX },
+    { id: 'pending', label: 'Pending Declaration', shortLabel: 'Decl', icon: AlertTriangle },
+];
+
+interface AssetSubTabsViewProps {
+    assetType: AssetCategoryType;
+    refreshKey: number;
+    onAssetChange: () => void;
+}
+
+const AssetSubTabsView: React.FC<AssetSubTabsViewProps> = ({ assetType, refreshKey, onAssetChange }) => {
+    const [subTab, setSubTab] = useState<AssetSubTab>('all');
+
+    return (
+        <>
+            <div className="flex items-center gap-1 mb-3 overflow-x-auto pb-1 scrollbar-hide">
+                {assetSubTabs.map((tab) => {
+                    const Icon = tab.icon;
+                    const isActive = subTab === tab.id;
+                    return (
+                        <button
+                            key={tab.id}
+                            onClick={() => setSubTab(tab.id)}
+                            className={`
+                                inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium
+                                transition-all duration-200 whitespace-nowrap
+                                ${isActive
+                                    ? 'bg-gray-900 text-white shadow-sm'
+                                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
+                                }
+                            `}
+                        >
+                            <Icon className={`h-3.5 w-3.5 ${isActive ? 'text-white' : tab.id === 'pending' ? 'text-amber-500' : ''}`} />
+                            <span className="hidden sm:inline">{tab.label}</span>
+                            <span className="sm:hidden">{tab.shortLabel}</span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            <div>
+                {subTab === 'all' && (
+                    <AssetMasterList key={`${assetType}-all-${refreshKey}`} assetType={assetType} />
+                )}
+                {subTab === 'assigned' && (
+                    <AssignedAssetsList key={`${assetType}-assigned-${refreshKey}`} assetType={assetType} />
+                )}
+                {subTab === 'unassigned' && (
+                    <UnassignedAssetsList
+                        key={`${assetType}-unassigned-${refreshKey}`}
+                        assetType={assetType}
+                        onAssigned={onAssetChange}
+                    />
+                )}
+                {subTab === 'pending' && (
+                    <PendingActionsList
+                        key={`${assetType}-pending-${refreshKey}`}
+                        assetType={assetType}
+                        onUploaded={onAssetChange}
+                    />
+                )}
+            </div>
+        </>
+    );
+};
 
 const AssetsPage: React.FC = () => {
     const userData = useUserData();
-    const [activeTab, setActiveTab] = useState('assets');
-    const [assetSubTab, setAssetSubTab] = useState('all');
+    const [activeTab, setActiveTab] = useState<AssetTopTab>('project');
     const [addCategoryDialogOpen, setAddCategoryDialogOpen] = useState(false);
     const [addAssetDialogOpen, setAddAssetDialogOpen] = useState(false);
-    // Refresh keys to trigger data refetch after adding items
     const [categoryRefreshKey, setCategoryRefreshKey] = useState(0);
     const [assetRefreshKey, setAssetRefreshKey] = useState(0);
 
-    // Hook for cross-component cache invalidation
     const { refreshSummaryCards, refreshCategoryDropdowns } = useAssetDataRefresh();
-
-    // Get granular permissions for current user
     const { canAddAsset, canAddCategory } = getAssetPermissions(userData?.user_id, userData?.role);
 
     const handleAssetChange = () => {
         setAssetRefreshKey(k => k + 1);
-        refreshSummaryCards(); // Also refresh summary counts
+        refreshSummaryCards();
     };
 
     const handleCategoryAdded = () => {
         setCategoryRefreshKey(k => k + 1);
-        refreshSummaryCards(); // Refresh category count in summary
-        refreshCategoryDropdowns(); // Refresh category dropdowns in dialogs
+        refreshSummaryCards();
+        refreshCategoryDropdowns();
     };
 
     const handleAssetAdded = () => {
         setAssetRefreshKey(k => k + 1);
-        refreshSummaryCards(); // Refresh asset counts in summary
+        refreshSummaryCards();
     };
 
-    const assetSubTabs = [
-        { id: 'all', label: 'All', icon: List },
-        { id: 'assigned', label: 'Assigned', icon: Users },
-        { id: 'unassigned', label: 'Unassigned', icon: UserX },
-        { id: 'pending', label: 'Pending Declaration', icon: AlertTriangle },
-    ];
+    const isAssetsTab = activeTab === 'project' || activeTab === 'it';
 
     return (
-        <div className="flex flex-col gap-3 sm:gap-4 h-[calc(100vh-80px)] overflow-hidden">
-            {/* Header - compact on mobile */}
+        <div className="flex flex-col gap-3 sm:gap-4">
             <div>
                 <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-gray-900">
                     Asset Management
@@ -66,23 +128,30 @@ const AssetsPage: React.FC = () => {
                 </p>
             </div>
 
-            {/* Summary Cards */}
             <AssetsSummaryCards />
 
-            {/* Main Tabs */}
             <Tabs
                 value={activeTab}
-                onValueChange={setActiveTab}
-                className="flex-1 flex flex-col min-h-0"
+                onValueChange={(v) => setActiveTab(v as AssetTopTab)}
+                className="flex flex-col"
             >
                 <div className="flex items-center justify-between gap-4">
                     <TabsList className="w-fit bg-gray-100/80 p-1">
                         <TabsTrigger
-                            value="assets"
-                            className="gap-2 data-[state=active]:bg-white data-[state=active]:shadow-sm"
+                            value="project"
+                            className="gap-2 data-[state=active]:bg-white data-[state=active]:shadow-sm data-[state=active]:text-blue-700"
                         >
-                            <Package className="h-4 w-4" />
-                            Assets
+                            <Briefcase className="h-4 w-4" />
+                            <span className="hidden sm:inline">Project Assets</span>
+                            <span className="sm:hidden">Project</span>
+                        </TabsTrigger>
+                        <TabsTrigger
+                            value="it"
+                            className="gap-2 data-[state=active]:bg-white data-[state=active]:shadow-sm data-[state=active]:text-purple-700"
+                        >
+                            <Laptop className="h-4 w-4" />
+                            <span className="hidden sm:inline">IT Assets</span>
+                            <span className="sm:hidden">IT</span>
                         </TabsTrigger>
                         <TabsTrigger
                             value="categories"
@@ -93,9 +162,8 @@ const AssetsPage: React.FC = () => {
                         </TabsTrigger>
                     </TabsList>
 
-                    {/* Action buttons - show based on granular permissions */}
                     <div>
-                        {activeTab === 'assets' && canAddAsset && (
+                        {isAssetsTab && canAddAsset && (
                             <Button
                                 size="sm"
                                 onClick={() => setAddAssetDialogOpen(true)}
@@ -120,74 +188,36 @@ const AssetsPage: React.FC = () => {
                     </div>
                 </div>
 
-                {/* Assets Tab Content with Sub-tabs */}
                 <TabsContent
-                    value="assets"
-                    className="flex-1 mt-3 sm:mt-4 min-h-0 data-[state=inactive]:hidden flex flex-col"
+                    value="project"
+                    className="mt-3 sm:mt-4 data-[state=inactive]:hidden"
                 >
-                    {/* Asset Sub-tabs - Compact pill navigation */}
-                    <div className="flex items-center gap-1 mb-3 overflow-x-auto pb-1 scrollbar-hide">
-                        {assetSubTabs.map((tab) => {
-                            const Icon = tab.icon;
-                            const isActive = assetSubTab === tab.id;
-                            return (
-                                <button
-                                    key={tab.id}
-                                    onClick={() => setAssetSubTab(tab.id)}
-                                    className={`
-                                        inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium
-                                        transition-all duration-200 whitespace-nowrap
-                                        ${isActive
-                                            ? 'bg-gray-900 text-white shadow-sm'
-                                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-800'
-                                        }
-                                    `}
-                                >
-                                    <Icon className={`h-3.5 w-3.5 ${isActive ? 'text-white' : tab.id === 'pending' ? 'text-amber-500' : ''}`} />
-                                    <span className="hidden sm:inline">{tab.label}</span>
-                                    <span className="sm:hidden">
-                                        {tab.id === 'all' ? 'All' :
-                                         tab.id === 'assigned' ? 'Asgn' :
-                                         tab.id === 'unassigned' ? 'Free' : 'Decl'}
-                                    </span>
-                                </button>
-                            );
-                        })}
-                    </div>
-
-                    {/* Sub-tab Content */}
-                    <div className="flex-1 min-h-0">
-                        {assetSubTab === 'all' && (
-                            <AssetMasterList key={`all-assets-${assetRefreshKey}`} />
-                        )}
-                        {assetSubTab === 'assigned' && (
-                            <AssignedAssetsList key={`assigned-assets-${assetRefreshKey}`} />
-                        )}
-                        {assetSubTab === 'unassigned' && (
-                            <UnassignedAssetsList
-                                key={`unassigned-assets-${assetRefreshKey}`}
-                                onAssigned={handleAssetChange}
-                            />
-                        )}
-                        {assetSubTab === 'pending' && (
-                            <PendingActionsList
-                                key={`pending-assets-${assetRefreshKey}`}
-                                onUploaded={handleAssetChange}
-                            />
-                        )}
-                    </div>
+                    <AssetSubTabsView
+                        assetType="Project"
+                        refreshKey={assetRefreshKey}
+                        onAssetChange={handleAssetChange}
+                    />
                 </TabsContent>
 
-                {/* Categories Tab Content */}
+                <TabsContent
+                    value="it"
+                    className="mt-3 sm:mt-4 data-[state=inactive]:hidden"
+                >
+                    <AssetSubTabsView
+                        assetType="IT"
+                        refreshKey={assetRefreshKey}
+                        onAssetChange={handleAssetChange}
+                    />
+                </TabsContent>
+
                 <TabsContent
                     value="categories"
-                    className="flex-1 mt-3 sm:mt-4 min-h-0 data-[state=inactive]:hidden"
+                    className="mt-3 sm:mt-4 data-[state=inactive]:hidden"
                 >
                     <AssetCategoriesList key={`categories-${categoryRefreshKey}`} />
                 </TabsContent>
             </Tabs>
 
-            {/* Dialogs */}
             <AddAssetCategoryDialog
                 isOpen={addCategoryDialogOpen}
                 onOpenChange={setAddCategoryDialogOpen}

--- a/frontend/src/pages/Assets/assets.constants.ts
+++ b/frontend/src/pages/Assets/assets.constants.ts
@@ -9,9 +9,18 @@ export const ASSET_MANAGEMENT_DOCTYPE = 'Asset Management';
 export const ASSET_CATEGORY_FIELDS = [
     'name',
     'asset_category',
+    'category_type',
     'creation',
     'modified',
 ] as const;
+
+// Asset Category types
+export type AssetCategoryType = 'Project' | 'IT';
+
+export const ASSET_CATEGORY_TYPE_OPTIONS: { label: AssetCategoryType; value: AssetCategoryType }[] = [
+    { label: 'Project', value: 'Project' },
+    { label: 'IT', value: 'IT' },
+];
 
 // Asset Master fields
 export const ASSET_MASTER_FIELDS = [
@@ -90,6 +99,10 @@ export const ASSET_CACHE_KEYS = {
 
     // Category dropdowns (shared across all dialogs)
     CATEGORIES_DROPDOWN: `${ASSET_CATEGORY_DOCTYPE}_dropdown`,
+
+    // Category-name lists by type (used by useAssetCategoryNamesByType)
+    PROJECT_CATEGORIES_NAMES: `${ASSET_CATEGORY_DOCTYPE}_names_project`,
+    IT_CATEGORIES_NAMES: `${ASSET_CATEGORY_DOCTYPE}_names_it`,
 
     // Asset Management (for individual asset assignments)
     assetManagement: (assetId: string) => `${ASSET_MANAGEMENT_DOCTYPE}_${assetId}`,

--- a/frontend/src/pages/Assets/components/AddAssetCategoryDialog.tsx
+++ b/frontend/src/pages/Assets/components/AddAssetCategoryDialog.tsx
@@ -13,9 +13,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/components/ui/use-toast';
-import { Boxes, ListChecks } from 'lucide-react';
+import { Boxes, ListChecks, Briefcase, Laptop } from 'lucide-react';
 
-import { ASSET_CATEGORY_DOCTYPE } from '../assets.constants';
+import {
+    ASSET_CATEGORY_DOCTYPE,
+    ASSET_CATEGORY_TYPE_OPTIONS,
+    AssetCategoryType,
+} from '../assets.constants';
 
 interface AddAssetCategoryDialogProps {
     isOpen: boolean;
@@ -23,12 +27,18 @@ interface AddAssetCategoryDialogProps {
     onCategoryAdded?: () => void;
 }
 
+const typeIconMap: Record<AssetCategoryType, React.ReactNode> = {
+    Project: <Briefcase className="h-4 w-4" />,
+    IT: <Laptop className="h-4 w-4" />,
+};
+
 export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
     isOpen,
     onOpenChange,
     onCategoryAdded,
 }) => {
     const [categoryName, setCategoryName] = useState('');
+    const [categoryType, setCategoryType] = useState<AssetCategoryType | ''>('');
     const [formError, setFormError] = useState<string | null>(null);
 
     const { toast } = useToast();
@@ -46,6 +56,7 @@ export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
 
     const resetForm = () => {
         setCategoryName('');
+        setCategoryType('');
         setFormError(null);
     };
 
@@ -67,22 +78,27 @@ export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
             return;
         }
 
+        if (!categoryType) {
+            setFormError('Please select a category type (Project or IT).');
+            return;
+        }
+
         setFormError(null);
 
         try {
             await createDoc(ASSET_CATEGORY_DOCTYPE, {
                 asset_category: trimmedName,
+                category_type: categoryType,
             });
 
             toast({
                 title: 'Category Created',
-                description: `"${trimmedName}" has been added successfully.`,
+                description: `"${trimmedName}" (${categoryType}) has been added successfully.`,
                 variant: 'success',
             });
 
             resetForm();
             onOpenChange(false);
-            // Trigger explicit refetch via callback instead of broad SWR mutate
             onCategoryAdded?.();
         } catch (err) {
             console.error('Failed to create category:', err);
@@ -90,7 +106,7 @@ export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
     };
 
     const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' && !isCreating && categoryName.trim()) {
+        if (e.key === 'Enter' && !isCreating && categoryName.trim() && categoryType) {
             e.preventDefault();
             handleSubmit();
         }
@@ -111,21 +127,55 @@ export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
                     </DialogDescription>
                 </DialogHeader>
 
-                <div className="py-4">
-                    <Label htmlFor="newCategoryName" className="text-sm font-medium text-gray-700">
-                        Category Name <span className="text-red-500">*</span>
-                    </Label>
-                    <Input
-                        id="newCategoryName"
-                        value={categoryName}
-                        onChange={(e) => setCategoryName(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        placeholder="e.g., Laptops, Vehicles, Furniture"
-                        className="mt-1.5"
-                        autoFocus
-                    />
+                <div className="space-y-4 py-4">
+                    <div>
+                        <Label htmlFor="newCategoryName" className="text-sm font-medium text-gray-700">
+                            Category Name <span className="text-red-500">*</span>
+                        </Label>
+                        <Input
+                            id="newCategoryName"
+                            value={categoryName}
+                            onChange={(e) => setCategoryName(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            placeholder="e.g., Laptops, Drill Machines, Ladders"
+                            className="mt-1.5"
+                            autoFocus
+                        />
+                    </div>
+
+                    <div>
+                        <Label className="text-sm font-medium text-gray-700">
+                            Category Type <span className="text-red-500">*</span>
+                        </Label>
+                        <div className="mt-1.5 grid grid-cols-2 gap-2">
+                            {ASSET_CATEGORY_TYPE_OPTIONS.map((opt) => {
+                                const isSelected = categoryType === opt.value;
+                                return (
+                                    <button
+                                        key={opt.value}
+                                        type="button"
+                                        onClick={() => setCategoryType(opt.value)}
+                                        className={`
+                                            inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium
+                                            transition-colors
+                                            ${isSelected
+                                                ? opt.value === 'Project'
+                                                    ? 'border-blue-500 bg-blue-50 text-blue-700'
+                                                    : 'border-purple-500 bg-purple-50 text-purple-700'
+                                                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                                            }
+                                        `}
+                                    >
+                                        {typeIconMap[opt.value]}
+                                        {opt.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+
                     {formError && (
-                        <p className="mt-2 text-sm text-red-600">{formError}</p>
+                        <p className="text-sm text-red-600">{formError}</p>
                     )}
                 </div>
 
@@ -139,7 +189,7 @@ export const AddAssetCategoryDialog: React.FC<AddAssetCategoryDialogProps> = ({
                     </Button>
                     <Button
                         onClick={handleSubmit}
-                        disabled={isCreating || !categoryName.trim()}
+                        disabled={isCreating || !categoryName.trim() || !categoryType}
                         className="gap-2"
                     >
                         {isCreating ? 'Creating...' : 'Create Category'}

--- a/frontend/src/pages/Assets/components/AssetCategoriesList.tsx
+++ b/frontend/src/pages/Assets/components/AssetCategoriesList.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { ColumnDef } from '@tanstack/react-table';
 import { Link } from 'react-router-dom';
-import { useFrappeGetDocList, useFrappeDeleteDoc, useFrappeUpdateDoc } from 'frappe-react-sdk';
+import { useFrappeGetDocList, useFrappeUpdateDoc } from 'frappe-react-sdk';
 
 import { DataTable } from '@/components/data-table/new-data-table';
 import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header';
@@ -13,12 +13,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
     Dialog,
     DialogContent,
     DialogDescription,
@@ -26,50 +20,51 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import {
-    AlertDialog,
-    AlertDialogAction,
-    AlertDialogCancel,
-    AlertDialogContent,
-    AlertDialogDescription,
-    AlertDialogFooter,
-    AlertDialogHeader,
-    AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
 import { useToast } from '@/components/ui/use-toast';
-import { MoreHorizontal, Pencil, Trash2, Boxes } from 'lucide-react';
+import { Pencil, Boxes, Briefcase, Laptop } from 'lucide-react';
 
 import {
     ASSET_CATEGORY_DOCTYPE,
     ASSET_CATEGORY_FIELDS,
     ASSET_MASTER_DOCTYPE,
+    ASSET_CATEGORY_TYPE_OPTIONS,
+    AssetCategoryType,
 } from '../assets.constants';
 import { getAssetPermissions } from '../utils/permissions';
+import { useAssetDataRefresh } from '../hooks/useAssetDataRefresh';
 
 interface AssetCategory {
     name: string;
     asset_category: string;
+    category_type: AssetCategoryType | null;
     creation: string;
     modified: string;
 }
+
+const typeBadgeClass: Record<AssetCategoryType, string> = {
+    Project: 'bg-blue-50 text-blue-700 border-blue-200',
+    IT: 'bg-purple-50 text-purple-700 border-purple-200',
+};
+
+const typeIconMap: Record<AssetCategoryType, React.ReactNode> = {
+    Project: <Briefcase className="h-3 w-3 mr-1" />,
+    IT: <Laptop className="h-3 w-3 mr-1" />,
+};
 
 export const AssetCategoriesList: React.FC = () => {
     const { toast } = useToast();
     const userData = useUserData();
 
+    const { refreshCategoryDropdowns } = useAssetDataRefresh();
+
     // Edit dialog state
     const [editDialogOpen, setEditDialogOpen] = useState(false);
     const [editingCategory, setEditingCategory] = useState<AssetCategory | null>(null);
     const [editCategoryName, setEditCategoryName] = useState('');
+    const [editCategoryType, setEditCategoryType] = useState<AssetCategoryType | ''>('');
     const [isUpdating, setIsUpdating] = useState(false);
 
-    // Delete dialog state
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-    const [deletingCategory, setDeletingCategory] = useState<AssetCategory | null>(null);
-    const [isDeleting, setIsDeleting] = useState(false);
-
     const { updateDoc } = useFrappeUpdateDoc();
-    const { deleteDoc } = useFrappeDeleteDoc();
 
     // Fetch asset counts per category
     const { data: assetCounts } = useFrappeGetDocList(
@@ -82,6 +77,25 @@ export const AssetCategoriesList: React.FC = () => {
         'asset_counts_by_category'
     );
 
+    // Fetch category counts per type for facet filter labels (e.g., "Project (21)")
+    const { data: categoryCountByType } = useFrappeGetDocList(
+        ASSET_CATEGORY_DOCTYPE,
+        {
+            fields: ['category_type', 'count(name) as count'],
+            groupBy: 'category_type',
+            limit: 0,
+        },
+        'asset_category_count_by_type'
+    );
+
+    const categoryCountByTypeMap = useMemo(() => {
+        const map: Record<string, number> = {};
+        categoryCountByType?.forEach((item: any) => {
+            if (item.category_type) map[item.category_type] = item.count;
+        });
+        return map;
+    }, [categoryCountByType]);
+
     const assetCountMap = useMemo(() => {
         const map: Record<string, number> = {};
         assetCounts?.forEach((item: any) => {
@@ -90,32 +104,33 @@ export const AssetCategoriesList: React.FC = () => {
         return map;
     }, [assetCounts]);
 
-    // Get granular permissions - only users with canManageCategories can edit/delete
+    // Only users with canManageCategories can edit
     const { canManageCategories } = getAssetPermissions(userData?.user_id, userData?.role);
 
-    // Handle edit
     const handleEditClick = useCallback((category: AssetCategory) => {
         setEditingCategory(category);
         setEditCategoryName(category.asset_category);
+        setEditCategoryType(category.category_type || '');
         setEditDialogOpen(true);
     }, []);
 
     const handleEditSubmit = async () => {
-        if (!editingCategory || !editCategoryName.trim()) return;
+        if (!editingCategory || !editCategoryType) return;
 
         try {
             setIsUpdating(true);
             await updateDoc(ASSET_CATEGORY_DOCTYPE, editingCategory.name, {
-                asset_category: editCategoryName.trim(),
+                category_type: editCategoryType,
             });
             toast({
                 title: 'Category Updated',
-                description: `Category renamed to "${editCategoryName.trim()}"`,
+                description: `"${editingCategory.asset_category}" saved as ${editCategoryType}`,
                 variant: 'success',
             });
             setEditDialogOpen(false);
             setEditingCategory(null);
             refetchTable();
+            refreshCategoryDropdowns();
         } catch (error: any) {
             toast({
                 title: 'Error',
@@ -124,48 +139,6 @@ export const AssetCategoriesList: React.FC = () => {
             });
         } finally {
             setIsUpdating(false);
-        }
-    };
-
-    // Handle delete
-    const handleDeleteClick = useCallback((category: AssetCategory) => {
-        setDeletingCategory(category);
-        setDeleteDialogOpen(true);
-    }, []);
-
-    const handleDeleteConfirm = async () => {
-        if (!deletingCategory) return;
-
-        const assetCount = assetCountMap[deletingCategory.name] || 0;
-        if (assetCount > 0) {
-            toast({
-                title: 'Cannot Delete',
-                description: `This category has ${assetCount} asset(s). Please reassign or delete them first.`,
-                variant: 'destructive',
-            });
-            setDeleteDialogOpen(false);
-            return;
-        }
-
-        try {
-            setIsDeleting(true);
-            await deleteDoc(ASSET_CATEGORY_DOCTYPE, deletingCategory.name);
-            toast({
-                title: 'Category Deleted',
-                description: `"${deletingCategory.asset_category}" has been deleted`,
-                variant: 'success',
-            });
-            setDeleteDialogOpen(false);
-            setDeletingCategory(null);
-            refetchTable();
-        } catch (error: any) {
-            toast({
-                title: 'Error',
-                description: error?.message || 'Failed to delete category',
-                variant: 'destructive',
-            });
-        } finally {
-            setIsDeleting(false);
         }
     };
 
@@ -184,7 +157,24 @@ export const AssetCategoriesList: React.FC = () => {
                     </span>
                 </Link>
             ),
-            size: 280,
+            size: 240,
+        },
+        {
+            accessorKey: 'category_type',
+            header: ({ column }) => <DataTableColumnHeader column={column} title="Type" />,
+            cell: ({ row }) => {
+                const type = row.original.category_type;
+                if (!type) {
+                    return <span className="text-xs text-gray-400 italic">Untagged</span>;
+                }
+                return (
+                    <Badge variant="outline" className={`font-medium ${typeBadgeClass[type]}`}>
+                        {typeIconMap[type]}
+                        {type}
+                    </Badge>
+                );
+            },
+            size: 120,
         },
         {
             id: 'asset_count',
@@ -214,49 +204,42 @@ export const AssetCategoriesList: React.FC = () => {
         },
         ...(canManageCategories ? [{
             id: 'actions',
-            header: () => <span className="sr-only">Actions</span>,
+            header: () => <span>Actions</span>,
             cell: ({ row }: { row: any }) => {
                 const category = row.original as AssetCategory;
-                const hasAssets = (assetCountMap[category.name] || 0) > 0;
-
                 return (
-                    <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                            <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity data-[state=open]:opacity-100"
-                            >
-                                <span className="sr-only">Open menu</span>
-                                <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-40">
-                            <DropdownMenuItem
-                                onClick={() => handleEditClick(category)}
-                                className="cursor-pointer"
-                            >
-                                <Pencil className="mr-2 h-4 w-4" />
-                                Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                                onClick={() => handleDeleteClick(category)}
-                                className={`cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50 ${hasAssets ? 'opacity-50' : ''}`}
-                            >
-                                <Trash2 className="mr-2 h-4 w-4" />
-                                Delete
-                            </DropdownMenuItem>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0 text-gray-600 hover:text-blue-600 hover:bg-blue-50"
+                        onClick={() => handleEditClick(category)}
+                        title="Edit category"
+                    >
+                        <span className="sr-only">Edit</span>
+                        <Pencil className="h-4 w-4" />
+                    </Button>
                 );
             },
-            size: 60,
+            size: 80,
         }] : []),
-    ], [assetCountMap, canManageCategories, handleEditClick, handleDeleteClick]);
+    ], [assetCountMap, canManageCategories, handleEditClick]);
 
     const searchableFields = [
         { value: 'asset_category', label: 'Category Name', placeholder: 'Search categories...', default: true },
     ];
+
+    const facetFilterOptions = useMemo(() => ({
+        category_type: {
+            title: 'Type',
+            options: ASSET_CATEGORY_TYPE_OPTIONS.map((opt) => {
+                const count = categoryCountByTypeMap[opt.value] ?? 0;
+                return {
+                    label: `${opt.label} (${count})`,
+                    value: opt.value,
+                };
+            }),
+        },
+    }), [categoryCountByTypeMap]);
 
     const {
         table,
@@ -291,6 +274,7 @@ export const AssetCategoriesList: React.FC = () => {
                 onSelectedSearchFieldChange={setSelectedSearchField}
                 searchTerm={searchTerm}
                 onSearchTermChange={setSearchTerm}
+                facetFilterOptions={facetFilterOptions}
                 showExportButton={false}
                 showRowSelection={false}
                 className="[&_tr]:group"
@@ -302,21 +286,52 @@ export const AssetCategoriesList: React.FC = () => {
                     <DialogHeader>
                         <DialogTitle className="text-lg font-semibold">Edit Category</DialogTitle>
                         <DialogDescription className="text-sm text-gray-500">
-                            Update the category name. This will not affect existing assets.
+                            Change the type for this category. The category name cannot be modified.
                         </DialogDescription>
                     </DialogHeader>
-                    <div className="py-4">
-                        <Label htmlFor="categoryName" className="text-sm font-medium text-gray-700">
-                            Category Name
-                        </Label>
-                        <Input
-                            id="categoryName"
-                            value={editCategoryName}
-                            onChange={(e) => setEditCategoryName(e.target.value)}
-                            placeholder="Enter category name"
-                            className="mt-1.5"
-                            autoFocus
-                        />
+                    <div className="space-y-4 py-4">
+                        <div>
+                            <Label htmlFor="categoryName" className="text-sm font-medium text-gray-700">
+                                Category Name
+                            </Label>
+                            <Input
+                                id="categoryName"
+                                value={editCategoryName}
+                                readOnly
+                                disabled
+                                className="mt-1.5 bg-gray-50 text-gray-600 cursor-not-allowed"
+                            />
+                        </div>
+                        <div>
+                            <Label className="text-sm font-medium text-gray-700">
+                                Category Type <span className="text-red-500">*</span>
+                            </Label>
+                            <div className="mt-1.5 grid grid-cols-2 gap-2">
+                                {ASSET_CATEGORY_TYPE_OPTIONS.map((opt) => {
+                                    const isSelected = editCategoryType === opt.value;
+                                    return (
+                                        <button
+                                            key={opt.value}
+                                            type="button"
+                                            onClick={() => setEditCategoryType(opt.value)}
+                                            className={`
+                                                inline-flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium
+                                                transition-colors
+                                                ${isSelected
+                                                    ? opt.value === 'Project'
+                                                        ? 'border-blue-500 bg-blue-50 text-blue-700'
+                                                        : 'border-purple-500 bg-purple-50 text-purple-700'
+                                                    : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                                                }
+                                            `}
+                                        >
+                                            {typeIconMap[opt.value]}
+                                            {opt.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
                     </div>
                     <DialogFooter className="gap-2 sm:gap-0">
                         <Button
@@ -328,36 +343,17 @@ export const AssetCategoriesList: React.FC = () => {
                         </Button>
                         <Button
                             onClick={handleEditSubmit}
-                            disabled={isUpdating || !editCategoryName.trim() || editCategoryName === editingCategory?.asset_category}
+                            disabled={
+                                isUpdating
+                                || !editCategoryType
+                                || editCategoryType === (editingCategory?.category_type || '')
+                            }
                         >
                             {isUpdating ? 'Saving...' : 'Save Changes'}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
-
-            {/* Delete Confirmation Dialog */}
-            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-                <AlertDialogContent>
-                    <AlertDialogHeader>
-                        <AlertDialogTitle>Delete Category</AlertDialogTitle>
-                        <AlertDialogDescription>
-                            Are you sure you want to delete <strong>"{deletingCategory?.asset_category}"</strong>?
-                            This action cannot be undone.
-                        </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                        <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                            onClick={handleDeleteConfirm}
-                            disabled={isDeleting}
-                            className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600"
-                        >
-                            {isDeleting ? 'Deleting...' : 'Delete'}
-                        </AlertDialogAction>
-                    </AlertDialogFooter>
-                </AlertDialogContent>
-            </AlertDialog>
         </>
     );
 };

--- a/frontend/src/pages/Assets/components/AssetMasterList.tsx
+++ b/frontend/src/pages/Assets/components/AssetMasterList.tsx
@@ -9,7 +9,8 @@ import { useServerDataTable } from '@/hooks/useServerDataTable';
 import { formatDate } from '@/utils/FormatDate';
 import { formatToRoundedIndianRupee } from '@/utils/FormatPrice';
 import { Badge } from '@/components/ui/badge';
-import { Package, User, Hash, IndianRupee } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Package, User, Hash } from 'lucide-react';
 
 import {
     ASSET_MASTER_DOCTYPE,
@@ -18,6 +19,7 @@ import {
     ASSET_DATE_COLUMNS,
     ASSET_CONDITION_OPTIONS,
     ASSET_CATEGORY_DOCTYPE,
+    AssetCategoryType,
 } from '../assets.constants';
 
 interface AssetMaster {
@@ -47,16 +49,42 @@ const conditionColorMap: Record<string, string> = {
     'Damaged': 'bg-red-50 text-red-700 border-red-200',
 };
 
-export const AssetMasterList: React.FC = () => {
-    // Fetch categories for facet filter
-    const { data: categoryList } = useFrappeGetDocList(
+interface AssetMasterListProps {
+    assetType?: AssetCategoryType;
+}
+
+// Outer guard: resolves category names for the chosen type, then mounts the
+// inner table. Until the category list is loaded we render a skeleton — this
+// prevents useServerDataTable from firing a racy first fetch with a sentinel
+// (`__none__`) filter that returns 0 rows.
+export const AssetMasterList: React.FC<AssetMasterListProps> = ({ assetType }) => {
+    const { data: categoryList, isLoading: categoryListLoading } = useFrappeGetDocList(
         ASSET_CATEGORY_DOCTYPE,
         {
             fields: ['name', 'asset_category'],
+            filters: assetType ? [['category_type', '=', assetType]] : [],
             orderBy: { field: 'asset_category', order: 'asc' },
             limit: 0,
         },
-        'asset_categories_for_filter'
+        assetType ? `asset_categories_for_filter_${assetType}` : 'asset_categories_for_filter'
+    );
+
+    if (assetType && (categoryListLoading || !categoryList)) {
+        return <Skeleton className="h-96 w-full bg-gray-100" />;
+    }
+
+    return <AssetMasterListInner assetType={assetType} categoryList={categoryList ?? []} />;
+};
+
+interface AssetMasterListInnerProps {
+    assetType?: AssetCategoryType;
+    categoryList: { name: string; asset_category: string }[];
+}
+
+const AssetMasterListInner: React.FC<AssetMasterListInnerProps> = ({ assetType, categoryList }) => {
+    const categoryNames = useMemo(
+        () => categoryList.map((c) => c.name),
+        [categoryList]
     );
 
     // Fetch users for displaying assignee names
@@ -78,10 +106,10 @@ export const AssetMasterList: React.FC = () => {
     }, [usersList]);
 
     const categoryOptions = useMemo(() =>
-        categoryList?.map((cat: any) => ({
+        categoryList.map((cat) => ({
             label: cat.asset_category,
             value: cat.name,
-        })) || [],
+        })),
         [categoryList]
     );
 
@@ -243,6 +271,12 @@ export const AssetMasterList: React.FC = () => {
         },
     ], [usersMap]);
 
+    const additionalFilters = useMemo(() => {
+        if (!assetType) return [];
+        if (categoryNames.length === 0) return [['asset_category', 'in', ['__none__']]];
+        return [['asset_category', 'in', categoryNames]];
+    }, [assetType, categoryNames]);
+
     const {
         table,
         totalCount,
@@ -260,8 +294,9 @@ export const AssetMasterList: React.FC = () => {
         fetchFields: ASSET_MASTER_FIELDS as unknown as string[],
         searchableFields: ASSET_SEARCHABLE_FIELDS,
         defaultSort: 'creation desc',
-        urlSyncKey: 'asset_master',
+        urlSyncKey: assetType ? `asset_master_${assetType.toLowerCase()}` : 'asset_master',
         enableRowSelection: false,
+        additionalFilters,
     });
 
     const facetFilterOptions = useMemo(() => ({
@@ -293,7 +328,7 @@ export const AssetMasterList: React.FC = () => {
             onExport="default"
             onExportAll={exportAllRows}
             isExporting={isExporting}
-            exportFileName="asset_master_data"
+            exportFileName={assetType ? `asset_master_${assetType.toLowerCase()}_data` : 'asset_master_data'}
             showRowSelection={false}
         />
     );

--- a/frontend/src/pages/Assets/components/AssignedAssetsList.tsx
+++ b/frontend/src/pages/Assets/components/AssignedAssetsList.tsx
@@ -8,14 +8,17 @@ import { DataTableColumnHeader } from '@/components/data-table/data-table-column
 import { useServerDataTable } from '@/hooks/useServerDataTable';
 import { formatDate } from '@/utils/FormatDate';
 import { Badge } from '@/components/ui/badge';
-import { Hash, User, FileText, CheckCircle2, AlertCircle, ExternalLink } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Hash, User, CheckCircle2, AlertCircle, ExternalLink } from 'lucide-react';
 
 import {
     ASSET_MANAGEMENT_DOCTYPE,
     ASSET_MANAGEMENT_FIELDS,
     ASSET_MANAGEMENT_SEARCHABLE_FIELDS,
     ASSET_MANAGEMENT_DATE_COLUMNS,
+    AssetCategoryType,
 } from '../assets.constants';
+import { useAssetMasterNamesByType } from '../hooks/useAssetMasterNamesByType';
 
 interface AssetManagement {
     name: string;
@@ -37,15 +40,39 @@ interface NirmaanUser {
     full_name: string;
 }
 
-export const AssignedAssetsList: React.FC = () => {
-    // Fetch asset details
+interface AssignedAssetsListProps {
+    assetType?: AssetCategoryType;
+}
+
+// Outer guard — blocks the table mount until masterNames-by-type is resolved.
+// Without this guard useServerDataTable would fire an initial fetch with an
+// empty/placeholder filter and the resulting "0 rows" can race past the real
+// fetch and leave the table looking empty.
+export const AssignedAssetsList: React.FC<AssignedAssetsListProps> = ({ assetType }) => {
+    const { masterNames, isLoading: typeMastersLoading } = useAssetMasterNamesByType(assetType);
+
+    if (assetType && typeMastersLoading) {
+        return <Skeleton className="h-96 w-full bg-gray-100" />;
+    }
+
+    return <AssignedAssetsListInner assetType={assetType} masterNames={masterNames} />;
+};
+
+interface AssignedAssetsListInnerProps {
+    assetType?: AssetCategoryType;
+    masterNames: string[];
+}
+
+const AssignedAssetsListInner: React.FC<AssignedAssetsListInnerProps> = ({ assetType, masterNames }) => {
+    // Fetch asset details — scope to typed asset names when filtering
     const { data: assetsList } = useFrappeGetDocList<AssetMaster>(
         'Asset Master',
         {
             fields: ['name', 'asset_name', 'asset_category'],
+            filters: assetType ? [['name', 'in', masterNames.length ? masterNames : ['__none__']]] : [],
             limit: 0,
         },
-        'assets_for_assigned_list'
+        assetType ? `assets_for_assigned_list_${assetType}` : 'assets_for_assigned_list'
     );
 
     const assetsMap = useMemo(() => {
@@ -181,6 +208,12 @@ export const AssignedAssetsList: React.FC = () => {
         },
     ], [assetsMap, usersMap]);
 
+    const additionalFilters = useMemo(() => {
+        if (!assetType) return [];
+        if (masterNames.length === 0) return [['asset', 'in', ['__none__']]];
+        return [['asset', 'in', masterNames]];
+    }, [assetType, masterNames]);
+
     const {
         table,
         totalCount,
@@ -198,8 +231,9 @@ export const AssignedAssetsList: React.FC = () => {
         fetchFields: ASSET_MANAGEMENT_FIELDS as unknown as string[],
         searchableFields: ASSET_MANAGEMENT_SEARCHABLE_FIELDS,
         defaultSort: 'asset_assigned_on desc',
-        urlSyncKey: 'assigned_assets',
+        urlSyncKey: assetType ? `assigned_assets_${assetType.toLowerCase()}` : 'assigned_assets',
         enableRowSelection: false,
+        additionalFilters,
     });
 
     return (
@@ -219,7 +253,7 @@ export const AssignedAssetsList: React.FC = () => {
             onExport="default"
             onExportAll={exportAllRows}
             isExporting={isExporting}
-            exportFileName="assigned_assets_data"
+            exportFileName={assetType ? `assigned_${assetType.toLowerCase()}_assets_data` : 'assigned_assets_data'}
             showRowSelection={false}
         />
     );

--- a/frontend/src/pages/Assets/components/PendingActionsList.tsx
+++ b/frontend/src/pages/Assets/components/PendingActionsList.tsx
@@ -18,6 +18,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { CustomAttachment } from '@/components/helpers/CustomAttachment';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
 import { Hash, User, Upload, AlertTriangle, FileText, Download } from 'lucide-react';
 import { TailSpin } from 'react-loader-spinner';
@@ -28,8 +29,10 @@ import {
     ASSET_MANAGEMENT_SEARCHABLE_FIELDS,
     ASSET_MANAGEMENT_DATE_COLUMNS,
     ASSET_MASTER_DOCTYPE,
+    AssetCategoryType,
 } from '../assets.constants';
 import { useAssetDataRefresh } from '../hooks/useAssetDataRefresh';
+import { useAssetMasterNamesByType } from '../hooks/useAssetMasterNamesByType';
 
 interface AssetManagement {
     name: string;
@@ -53,9 +56,39 @@ interface NirmaanUser {
 
 interface PendingActionsListProps {
     onUploaded?: () => void;
+    assetType?: AssetCategoryType;
 }
 
-export const PendingActionsList: React.FC<PendingActionsListProps> = ({ onUploaded }) => {
+// Outer guard — blocks the table mount until masterNames-by-type is resolved.
+// Without this guard useServerDataTable would fire an initial fetch with a
+// placeholder filter and the resulting "0 rows" can race past the real fetch.
+export const PendingActionsList: React.FC<PendingActionsListProps> = ({ onUploaded, assetType }) => {
+    const { masterNames, isLoading: typeMastersLoading } = useAssetMasterNamesByType(assetType);
+
+    if (assetType && typeMastersLoading) {
+        return <Skeleton className="h-96 w-full bg-gray-100" />;
+    }
+
+    return (
+        <PendingActionsListInner
+            assetType={assetType}
+            masterNames={masterNames}
+            onUploaded={onUploaded}
+        />
+    );
+};
+
+interface PendingActionsListInnerProps {
+    assetType?: AssetCategoryType;
+    masterNames: string[];
+    onUploaded?: () => void;
+}
+
+const PendingActionsListInner: React.FC<PendingActionsListInnerProps> = ({
+    assetType,
+    masterNames,
+    onUploaded,
+}) => {
     const { toast } = useToast();
     const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
     const [selectedAssignment, setSelectedAssignment] = useState<AssetManagement | null>(null);
@@ -109,14 +142,15 @@ export const PendingActionsList: React.FC<PendingActionsListProps> = ({ onUpload
         }
     };
 
-    // Fetch asset details
+    // Fetch asset details — scope to typed asset names when filtering
     const { data: assetsList } = useFrappeGetDocList<AssetMaster>(
         'Asset Master',
         {
             fields: ['name', 'asset_name', 'asset_category'],
+            filters: assetType ? [['name', 'in', masterNames.length ? masterNames : ['__none__']]] : [],
             limit: 0,
         },
-        'assets_for_pending_list'
+        assetType ? `assets_for_pending_list_${assetType}` : 'assets_for_pending_list'
     );
 
     const assetsMap = useMemo(() => {
@@ -315,6 +349,18 @@ export const PendingActionsList: React.FC<PendingActionsListProps> = ({ onUpload
         },
     ], [assetsMap, usersMap, downloadingAssetId, handleDownloadDeclaration]);
 
+    const additionalFilters = useMemo(() => {
+        const filters: any[] = [['asset_declaration_attachment', '=', '']];
+        if (assetType) {
+            if (masterNames.length === 0) {
+                filters.push(['asset', 'in', ['__none__']]);
+            } else {
+                filters.push(['asset', 'in', masterNames]);
+            }
+        }
+        return filters;
+    }, [assetType, masterNames]);
+
     const {
         table,
         totalCount,
@@ -331,9 +377,9 @@ export const PendingActionsList: React.FC<PendingActionsListProps> = ({ onUpload
         fetchFields: ASSET_MANAGEMENT_FIELDS as unknown as string[],
         searchableFields: ASSET_MANAGEMENT_SEARCHABLE_FIELDS,
         defaultSort: 'asset_assigned_on desc',
-        urlSyncKey: 'pending_actions',
+        urlSyncKey: assetType ? `pending_actions_${assetType.toLowerCase()}` : 'pending_actions',
         enableRowSelection: false,
-        additionalFilters: [['asset_declaration_attachment', '=', '']],
+        additionalFilters,
     });
 
     return (

--- a/frontend/src/pages/Assets/components/UnassignedAssetsList.tsx
+++ b/frontend/src/pages/Assets/components/UnassignedAssetsList.tsx
@@ -10,6 +10,7 @@ import { formatDate } from '@/utils/FormatDate';
 import { formatToRoundedIndianRupee } from '@/utils/FormatPrice';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useUserData } from '@/hooks/useUserData';
 import { Package, Hash, UserPlus } from 'lucide-react';
 
@@ -22,6 +23,7 @@ import {
     ASSET_DATE_COLUMNS,
     ASSET_CONDITION_OPTIONS,
     ASSET_CATEGORY_DOCTYPE,
+    AssetCategoryType,
 } from '../assets.constants';
 import { getAssetPermissions } from '../utils/permissions';
 
@@ -47,33 +49,64 @@ const conditionColorMap: Record<string, string> = {
 
 interface UnassignedAssetsListProps {
     onAssigned?: () => void;
+    assetType?: AssetCategoryType;
 }
 
-export const UnassignedAssetsList: React.FC<UnassignedAssetsListProps> = ({ onAssigned }) => {
+// Outer guard — blocks table mount until typed categoryList is loaded so the
+// inner useServerDataTable doesn't fire a racy first fetch with a placeholder.
+export const UnassignedAssetsList: React.FC<UnassignedAssetsListProps> = ({ onAssigned, assetType }) => {
+    const { data: categoryList, isLoading: categoryListLoading } = useFrappeGetDocList(
+        ASSET_CATEGORY_DOCTYPE,
+        {
+            fields: ['name', 'asset_category'],
+            filters: assetType ? [['category_type', '=', assetType]] : [],
+            orderBy: { field: 'asset_category', order: 'asc' },
+            limit: 0,
+        },
+        assetType ? `asset_categories_for_unassigned_filter_${assetType}` : 'asset_categories_for_unassigned_filter'
+    );
+
+    if (assetType && (categoryListLoading || !categoryList)) {
+        return <Skeleton className="h-96 w-full bg-gray-100" />;
+    }
+
+    return (
+        <UnassignedAssetsListInner
+            assetType={assetType}
+            categoryList={categoryList ?? []}
+            onAssigned={onAssigned}
+        />
+    );
+};
+
+interface UnassignedAssetsListInnerProps {
+    assetType?: AssetCategoryType;
+    categoryList: { name: string; asset_category: string }[];
+    onAssigned?: () => void;
+}
+
+const UnassignedAssetsListInner: React.FC<UnassignedAssetsListInnerProps> = ({
+    assetType,
+    categoryList,
+    onAssigned,
+}) => {
     const userData = useUserData();
     const [assignDialogOpen, setAssignDialogOpen] = useState(false);
     const [selectedAsset, setSelectedAsset] = useState<{ id: string; name: string } | null>(null);
 
-    // Fetch categories for facet filter
-    const { data: categoryList } = useFrappeGetDocList(
-        ASSET_CATEGORY_DOCTYPE,
-        {
-            fields: ['name', 'asset_category'],
-            orderBy: { field: 'asset_category', order: 'asc' },
-            limit: 0,
-        },
-        'asset_categories_for_unassigned_filter'
-    );
-
-    const categoryOptions = useMemo(() =>
-        categoryList?.map((cat: any) => ({
-            label: cat.asset_category,
-            value: cat.name,
-        })) || [],
+    const categoryNames = useMemo(
+        () => categoryList.map((c) => c.name),
         [categoryList]
     );
 
-    // Get granular permissions - canAssignAsset determines if user can assign unassigned assets
+    const categoryOptions = useMemo(() =>
+        categoryList.map((cat) => ({
+            label: cat.asset_category,
+            value: cat.name,
+        })),
+        [categoryList]
+    );
+
     const { canAssignAsset } = getAssetPermissions(userData?.user_id, userData?.role);
 
     const handleAssignClick = (asset: AssetMaster) => {
@@ -190,6 +223,18 @@ export const UnassignedAssetsList: React.FC<UnassignedAssetsListProps> = ({ onAs
         }] : []),
     ], [canAssignAsset]);
 
+    const additionalFilters = useMemo(() => {
+        const filters: any[] = [['current_assignee', '=', '']];
+        if (assetType) {
+            if (categoryNames.length === 0) {
+                filters.push(['asset_category', 'in', ['__none__']]);
+            } else {
+                filters.push(['asset_category', 'in', categoryNames]);
+            }
+        }
+        return filters;
+    }, [assetType, categoryNames]);
+
     const {
         table,
         totalCount,
@@ -208,9 +253,9 @@ export const UnassignedAssetsList: React.FC<UnassignedAssetsListProps> = ({ onAs
         fetchFields: ASSET_MASTER_FIELDS as unknown as string[],
         searchableFields: ASSET_SEARCHABLE_FIELDS,
         defaultSort: 'creation desc',
-        urlSyncKey: 'unassigned_assets',
+        urlSyncKey: assetType ? `unassigned_assets_${assetType.toLowerCase()}` : 'unassigned_assets',
         enableRowSelection: false,
-        additionalFilters: [['current_assignee', '=', '']],
+        additionalFilters,
     });
 
     const facetFilterOptions = useMemo(() => ({
@@ -243,7 +288,7 @@ export const UnassignedAssetsList: React.FC<UnassignedAssetsListProps> = ({ onAs
                 onExport="default"
                 onExportAll={exportAllRows}
                 isExporting={isExporting}
-                exportFileName="unassigned_assets_data"
+                exportFileName={assetType ? `unassigned_${assetType.toLowerCase()}_assets_data` : 'unassigned_assets_data'}
                 showRowSelection={false}
             />
 

--- a/frontend/src/pages/Assets/hooks/useAssetCategoryNamesByType.ts
+++ b/frontend/src/pages/Assets/hooks/useAssetCategoryNamesByType.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useFrappeGetDocList } from 'frappe-react-sdk';
+import {
+    ASSET_CATEGORY_DOCTYPE,
+    ASSET_CACHE_KEYS,
+    AssetCategoryType,
+} from '../assets.constants';
+
+interface AssetCategoryNameRow {
+    name: string;
+}
+
+export interface UseAssetCategoryNamesByTypeResult {
+    categoryNames: string[];
+    isLoading: boolean;
+}
+
+export function useAssetCategoryNamesByType(
+    type: AssetCategoryType | undefined,
+): UseAssetCategoryNamesByTypeResult {
+    const enabled = type === 'Project' || type === 'IT';
+    const cacheKey = !enabled
+        ? null
+        : type === 'Project'
+            ? ASSET_CACHE_KEYS.PROJECT_CATEGORIES_NAMES
+            : ASSET_CACHE_KEYS.IT_CATEGORIES_NAMES;
+
+    const { data, isLoading } = useFrappeGetDocList<AssetCategoryNameRow>(
+        ASSET_CATEGORY_DOCTYPE,
+        {
+            fields: ['name'],
+            filters: enabled ? [['category_type', '=', type as string]] : [],
+            limit: 1000,
+        },
+        cacheKey,
+    );
+
+    const categoryNames = useMemo(
+        () => (data ?? []).map((row) => row.name),
+        [data],
+    );
+
+    return {
+        categoryNames,
+        isLoading: enabled && isLoading,
+    };
+}

--- a/frontend/src/pages/Assets/hooks/useAssetDataRefresh.ts
+++ b/frontend/src/pages/Assets/hooks/useAssetDataRefresh.ts
@@ -26,9 +26,12 @@ export const useAssetDataRefresh = () => {
 
     /**
      * Refresh category dropdown data across all dialogs (Add, Edit)
+     * and per-type category-name lists used by Project / IT tabs.
      */
     const refreshCategoryDropdowns = useCallback(() => {
         mutate(ASSET_CACHE_KEYS.CATEGORIES_DROPDOWN, undefined, { revalidate: true });
+        mutate(ASSET_CACHE_KEYS.PROJECT_CATEGORIES_NAMES, undefined, { revalidate: true });
+        mutate(ASSET_CACHE_KEYS.IT_CATEGORIES_NAMES, undefined, { revalidate: true });
     }, [mutate]);
 
     /**

--- a/frontend/src/pages/Assets/hooks/useAssetMasterNamesByType.ts
+++ b/frontend/src/pages/Assets/hooks/useAssetMasterNamesByType.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { useFrappeGetDocList } from 'frappe-react-sdk';
+import {
+    ASSET_MASTER_DOCTYPE,
+    AssetCategoryType,
+} from '../assets.constants';
+import { useAssetCategoryNamesByType } from './useAssetCategoryNamesByType';
+
+interface AssetMasterNameRow {
+    name: string;
+}
+
+export interface UseAssetMasterNamesByTypeResult {
+    masterNames: string[];
+    isLoading: boolean;
+}
+
+export function useAssetMasterNamesByType(
+    type: AssetCategoryType | undefined,
+): UseAssetMasterNamesByTypeResult {
+    const { categoryNames, isLoading: categoriesLoading } = useAssetCategoryNamesByType(type);
+
+    const enabled = (type === 'Project' || type === 'IT') && categoryNames.length > 0;
+
+    const { data, isLoading } = useFrappeGetDocList<AssetMasterNameRow>(
+        ASSET_MASTER_DOCTYPE,
+        {
+            fields: ['name'],
+            filters: enabled ? [['asset_category', 'in', categoryNames]] : [],
+            limit: 10000,
+        },
+        enabled ? `asset_master_names_by_type_${type}_${categoryNames.length}` : null,
+    );
+
+    const masterNames = useMemo(
+        () => (data ?? []).map((row) => row.name),
+        [data],
+    );
+
+    return {
+        masterNames,
+        isLoading: !!type && (categoriesLoading || (enabled && isLoading)),
+    };
+}

--- a/nirmaan_stack/nirmaan_stack/doctype/asset_category/asset_category.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/asset_category/asset_category.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "details_section",
-  "asset_category"
+  "asset_category",
+  "category_type"
  ],
  "fields": [
   {
@@ -20,6 +21,15 @@
    "fieldtype": "Data",
    "label": "Asset Category",
    "unique": 1
+  },
+  {
+   "fieldname": "category_type",
+   "fieldtype": "Select",
+   "label": "Category Type",
+   "options": "Project\nIT",
+   "reqd": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1
   }
  ],
  "grid_page_length": 50,

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -113,3 +113,4 @@ nirmaan_stack.patches.v3_0.drop_itr_doctype
 nirmaan_stack.patches.v3_0.backfill_project_schedule #v2
 nirmaan_stack.patches.v3_0.backfill_cashflow_gap_limited #v1
 nirmaan_stack.patches.v3_0.backfill_tds_repository_status #v2
+nirmaan_stack.patches.v3_0.backfill_asset_category_type

--- a/nirmaan_stack/patches/v3_0/backfill_asset_category_type.py
+++ b/nirmaan_stack/patches/v3_0/backfill_asset_category_type.py
@@ -1,0 +1,29 @@
+import frappe
+
+# Categories considered IT by default. Match both singular/plural spellings
+# in case data has either form. Everything else is tagged "Project".
+IT_CATEGORY_NAMES = {"Laptop", "Monitors", "Tab"}
+
+
+def execute():
+	rows = frappe.get_all(
+		"Asset Category",
+		filters={"category_type": ["in", ["", None]]},
+		fields=["name"],
+	)
+
+	updated = 0
+	for row in rows:
+		new_type = "IT" if row.name in IT_CATEGORY_NAMES else "Project"
+		frappe.db.set_value(
+			"Asset Category",
+			row.name,
+			"category_type",
+			new_type,
+			update_modified=False,
+		)
+		updated += 1
+
+	if updated:
+		frappe.db.commit()
+		print(f"backfill_asset_category_type: tagged {updated} Asset Category rows")


### PR DESCRIPTION
Add a required `category_type` Select field (Project / IT) to the Asset Category doctype, with a backfill patch that tags Laptop / Monitors / Tab as IT and everything else as Project. Existing rows are updated via `frappe.db.set_value(..., update_modified=False)` so audit timestamps are preserved.

Frontend:
- Asset Management page now has three top-level tabs: Project Assets, IT Assets, Categories. Each asset tab keeps the All / Assigned / Unassigned / Pending Declaration sub-tabs and filters by the category's type via two helper hooks (useAssetCategoryNamesByType, useAssetMasterNamesByType).
- Each list (AssetMasterList, UnassignedAssetsList, AssignedAssetsList, PendingActionsList) is now split into an outer guard + inner table so useServerDataTable mounts only after the type filter is resolved, fixing a race condition where the initial fetch ran with a placeholder filter and returned 0 rows.
- Categories tab shows a Type column with a colored badge, a Type facet filter with per-type counts, and a single Edit action that opens an inline dialog where only the type can be changed (the name is read-only).
- AssetOverview renders the category type as a badge next to the category.
- Page no longer constrains its own height — single page-level scroll instead of nested scrollers.
- Cache invalidation in useAssetDataRefresh is unchanged; refreshes the new PROJECT_CATEGORIES_NAMES / IT_CATEGORIES_NAMES keys via existing refreshCategoryDropdowns.

Migration:
- patches.txt registers nirmaan_stack.patches.v3_0.backfill_asset_category_type
- bench --site localhost migrate must be run; existing 26 rows are tagged automatically (3 IT / 23 Project).