### PR TITLE
feat: receipt autofill across payment flows + link inflows to invoices

### DIFF
--- a/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
@@ -1,16 +1,17 @@
 // src/pages/non-project-expenses/components/NewNonProjectExpense.tsx
 
-import React, { useCallback, useEffect, useState, useMemo } from "react";
+import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import {
     useFrappeCreateDoc,
     useFrappeFileUpload,
     useFrappeGetDocList,
+    useFrappePostCall,
     GetDocListArgs,
     FrappeDoc
 } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
 import { formatDate as formatDateFns } from "date-fns";
-import { Check, ChevronsUpDown } from "lucide-react"; // Icons for Combobox
+import { Check, ChevronsUpDown, Loader2, Sparkles } from "lucide-react"; // Icons for Combobox + autofill
 
 // --- UI Components ---
 import {
@@ -93,8 +94,24 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
     // State for the Expense Type Popover/Command
     const [expenseTypePopoverOpen, setExpenseTypePopoverOpen] = useState(false);
 
+    // --- Document AI autofill (Payment Details side only) ---
+    // When the user uploads a payment receipt we extract UTR / Payment_Date /
+    // Transfer_Amount via the expense processor and pre-fill the form. The
+    // session ref invalidates in-flight extractions on cancel / reset /
+    // checkbox-uncheck so stale responses can't leak into a fresh form.
+    const [autofilledFields, setAutofilledFields] = useState<Set<string>>(new Set());
+    const [isAutofilling, setIsAutofilling] = useState(false);
+    const [uploadedPaymentUrl, setUploadedPaymentUrl] = useState<string | null>(null);
+    // Two-stage flow inside the Payment Details block (mirrors inflow):
+    // "upload" → receipt picker + Skip; "form" → the actual date/ref/attachment fields.
+    const [paymentStage, setPaymentStage] = useState<"upload" | "form">("upload");
+    const extractionSessionRef = useRef(0);
+
     const { createDoc, loading: createLoading } = useFrappeCreateDoc();
     const { upload, loading: uploadLoading } = useFrappeFileUpload();
+    const { call: extractPaymentFields } = useFrappePostCall(
+        "nirmaan_stack.api.payment_autofill.extract_payment_fields"
+    );
 
     const expenseTypeFetchOptions = useMemo(() => getNonProjectExpenseTypeListOptions(), []);
     const expenseTypeQueryKey = queryKeys.expenseTypes.list(expenseTypeFetchOptions);
@@ -114,7 +131,105 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         if (formErrors[name as keyof NewExpenseFormState]) {
             setFormErrors(prev => ({ ...prev, [name]: undefined }));
         }
-    }, [formErrors]);
+        // If user manually edits an auto-filled field, drop its amber tint.
+        if (autofilledFields.has(name)) {
+            setAutofilledFields(prev => {
+                const next = new Set(prev);
+                next.delete(name);
+                return next;
+            });
+        }
+    }, [formErrors, autofilledFields]);
+
+    // Skip Document AI for file types it doesn't accept (csv / xlsx). NPE
+    // allows those for archival but the backend would throw on extraction.
+    const SUPPORTED_EXTS = ["pdf", "png", "jpg", "jpeg"];
+    const isSupportedForAutofill = (file: File) => {
+        const ext = file.name.split(".").pop()?.toLowerCase() || "";
+        return SUPPORTED_EXTS.includes(ext);
+    };
+
+    const runPaymentAutofill = useCallback(async (file: File) => {
+        const session = ++extractionSessionRef.current;
+        setIsAutofilling(true);
+        try {
+            const tempDocName = `temp-npe-${Date.now()}`;
+            const uploaded = await upload(file, {
+                doctype: "Non Project Expenses",
+                docname: tempDocName,
+                fieldname: "payment_attachment",
+                isPrivate: true,
+            });
+            if (session !== extractionSessionRef.current) return;
+            setUploadedPaymentUrl(uploaded.file_url);
+
+            const res = await extractPaymentFields({ file_url: uploaded.file_url });
+            if (session !== extractionSessionRef.current) return;
+            const data = (res as any)?.message ?? res;
+
+            const filled = new Set<string>();
+            const updates: Partial<NewExpenseFormState> = {};
+            if (data?.utr) { updates.payment_ref = data.utr; filled.add("payment_ref"); }
+            if (data?.payment_date) { updates.payment_date = data.payment_date; filled.add("payment_date"); }
+            if (data?.transfer_amount) { updates.amount = data.transfer_amount; filled.add("amount"); }
+            if (Object.keys(updates).length > 0) {
+                setFormState(prev => ({ ...prev, ...updates }));
+            }
+            setAutofilledFields(filled);
+
+            if (filled.size > 0) {
+                toast({
+                    title: "Auto-filled from receipt",
+                    description: `Filled ${filled.size} field${filled.size > 1 ? "s" : ""}. Please verify before saving.`,
+                    variant: "success",
+                });
+            } else {
+                toast({
+                    title: "Couldn't auto-fill",
+                    description: "Please enter Amount, Payment Ref, and Payment Date manually.",
+                });
+            }
+        } catch (e: any) {
+            if (session !== extractionSessionRef.current) return;
+            toast({
+                title: "Auto-fill failed",
+                description: e?.message || "Please enter details manually.",
+                variant: "destructive",
+            });
+        } finally {
+            if (session === extractionSessionRef.current) {
+                setIsAutofilling(false);
+                // Advance to form whether extraction succeeded or failed —
+                // user always lands on the fields to verify / complete entry.
+                setPaymentStage("form");
+            }
+        }
+    }, [upload, extractPaymentFields, toast]);
+
+    const handlePaymentFileSelect = useCallback((file: File | null) => {
+        setPaymentAttachmentFile(file);
+        // Picking a new file invalidates any cached upload + autofill tint.
+        setUploadedPaymentUrl(null);
+        setAutofilledFields(new Set());
+        if (file && isSupportedForAutofill(file)) {
+            runPaymentAutofill(file);
+        }
+    }, [runPaymentAutofill]);
+
+    // Wrap the checkbox toggle so unchecking Record Payment Details also
+    // invalidates any in-flight extraction and clears autofill state.
+    // Checking it back ON starts fresh at the upload stage.
+    const handleRecordPaymentDetailsChange = useCallback((checked: boolean) => {
+        extractionSessionRef.current++;
+        if (!checked) {
+            setAutofilledFields(new Set());
+            setIsAutofilling(false);
+            setUploadedPaymentUrl(null);
+            setPaymentAttachmentFile(null);
+        }
+        setPaymentStage("upload");
+        setRecordPaymentDetails(checked);
+    }, []);
 
     // Handler for Expense Type selection from CommandItem
     const handleExpenseTypeSelect = useCallback((currentValue: string) => {
@@ -160,10 +275,16 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         let invoiceAttachmentUrl: string | undefined = undefined;
 
         try {
-            // Attachment upload logic (same as before)
-            if (recordPaymentDetails && paymentAttachmentFile) {
-                const uploadedFile = await upload(paymentAttachmentFile, { doctype: "Non Project Expenses", isPrivate: true, fieldname: "payment_attachment" });
-                paymentAttachmentUrl = uploadedFile.file_url;
+            // Payment attachment: reuse the upload performed during autofill if
+            // available; otherwise fall back to the original upload-on-submit
+            // (which is also the path used for unsupported file types).
+            if (recordPaymentDetails) {
+                if (uploadedPaymentUrl) {
+                    paymentAttachmentUrl = uploadedPaymentUrl;
+                } else if (paymentAttachmentFile) {
+                    const uploadedFile = await upload(paymentAttachmentFile, { doctype: "Non Project Expenses", isPrivate: true, fieldname: "payment_attachment" });
+                    paymentAttachmentUrl = uploadedFile.file_url;
+                }
             }
             if (recordInvoiceDetails && invoiceAttachmentFile) {
                 const uploadedFile = await upload(invoiceAttachmentFile, { doctype: "Non Project Expenses", isPrivate: true, fieldname: "invoice_attachment" });
@@ -189,10 +310,13 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         }
     }, [
         createDoc, formState, validateForm, toast, refetchList, toggleNewNonProjectExpenseDialog, upload,
-        recordPaymentDetails, paymentAttachmentFile, recordInvoiceDetails, invoiceAttachmentFile
+        recordPaymentDetails, paymentAttachmentFile, uploadedPaymentUrl, recordInvoiceDetails, invoiceAttachmentFile
     ]);
 
     const closeDialogAndReset = useCallback(() => {
+        // Invalidate any in-flight autofill so its eventual response doesn't
+        // leak state into the next dialog session.
+        extractionSessionRef.current++;
         setFormState(INITIAL_FORM_STATE);
         setFormErrors({});
         setRecordPaymentDetails(false);
@@ -200,11 +324,17 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         setPaymentAttachmentFile(null);
         setInvoiceAttachmentFile(null);
         setExpenseTypePopoverOpen(false); // Close popover on dialog close
+        setAutofilledFields(new Set());
+        setIsAutofilling(false);
+        setUploadedPaymentUrl(null);
+        setPaymentStage("upload");
         setNewNonProjectExpenseDialog(false); // Use the setter
     }, [setNewNonProjectExpenseDialog]);
 
     useEffect(() => {
         if (newNonProjectExpenseDialog) {
+            // Bump session so any orphan autofill from a previous open can't land here.
+            extractionSessionRef.current++;
             setFormState(INITIAL_FORM_STATE);
             setFormErrors({});
             setRecordPaymentDetails(true);
@@ -212,11 +342,15 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
             setPaymentAttachmentFile(null);
             setInvoiceAttachmentFile(null);
             setExpenseTypePopoverOpen(false);
+            setAutofilledFields(new Set());
+            setIsAutofilling(false);
+            setUploadedPaymentUrl(null);
+            setPaymentStage("upload");
         }
     }, [newNonProjectExpenseDialog]);
 
     const isLoadingOverall = createLoading || uploadLoading || expenseTypesLoading;
-    const isSubmitDisabled = isLoadingOverall || !formState.type || !formState.description.trim() || !formState.amount || !formState.payment_date;
+    const isSubmitDisabled = isLoadingOverall || isAutofilling || !formState.type || !formState.description.trim() || !formState.amount || !formState.payment_date;
 
     const selectedExpenseTypeLabel = expenseTypeOptionsForCommand.find(option => option.value === formState.type)?.label || "Select Expense Type...";
 
@@ -286,7 +420,7 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
                     </div>
                     <div className="grid grid-cols-4 items-center gap-3">
                         <Label htmlFor="amount_new_npe" className="text-right col-span-1">Amount <sup className="text-destructive">*</sup></Label>
-                        <Input id="amount_new_npe" name="amount" type="number" value={formState.amount} onChange={handleInputChange} className="col-span-3" disabled={isLoadingOverall} />
+                        <Input id="amount_new_npe" name="amount" type="number" value={formState.amount} onChange={handleInputChange} className={cn("col-span-3", autofilledFields.has("amount") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400")} disabled={isLoadingOverall} />
                         {formErrors.amount && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.amount}</p>}
                         <p className="col-span-3 col-start-2 text-xs text-muted-foreground mt-0.5">
                             Use negative amount for refunds.
@@ -297,34 +431,87 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
 
                     {/* Payment Details */}
                     <div className="flex items-center space-x-2">
-                        <Checkbox id="recordPaymentDetails_new_npe" checked={recordPaymentDetails} onCheckedChange={(checked) => setRecordPaymentDetails(Boolean(checked))} disabled={isLoadingOverall} />
+                        <Checkbox id="recordPaymentDetails_new_npe" checked={recordPaymentDetails} onCheckedChange={(checked) => handleRecordPaymentDetailsChange(Boolean(checked))} disabled={isLoadingOverall} />
                         <Label htmlFor="recordPaymentDetails_new_npe" className="font-medium">Record Payment Details</Label>
                     </div>
                     {recordPaymentDetails && (
                         <div className="pl-6 space-y-3 border-l-2 ml-2 mt-2 border-dashed">
-                            <div className="grid grid-cols-4 items-center gap-3">
-                                <Label htmlFor="payment_date_new_npe" className="text-right col-span-1">Payment Date <sup className="text-destructive">*</sup></Label>
-                                <Input id="payment_date_new_npe" name="payment_date" type="date" value={formState.payment_date} onChange={handleInputChange} max={formatDateFns(new Date(), "yyyy-MM-dd")} className="col-span-3" disabled={isLoadingOverall} />
-                                {formErrors.payment_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
-                            </div>
-                            <div className="grid grid-cols-4 items-center gap-3">
-                                <Label htmlFor="payment_ref_new_npe" className="text-right col-span-1">Payment Ref</Label>
-                                <Input id="payment_ref_new_npe" name="payment_ref" value={formState.payment_ref} onChange={handleInputChange} className="col-span-3" disabled={isLoadingOverall} />
-                            </div>
-                            <div className="grid grid-cols-4 items-start gap-3">
-                                <Label className="text-right col-span-1 pt-2">Payment Attachment</Label>
-                                <div className="col-span-3">
-                                    <CustomAttachment
-                                        label="Upload Payment Proof"
-                                        selectedFile={paymentAttachmentFile}
-                                        onFileSelect={setPaymentAttachmentFile}
-                                        onError={handleAttachmentError}
-                                        maxFileSize={5 * 1024 * 1024}
-                                        acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
-                                        disabled={isLoadingOverall}
-                                    />
+                            {paymentStage === "upload" ? (
+                                // ───────── Stage 1: Upload receipt ─────────
+                                <div className="space-y-4 py-2">
+                                    {!isAutofilling ? (
+                                        <>
+                                            <div className="text-center space-y-1">
+                                                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                                    Upload Payment Receipt
+                                                </h3>
+                                                <p className="text-xs text-muted-foreground">
+                                                    We'll read the receipt and fill in Amount, Payment Ref, and Payment Date for you.
+                                                </p>
+                                            </div>
+                                            <CustomAttachment
+                                                label="Choose Receipt (PDF or image)"
+                                                selectedFile={paymentAttachmentFile}
+                                                onFileSelect={handlePaymentFileSelect}
+                                                onError={handleAttachmentError}
+                                                maxFileSize={5 * 1024 * 1024}
+                                                acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                                                disabled={isLoadingOverall}
+                                            />
+                                            <p className="text-[11px] text-center text-muted-foreground">
+                                                Supported for auto-fill: PDF, PNG, JPG · max 5 MB
+                                            </p>
+                                        </>
+                                    ) : (
+                                        <div className="flex flex-col items-center gap-3 py-6">
+                                            <Loader2 className="h-8 w-8 text-amber-600 animate-spin" />
+                                            <div className="text-center space-y-1">
+                                                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                                                    Reading your receipt…
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    AI is extracting payment details. This usually takes a few seconds.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
-                            </div>
+                            ) : (
+                                // ───────── Stage 2: Form (prefilled if autofill ran) ─────────
+                                <>
+                                    {autofilledFields.size > 0 && (
+                                        <div className="flex items-center gap-2 rounded-md bg-amber-50 border border-amber-300 px-3 py-2">
+                                            <Sparkles className="h-3.5 w-3.5 text-amber-700 flex-shrink-0" />
+                                            <span className="text-xs text-amber-900 leading-snug">
+                                                Auto-filled from receipt — please review and edit if anything is wrong.
+                                            </span>
+                                        </div>
+                                    )}
+                                    <div className="grid grid-cols-4 items-center gap-3">
+                                        <Label htmlFor="payment_date_new_npe" className="text-right col-span-1">Payment Date <sup className="text-destructive">*</sup></Label>
+                                        <Input id="payment_date_new_npe" name="payment_date" type="date" value={formState.payment_date} onChange={handleInputChange} max={formatDateFns(new Date(), "yyyy-MM-dd")} className={cn("col-span-3", autofilledFields.has("payment_date") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400")} disabled={isLoadingOverall} />
+                                        {formErrors.payment_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
+                                    </div>
+                                    <div className="grid grid-cols-4 items-center gap-3">
+                                        <Label htmlFor="payment_ref_new_npe" className="text-right col-span-1">Payment Ref</Label>
+                                        <Input id="payment_ref_new_npe" name="payment_ref" value={formState.payment_ref} onChange={handleInputChange} className={cn("col-span-3", autofilledFields.has("payment_ref") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400")} disabled={isLoadingOverall} />
+                                    </div>
+                                    <div className="grid grid-cols-4 items-start gap-3">
+                                        <Label className="text-right col-span-1 pt-2">Payment Attachment</Label>
+                                        <div className="col-span-3">
+                                            <CustomAttachment
+                                                label="Upload Payment Proof"
+                                                selectedFile={paymentAttachmentFile}
+                                                onFileSelect={handlePaymentFileSelect}
+                                                onError={handleAttachmentError}
+                                                maxFileSize={5 * 1024 * 1024}
+                                                acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                                                disabled={isLoadingOverall}
+                                            />
+                                        </div>
+                                    </div>
+                                </>
+                            )}
                         </div>
                     )}
 

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
@@ -581,7 +581,9 @@ export function InvoiceDialog<T extends DocumentType>({
     const current = parseNumber(invoiceData.amount) || 0;
     if (poTotal <= 0 || current <= 0) return null;
     const wouldBeTotal = existing + current;
-    const wouldExceed = wouldBeTotal > poTotal + 0.01;
+    // Tolerate up to ₹10 of rounding drift — must match the backend
+    // hard-block threshold in update_invoice_data._check_po_amount_overage.
+    const wouldExceed = wouldBeTotal > poTotal + 10;
     return {
       poTotal,
       existing,
@@ -703,24 +705,26 @@ export function InvoiceDialog<T extends DocumentType>({
               </div>
             )}
 
-            {/* Soft warning: supplier GSTIN mismatch */}
+            {/* Hard-block: supplier GSTIN mismatch */}
             {supplierGstinMismatch && (
-              <div className="flex items-start gap-2 rounded-md bg-amber-50 border border-amber-300 px-3 py-2">
-                <AlertTriangle className="h-4 w-4 text-amber-700 flex-shrink-0 mt-0.5" />
-                <div className="text-xs text-amber-900 leading-snug">
-                  <p className="font-medium">Supplier GSTIN mismatch.</p>
+              <div className="flex items-start gap-2 rounded-md bg-red-50 border border-red-300 px-3 py-2">
+                <XCircle className="h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+                <div className="text-xs text-red-900 leading-snug">
+                  <p className="font-medium">Supplier GSTIN mismatch — submit blocked.</p>
                   <p className="mt-0.5">{autofillValidation?.supplier_gstin?.message}</p>
+                  <p className="mt-0.5 italic">Re-upload the correct invoice or verify the vendor's GSTIN on file.</p>
                 </div>
               </div>
             )}
 
-            {/* Soft warning: receiver GSTIN mismatch */}
+            {/* Hard-block: receiver GSTIN mismatch */}
             {receiverGstinMismatch && (
-              <div className="flex items-start gap-2 rounded-md bg-amber-50 border border-amber-300 px-3 py-2">
-                <AlertTriangle className="h-4 w-4 text-amber-700 flex-shrink-0 mt-0.5" />
-                <div className="text-xs text-amber-900 leading-snug">
-                  <p className="font-medium">Receiver (Nirmaan) GSTIN mismatch.</p>
+              <div className="flex items-start gap-2 rounded-md bg-red-50 border border-red-300 px-3 py-2">
+                <XCircle className="h-4 w-4 text-red-600 flex-shrink-0 mt-0.5" />
+                <div className="text-xs text-red-900 leading-snug">
+                  <p className="font-medium">Receiver (Nirmaan) GSTIN mismatch — submit blocked.</p>
                   <p className="mt-0.5">{autofillValidation?.receiver_gstin?.message}</p>
+                  <p className="mt-0.5 italic">Re-upload the correct invoice or verify the PO's Project GST setup.</p>
                 </div>
               </div>
             )}
@@ -946,7 +950,9 @@ export function InvoiceDialog<T extends DocumentType>({
                     isLoading ||
                     validationState === "error" ||
                     validationState === "checking" ||
-                    !!liveAmountValidation?.wouldExceed
+                    !!liveAmountValidation?.wouldExceed ||
+                    supplierGstinMismatch ||
+                    receiverGstinMismatch
                   }
                 >
                   {isEditMode ? "Update Invoice" : "Add Invoice"}

--- a/frontend/src/pages/ProjectInvoices/AllProjectInvoices.tsx
+++ b/frontend/src/pages/ProjectInvoices/AllProjectInvoices.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
   FrappeDoc,
   GetDocListArgs,
@@ -46,6 +46,8 @@ import { NewProjectInvoiceDialog } from "./components/NewProjectInvoiceDialog"; 
 import { EditProjectInvoiceDialog } from "./components/EditProjectInvoiceDialog"; // Import the new edit dialog
 import { ProjectInvoiceSummaryCard } from "./components/ProjectInvoiceSummaryCard";
 import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
+import { ProjectInflows } from "@/types/NirmaanStack/ProjectInflows";
+import { LinkedInflowEntry } from "./config/projectInvoices.config";
 import { Projects } from "@/types/NirmaanStack/Projects";
 import { useDialogStore } from "@/zustand/useDialogStore"; // For managing edit dialog state
 import { Customers } from "@/types/NirmaanStack/Customers";
@@ -200,6 +202,17 @@ export const AllProjectInvoices: React.FC<{
     }
   };
 
+  // Map: invoice_id → list of inflows posted against it. Populated lazily by
+  // the side-fetch below. Stored in a ref so the columns memo stays stable;
+  // `mapVersion` state bump triggers a re-render so cells re-read the ref.
+  const inflowsByInvoiceRef = useRef<Map<string, LinkedInflowEntry[]>>(new Map());
+  const [, setMapVersion] = useState(0);
+
+  const getInflowsForInvoice = useCallback(
+    (invoiceId: string) => inflowsByInvoiceRef.current.get(invoiceId) ?? [],
+    []
+  );
+
   const tableColumns = useMemo(
     () =>
       getProjectInvoiceColumns({
@@ -212,6 +225,7 @@ export const AllProjectInvoices: React.FC<{
         onDelete: handleOpenDeleteDialog,
         onEdit: handleOpenEditDialog,
         hideCustomerColumn: !!customerId, // Hide customer column when viewing from customer page
+        getInflowsForInvoice,
       }),
     [
       canEdit,
@@ -223,6 +237,7 @@ export const AllProjectInvoices: React.FC<{
       handleOpenDeleteDialog,
       handleOpenEditDialog,
       customerId,
+      getInflowsForInvoice,
     ]
   );
 
@@ -258,6 +273,57 @@ export const AllProjectInvoices: React.FC<{
     defaultSort: "invoice_date desc",
     aggregatesConfig: PROJECT_INVOICE_AGGREGATES_CONFIG,
   });
+
+  // --- Side-fetch: inflows posted against each visible invoice ---
+  // One invoice can be paid in multiple inflow chunks. We fetch all
+  // `Project Inflows` whose `invoice` Link points at one of the visible
+  // invoices, then group them by invoice id and stash in the ref.
+  const visibleInvoiceIds = useMemo(
+    () => (projectInvoicesData ?? []).map((inv) => inv.name),
+    [projectInvoicesData]
+  );
+  const { data: inflowsForVisibleInvoices } = useFrappeGetDocList<ProjectInflows>(
+    "Project Inflows",
+    {
+      filters: [
+        [
+          "invoice",
+          "in",
+          visibleInvoiceIds.length ? visibleInvoiceIds : ["__none__"],
+        ],
+      ],
+      fields: [
+        "name",
+        "invoice",
+        "utr",
+        "amount",
+        "payment_date",
+        "inflow_attachment",
+      ],
+      limit: 100000,
+    },
+    visibleInvoiceIds.length
+      ? `InflowsForInvoices_${visibleInvoiceIds.join(",")}`
+      : null
+  );
+
+  useEffect(() => {
+    const grouped = new Map<string, LinkedInflowEntry[]>();
+    (inflowsForVisibleInvoices ?? []).forEach((inf) => {
+      if (!inf.invoice) return;
+      const arr = grouped.get(inf.invoice) ?? [];
+      arr.push({
+        name: inf.name,
+        utr: inf.utr,
+        inflow_attachment: inf.inflow_attachment,
+        amount: typeof inf.amount === "number" ? inf.amount : Number(inf.amount) || undefined,
+        payment_date: inf.payment_date,
+      });
+      grouped.set(inf.invoice, arr);
+    });
+    inflowsByInvoiceRef.current = grouped;
+    setMapVersion((v) => v + 1);
+  }, [inflowsForVisibleInvoices]);
 
   // --- Dynamic Facet Values ---
   const {

--- a/frontend/src/pages/ProjectInvoices/config/projectInvoices.config.tsx
+++ b/frontend/src/pages/ProjectInvoices/config/projectInvoices.config.tsx
@@ -10,6 +10,20 @@ import formatToIndianRupee from "@/utils/FormatPrice";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { dateFilterFn, facetedFilterFn } from "@/utils/tableFilters";
 import SITEURL from "@/constants/siteURL";
+import {
+    HoverCard,
+    HoverCardContent,
+    HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+/** Minimal inflow shape needed to render the reverse "Inflows" column. */
+export type LinkedInflowEntry = {
+    name: string;
+    utr?: string;
+    inflow_attachment?: string;
+    amount?: number;
+    payment_date?: string;
+};
 
 // =================================================================================
 // 1. STATIC CONFIGURATION
@@ -68,6 +82,12 @@ interface ColumnGeneratorOptions {
     onDelete: (invoice: ProjectInvoice) => void;
     onEdit: (invoice: ProjectInvoice) => void;
     hideCustomerColumn?: boolean; // Hide customer column when viewing from customer page
+    /**
+     * Resolves the inflows that have been recorded against the given invoice.
+     * Supplied by the parent page after it side-fetches Project Inflows
+     * filtered by `invoice IN (visible invoice ids)`. Returns [] when none.
+     */
+    getInflowsForInvoice?: (invoiceId: string) => LinkedInflowEntry[];
 }
 
 // =================================================================================
@@ -77,7 +97,7 @@ export const getProjectInvoiceColumns = (
     options: ColumnGeneratorOptions
 ): ColumnDef<ProjectInvoice>[] => {
 
-    const { canEdit, canDelete, getProjectName, getCustomerName, getUserName, getGstName, onDelete, onEdit, hideCustomerColumn } = options;
+    const { canEdit, canDelete, getProjectName, getCustomerName, getUserName, getGstName, onDelete, onEdit, hideCustomerColumn, getInflowsForInvoice } = options;
     const showActionsColumn = canEdit || canDelete;
 
     const columns: ColumnDef<ProjectInvoice>[] = [
@@ -154,6 +174,82 @@ export const getProjectInvoiceColumns = (
             header: ({ column }) => <DataTableColumnHeader column={column} title="Amount(Incl. GST)" />,
             cell: ({ row }) => <div className="tabular-nums">{formatToIndianRupee(row.original.amount)}</div>,
             meta: { exportHeaderName: "Amount", exportValue: (row: ProjectInvoice) => row.amount, isNumeric: true }
+        },
+        // Reverse-direction "Inflows" column — shows how many inflow payments
+        // the customer has made against this invoice (one invoice can be paid
+        // in multiple chunks). Compact count-pill + HoverCard reveals each
+        // inflow as a clickable link to its payment proof attachment.
+        {
+            id: "inflows",
+            header: ({ column }) => (
+                <DataTableColumnHeader column={column} title="Inflows" />
+            ),
+            cell: ({ row }) => {
+                const list = getInflowsForInvoice?.(row.original.name) ?? [];
+                if (list.length === 0) {
+                    return <span className="text-muted-foreground text-xs">--</span>;
+                }
+                const label = `${list.length} ${list.length === 1 ? "inflow" : "inflows"}`;
+                return (
+                    <HoverCard openDelay={100} closeDelay={150}>
+                        <HoverCardTrigger asChild>
+                            <span
+                                className="inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200 cursor-pointer hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-800 whitespace-nowrap"
+                                title={`${list.length} inflow${list.length === 1 ? "" : "s"} against this invoice`}
+                            >
+                                {label}
+                            </span>
+                        </HoverCardTrigger>
+                        <HoverCardContent
+                            className="w-auto max-w-sm p-2"
+                            side="bottom"
+                            align="start"
+                        >
+                            <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5 px-1">
+                                Inflows against this invoice
+                            </p>
+                            <ul className="space-y-0.5">
+                                {list.map((inf) => {
+                                    const display = inf.utr || inf.name;
+                                    const amountText = typeof inf.amount === "number"
+                                        ? ` — ${formatToIndianRupee(inf.amount)}`
+                                        : "";
+                                    return (
+                                        <li key={inf.name}>
+                                            {inf.inflow_attachment ? (
+                                                <a
+                                                    href={SITEURL + inf.inflow_attachment}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="block text-xs text-blue-600 hover:underline px-1 py-0.5 rounded hover:bg-blue-50"
+                                                >
+                                                    {display}{amountText}
+                                                </a>
+                                            ) : (
+                                                <span
+                                                    className="block text-xs text-muted-foreground px-1 py-0.5"
+                                                    title="No payment proof attached"
+                                                >
+                                                    {display}{amountText}
+                                                </span>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </HoverCardContent>
+                    </HoverCard>
+                );
+            },
+            enableSorting: false,
+            size: 140,
+            meta: {
+                exportHeaderName: "Inflows",
+                exportValue: (row: ProjectInvoice) =>
+                    (getInflowsForInvoice?.(row.name) ?? [])
+                        .map(inf => inf.utr || inf.name)
+                        .join("; ") || "--",
+            },
         },
         {
             accessorKey: "invoice_date",

--- a/frontend/src/pages/ProjectPayments/update-payment/UpdatePaymentDialog.tsx
+++ b/frontend/src/pages/ProjectPayments/update-payment/UpdatePaymentDialog.tsx
@@ -15,9 +15,10 @@ import { CustomAttachment }      from "@/components/helpers/CustomAttachment";
 
 import { useDialogStore }          from "@/zustand/useDialogStore";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Loader2, Sparkles } from "lucide-react";
 import { useUpdatePaymentRequest } from "../hooks/useUpdatePaymentRequests";
-import { useFrappeFileUpload } from "frappe-react-sdk";
+import { useFrappeFileUpload, useFrappePostCall } from "frappe-react-sdk";
 import { DOC_TYPES } from "../approve-payments/constants";
 import { useOrderPayments } from "@/hooks/useOrderPayments";
 import { useOrderTotals } from "@/hooks/useOrderTotals";
@@ -67,23 +68,156 @@ export default function UpdatePaymentRequestDialog({
   const [payDate, setPD]    = useState("");
   const [file, setFile]     = useState<File | null>(null);
 
+  /* Two-stage flow (fulfil mode only): "upload" shows just the file picker
+     so the user uploads the receipt first; once Document AI returns, we
+     flip to "form" with UTR + Payment Date pre-filled. Users who don't
+     have a receipt handy can skip straight to the form. */
+  const [stage, setStage]                       = useState<"upload" | "form">("upload");
+  const [autofilledFields, setAutofilledFields] = useState<Set<string>>(new Set());
+  const [isAutofilling, setIsAutofilling]       = useState(false);
+  const [uploadedFileUrl, setUploadedFileUrl]   = useState<string | null>(null);
+  /* Raw values from Document AI — frontend re-derives the mismatch state
+     against (payment.amount − tds) so the banner reacts as TDS changes. */
+  const [receiptAmount, setReceiptAmount]       = useState<number | null>(null);
+  const [amountDeltaThreshold, setAmountDeltaThreshold] = useState<number>(2);
+
+  /* Reset every form / autofill bit whenever the dialog (re)opens or the
+     selected payment row changes. The dialog component stays mounted
+     between opens (parent toggles a Zustand `open` flag), so without this
+     a Cancel on row A would leak its UTR / Payment Date into row B's
+     dialog the next time the user clicks Pay. */
+  useEffect(() => {
+    if (open && mode === "fulfil") {
+      setUtr(""); setTds(""); setPD(""); setFile(null);
+      setAutofilledFields(new Set());
+      setUploadedFileUrl(null);
+      setIsAutofilling(false);
+      setReceiptAmount(null);
+      setStage("upload");
+    }
+  }, [open, mode, payment.name]);
+
   const { trigger, isMutating } = useUpdatePaymentRequest();
   const { upload, loading: uploadLoading } = useFrappeFileUpload();
+  const { call: extractPaymentFields } = useFrappePostCall(
+    "nirmaan_stack.api.payment_autofill.extract_payment_fields"
+  );
 
   /* ---------------- submit handlers ------------------------------- */
-  const reset = () => { setUtr(""); setTds(""); setPD(""); setFile(null); };
+  const reset = () => {
+    setUtr(""); setTds(""); setPD(""); setFile(null);
+    setAutofilledFields(new Set());
+    setUploadedFileUrl(null);
+    setIsAutofilling(false);
+    setReceiptAmount(null);
+    setStage("upload");
+  };
+
+  const clearAutofillFlag = (field: string) => {
+    if (!autofilledFields.has(field)) return;
+    const next = new Set(autofilledFields);
+    next.delete(field);
+    setAutofilledFields(next);
+  };
+
+  const runAutofillExtraction = async (selectedFile: File) => {
+    setIsAutofilling(true);
+    try {
+      const uploaded = await upload(selectedFile, {
+        doctype: DOC_TYPES.PROJECT_PAYMENTS,
+        docname: payment.name,
+        fieldname: "payment_attachment",
+        isPrivate: true,
+      });
+      setUploadedFileUrl(uploaded.file_url);
+
+      const res = await extractPaymentFields({ file_url: uploaded.file_url });
+      const data = (res as any)?.message ?? res;
+
+      const filled = new Set<string>();
+      if (data?.utr) {
+        setUtr(data.utr);
+        filled.add("utr");
+      }
+      if (data?.payment_date) {
+        setPD(data.payment_date);
+        filled.add("payment_date");
+      }
+      setAutofilledFields(filled);
+
+      // Stash raw extracted amount + tolerance; the form derives the
+      // mismatch state dynamically against (payment.amount − tds).
+      const amt = data?.validation?.amount;
+      setReceiptAmount(typeof amt?.extracted === "number" ? amt.extracted : null);
+      if (typeof amt?.delta_threshold === "number") {
+        setAmountDeltaThreshold(amt.delta_threshold);
+      }
+
+      if (filled.size > 0) {
+        toast({
+          title: "Auto-filled from receipt",
+          description: `Filled ${filled.size} field${filled.size > 1 ? "s" : ""}. Please verify before confirming.`,
+          variant: "success",
+        });
+      } else {
+        toast({
+          title: "Couldn't auto-fill",
+          description: "Please enter UTR and Payment Date manually.",
+          variant: "default",
+        });
+      }
+    } catch (e: any) {
+      toast({
+        title: "Auto-fill failed",
+        description: e?.message || "Please enter details manually.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsAutofilling(false);
+      // Whether autofill succeeded or failed, move the user into the form
+      // so they can verify / fill the remaining fields.
+      setStage("form");
+    }
+  };
+
+  const handleFileSelect = (selectedFile: File | null) => {
+    setFile(selectedFile);
+    setUploadedFileUrl(null);
+    setAutofilledFields(new Set());
+    setReceiptAmount(null);
+    if (selectedFile) {
+      runAutofillExtraction(selectedFile);
+    }
+  };
+
+  /* Live amount mismatch — recomputes when TDS changes so the banner
+     hides automatically once the user accounts for the deduction. */
+  const amountMismatch = useMemo(() => {
+    if (receiptAmount == null) return null;
+    const effectiveExpected = payment.amount - (parseNumber(tds) || 0);
+    const delta = +(receiptAmount - effectiveExpected).toFixed(2);
+    if (Math.abs(delta) <= amountDeltaThreshold) return null;
+    return {
+      expected: effectiveExpected,
+      extracted: receiptAmount,
+      delta,
+    };
+  }, [receiptAmount, amountDeltaThreshold, payment.amount, tds]);
 
   const doFulfil = async () => {
     try {
 
-      let uploadedFile;
-      if (file) {
+      let uploadedFile: { file_url: string } | undefined;
+      if (uploadedFileUrl) {
+        // Already uploaded during autofill — reuse the same File record.
+        uploadedFile = { file_url: uploadedFileUrl };
+      } else if (file) {
           uploadedFile = await upload(file, {
               doctype: DOC_TYPES.PROJECT_PAYMENTS, docname: payment.name,
               fieldname: "payment_attachment", isPrivate: true,
           });
 
-      } 
+      }
       const payload = {
         action : "fulfil" as const,
         name   : payment.name,
@@ -151,49 +285,126 @@ export default function UpdatePaymentRequestDialog({
         </div>
 
         {mode === "fulfil" ? (
-          <>
-            <Separator className="my-3" />
-
-            {/* UTR */}
-            <div className="grid grid-cols-5 items-center gap-4">
-              <Label htmlFor="utr" className="col-span-2 text-right">
-                UTR <sup className="text-red-500">*</sup>
-              </Label>
-              <Input id="utr" className="col-span-3 h-8"
-                     value={utr} onChange={e=>setUtr(e.target.value)} />
+          stage === "upload" ? (
+            // ───────── Stage 1: Upload receipt ─────────
+            <div className="pt-4 space-y-4">
+              <Separator />
+              {!isAutofilling ? (
+                <>
+                  <div className="text-center space-y-1">
+                    <h3 className="text-sm font-semibold text-gray-900">
+                      Upload Payment Receipt
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      We'll read the receipt and fill in UTR and Payment Date for you.
+                    </p>
+                  </div>
+                  <CustomAttachment
+                    label="Choose Receipt (PDF or image)"
+                    selectedFile={file}
+                    onFileSelect={handleFileSelect}
+                    maxFileSize={5 * 1024 * 1024}
+                    className="w-full"
+                  />
+                  <p className="text-[11px] text-center text-muted-foreground">
+                    Supported: PDF, PNG, JPG · max 5 MB
+                  </p>
+                </>
+              ) : (
+                <div className="flex flex-col items-center gap-3 py-6">
+                  <Loader2 className="h-8 w-8 text-amber-600 animate-spin" />
+                  <div className="text-center space-y-1">
+                    <p className="text-sm font-medium text-gray-900">
+                      Reading your receipt…
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      AI is extracting payment details. This usually takes a few seconds.
+                    </p>
+                  </div>
+                </div>
+              )}
+              {!isAutofilling && (
+                <div className="flex justify-end items-center pt-3 border-t">
+                  <AlertDialogCancel asChild>
+                    <Button variant="outline" size="sm">Cancel</Button>
+                  </AlertDialogCancel>
+                </div>
+              )}
             </div>
+          ) : (
+            // ───────── Stage 2: Form (prefilled if autofill ran) ─────────
+            <>
+              <Separator className="my-3" />
 
-            {/* TDS */}
-            <div className="grid grid-cols-5 items-center gap-4">
-              <Label htmlFor="tds" className="col-span-2 text-right">TDS</Label>
-              <div className="col-span-3">
-                <Input id="tds" type="number" className="h-8"
-                       value={tds} onChange={e=>setTds(e.target.value)} />
-                {parseNumber(tds) > 0 &&
-                  <span className="text-xs text-muted-foreground">
-                    Amt&nbsp;Paid:&nbsp;{fmt(payment.amount - parseNumber(tds))}
-                  </span>}
+              {autofilledFields.size > 0 && (
+                <div className="flex items-center gap-2 text-xs text-amber-900 bg-amber-50 border border-amber-300 rounded px-2 py-1.5">
+                  <Sparkles className="h-3.5 w-3.5 text-amber-700 flex-shrink-0" />
+                  <span>Auto-filled from receipt — please review and edit if anything is wrong.</span>
+                </div>
+              )}
+
+              {/* Soft warning: receipt amount differs from (requested − TDS) by > ₹2 */}
+              {amountMismatch && (
+                <div className="flex items-start gap-2 rounded-md bg-amber-50 border border-amber-300 px-3 py-2">
+                  <AlertTriangle className="h-4 w-4 text-amber-700 flex-shrink-0 mt-0.5" />
+                  <div className="text-xs text-amber-900 leading-snug">
+                    <p className="font-medium">Amount mismatch on receipt.</p>
+                    <p className="mt-0.5">
+                      Receipt shows {fmt(amountMismatch.extracted)} transferred, but the expected payable is {fmt(amountMismatch.expected)}
+                      {parseNumber(tds) > 0 ? ` (${fmt(payment.amount)} − ${fmt(parseNumber(tds))} TDS)` : ""}
+                      {" "}— off by {fmt(Math.abs(amountMismatch.delta))}. Please double-check the receipt
+                      {parseNumber(tds) === 0 ? " or enter TDS if applicable." : "."}
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* UTR */}
+              <div className="grid grid-cols-5 items-center gap-4">
+                <Label htmlFor="utr" className="col-span-2 text-right">
+                  UTR <sup className="text-red-500">*</sup>
+                </Label>
+                <Input id="utr"
+                       className={`col-span-3 h-8 ${autofilledFields.has("utr") ? "bg-amber-50 border-amber-300 focus-visible:ring-amber-400" : ""}`}
+                       value={utr}
+                       onChange={e => { setUtr(e.target.value); clearAutofillFlag("utr"); }} />
               </div>
-            </div>
 
-            {/* Date */}
-            <div className="grid grid-cols-5 items-center gap-4">
-              <Label htmlFor="payDate" className="col-span-2 text-right">
-                Payment Date <sup className="text-red-500">*</sup>
-              </Label>
-              <Input id="payDate" type="date" className="col-span-3 h-8"
-                     value={payDate} onChange={e=>setPD(e.target.value)}
-                     max={new Date().toISOString().slice(0,10)} />
-            </div>
+              {/* TDS */}
+              <div className="grid grid-cols-5 items-center gap-4">
+                <Label htmlFor="tds" className="col-span-2 text-right">TDS</Label>
+                <div className="col-span-3">
+                  <Input id="tds" type="number" className="h-8"
+                         value={tds} onChange={e=>setTds(e.target.value)} />
+                  {parseNumber(tds) > 0 &&
+                    <span className="text-xs text-muted-foreground">
+                      Amt&nbsp;Paid:&nbsp;{fmt(payment.amount - parseNumber(tds))}
+                    </span>}
+                </div>
+              </div>
 
-            {/* Attachment */}
-            <CustomAttachment
-              label="Payment Proof"
-              selectedFile={file}
-              onFileSelect={setFile}
-              maxFileSize={5 * 1024 * 1024}
-            />
-          </>
+              {/* Date */}
+              <div className="grid grid-cols-5 items-center gap-4">
+                <Label htmlFor="payDate" className="col-span-2 text-right">
+                  Payment Date <sup className="text-red-500">*</sup>
+                </Label>
+                <Input id="payDate" type="date"
+                       className={`col-span-3 h-8 ${autofilledFields.has("payment_date") ? "bg-amber-50 border-amber-300 focus-visible:ring-amber-400" : ""}`}
+                       value={payDate}
+                       onChange={e => { setPD(e.target.value); clearAutofillFlag("payment_date"); }}
+                       max={new Date().toISOString().slice(0,10)} />
+              </div>
+
+              {/* Attachment (re-shown so user can replace the receipt without
+                  losing the form). Re-running autofill on replace is intentional. */}
+              <CustomAttachment
+                label="Payment Proof"
+                selectedFile={file}
+                onFileSelect={handleFileSelect}
+                maxFileSize={5 * 1024 * 1024}
+              />
+            </>
+          )
         ) : (
           <p className="pt-4 text-sm">
             Are you sure you want to delete this payment request?
@@ -201,21 +412,23 @@ export default function UpdatePaymentRequestDialog({
         )}
 
         {/* ---------- Buttons ---------- */}
-        <div className="flex gap-2 items-center pt-6 justify-end">
-          {isMutating || uploadLoading
-            ? <TailSpin height={24} width={24} color="red" />
-            : <>
-                <AlertDialogCancel asChild>
-                  <Button variant="outline">Cancel</Button>
-                </AlertDialogCancel>
-                {mode === "fulfil"
-                  ? <Button onClick={doFulfil}
-                      disabled={!utr || !payDate}>Confirm Payment</Button>
-                  : <Button variant="destructive" onClick={doDelete}>
-                      Confirm Delete
-                    </Button>}
-              </>}
-        </div>
+        {!(mode === "fulfil" && stage === "upload") && (
+          <div className="flex gap-2 items-center pt-6 justify-end">
+            {isMutating || uploadLoading
+              ? <TailSpin height={24} width={24} color="red" />
+              : <>
+                  <AlertDialogCancel asChild>
+                    <Button variant="outline">Cancel</Button>
+                  </AlertDialogCancel>
+                  {mode === "fulfil"
+                    ? <Button onClick={doFulfil}
+                        disabled={!utr || !payDate || isAutofilling}>Confirm Payment</Button>
+                    : <Button variant="destructive" onClick={doDelete}>
+                        Confirm Delete
+                      </Button>}
+                </>}
+          </div>
+        )}
       </AlertDialogContent>
     </AlertDialog>
   );

--- a/frontend/src/pages/inflow-payments/InFlowPayments.tsx
+++ b/frontend/src/pages/inflow-payments/InFlowPayments.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useMemo } from "react";
+import React, { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { ColumnDef, Row } from "@tanstack/react-table";
 import { Link } from "react-router-dom";
@@ -58,6 +58,7 @@ import { memoize } from "lodash";
 
 // --- Types ---
 import { ProjectInflows } from "@/types/NirmaanStack/ProjectInflows";
+import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
 import { Projects } from "@/types/NirmaanStack/Projects";
 import { Customers } from "@/types/NirmaanStack/Customers";
 
@@ -142,6 +143,13 @@ export const InFlowPayments: React.FC<InFlowPaymentsProps> = ({
   const [inflowToDelete, setInflowToDelete] = useState<ProjectInflows | null>(
     null
   ); // NEW
+
+  // Map: invoice_id → {invoice_no, attachment} for display in the Linked
+  // Invoice column. Stored in a ref so the `columns` memo stays stable; a
+  // `mapVersion` state bump triggers a re-render so cells re-read the ref.
+  type InvoiceMeta = { invoice_no: string; attachment: string };
+  const invoiceMetaRef = useRef<Map<string, InvoiceMeta>>(new Map());
+  const [, setMapVersion] = useState(0);
 
   // --- Supporting Data Fetches ---
   const projectFiltersForLookup = useMemo(
@@ -406,6 +414,43 @@ export const InFlowPayments: React.FC<InFlowPaymentsProps> = ({
         },
       },
       {
+        id: "invoice",
+        accessorKey: "invoice",
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title="Linked Invoice" />
+        ),
+        cell: ({ row }) => {
+          const invoiceId = row.original.invoice;
+          if (!invoiceId) {
+            return <span className="text-muted-foreground text-xs">--</span>;
+          }
+          const meta = invoiceMetaRef.current.get(invoiceId);
+          const display = meta?.invoice_no || invoiceId;
+          if (meta?.attachment) {
+            return (
+              <a
+                href={SITEURL + meta.attachment}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-medium text-blue-600 hover:underline whitespace-nowrap"
+              >
+                {display}
+              </a>
+            );
+          }
+          return <span className="text-xs font-medium whitespace-nowrap">{display}</span>;
+        },
+        enableSorting: false,
+        size: 160,
+        meta: {
+          exportHeaderName: "Linked Invoice",
+          exportValue: (row: ProjectInflows) => {
+            if (!row.invoice) return "--";
+            return invoiceMetaRef.current.get(row.invoice)?.invoice_no || row.invoice;
+          },
+        },
+      },
+      {
         id: "download_proof",
         header: "Proof",
         cell: ({ row }) =>
@@ -517,6 +562,38 @@ export const InFlowPayments: React.FC<InFlowPaymentsProps> = ({
     additionalFilters: staticFilters,
     aggregatesConfig: INFLOW_AGGREGATES_CONFIG, // NEW: Pass the config
   });
+
+  // --- Side-fetch invoice metadata (invoice_no + attachment) for the
+  //     distinct invoice ids referenced by the visible inflow rows. Lets the
+  //     "Linked Invoice" column render a clickable link to the invoice file.
+  const linkedInvoiceIds = useMemo(
+    () => Array.from(new Set((data ?? []).map((d) => d.invoice).filter(Boolean) as string[])),
+    [data]
+  );
+  const { data: invoiceMetaRows } = useFrappeGetDocList<ProjectInvoice>(
+    "Project Invoices",
+    {
+      filters: [["name", "in", linkedInvoiceIds.length ? linkedInvoiceIds : ["__none__"]]],
+      fields: ["name", "invoice_no", "attachment"],
+      limit: 1000,
+    },
+    linkedInvoiceIds.length
+      ? `InflowInvoiceMeta_${linkedInvoiceIds.join(",")}`
+      : null
+  );
+
+  // Stash the lookup in the ref + bump version so the cell re-reads.
+  useEffect(() => {
+    const m = new Map<string, InvoiceMeta>();
+    (invoiceMetaRows ?? []).forEach((inv) => {
+      m.set(inv.name, {
+        invoice_no: inv.invoice_no || inv.name,
+        attachment: inv.attachment || "",
+      });
+    });
+    invoiceMetaRef.current = m;
+    setMapVersion((v) => v + 1);
+  }, [invoiceMetaRows]);
 
   // --- Dynamic Facet Values ---
   const {

--- a/frontend/src/pages/inflow-payments/components/EditInflowPayment.tsx
+++ b/frontend/src/pages/inflow-payments/components/EditInflowPayment.tsx
@@ -11,6 +11,7 @@ import {
 } from "frappe-react-sdk";
 import memoize from 'lodash/memoize';
 import { TailSpin } from "react-loader-spinner";
+import ReactSelect from "react-select";
 import {
     AlertCircle,
     X as XIcon,
@@ -48,10 +49,14 @@ import { cn } from "@/lib/utils";
 
 // --- Types ---
 import { ProjectInflows as ProjectInflowsType } from "@/types/NirmaanStack/ProjectInflows";
+import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
 import { Projects } from "@/types/NirmaanStack/Projects";
 import { Customers } from "@/types/NirmaanStack/Customers";
 
+type InvoiceOption = { value: string; label: string };
+
 // --- Utils & State ---
+import { getSelectStyles } from "@/config/selectTheme";
 import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { getTotalInflowAmount } from "@/utils/getAmounts";
 import { parseNumber } from "@/utils/parseNumber";
@@ -94,11 +99,35 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
     const [customerName, setCustomerName] = useState("");
     const [isProjectValid, setIsProjectValid] = useState(true);
 
+    // Linked invoice state — single Link, pre-populated from inflowToEdit.invoice.
+    const [selectedInvoice, setSelectedInvoice] = useState<InvoiceOption | null>(null);
+
     const { updateDoc, loading: updateLoading } = useFrappeUpdateDoc();
     const { upload, loading: uploadLoading } = useFrappeFileUpload();
 
     const { data: projects, isLoading: projectsLoading } = useFrappeGetDocList<Projects>("Projects", getProjectListOptions({ fields: ["name", "project_name", "customer"] }) as any, queryKeys.projects.list());
     const { data: customers, isLoading: customersLoading } = useFrappeGetDocList<Customers>("Customers", getCustomerListOptions({ fields: ["name", "company_name"] }) as any, queryKeys.customers.list());
+
+    // Invoices belonging to the inflow's project — populates the multi-select.
+    const { data: projectInvoicesForLink, isLoading: projectInvoicesLoading } = useFrappeGetDocList<ProjectInvoice>(
+        "Project Invoices",
+        {
+            filters: inflowToEdit.project ? [["project", "=", inflowToEdit.project]] : undefined,
+            fields: ["name", "invoice_no", "amount", "invoice_date"],
+            limit: 1000,
+            orderBy: { field: "invoice_date", order: "desc" },
+        },
+        inflowToEdit.project ? `ProjectInvoicesForInflow_${inflowToEdit.project}` : null
+    );
+
+    const invoiceOptions = useMemo<InvoiceOption[]>(
+        () =>
+            (projectInvoicesForLink ?? []).map(inv => ({
+                value: inv.name,
+                label: `${inv.invoice_no || inv.name} — ${formatToRoundedIndianRupee(inv.amount || 0)}`,
+            })),
+        [projectInvoicesForLink]
+    );
 
     useEffect(() => {
         if (editInflowDialog && inflowToEdit) {
@@ -130,8 +159,30 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
             if (!currentProject?.customer && inflowToEdit.project) {
                 toast({ title: "Warning", description: "The associated project does not have a customer linked. This inflow might be problematic.", variant: "default" });
             }
+
+            // Seed selectedInvoice directly from the parent row's `invoice`
+            // Link field (now fetched as part of the inflow list). Label is
+            // initially the bare id; a separate effect below upgrades it to
+            // `invoice_no — ₹amount` once project invoice metadata loads.
+            if (inflowToEdit.invoice) {
+                setSelectedInvoice({ value: inflowToEdit.invoice, label: inflowToEdit.invoice });
+            } else {
+                setSelectedInvoice(null);
+            }
         }
     }, [editInflowDialog, inflowToEdit, projects, customers, toast]);
+
+    // When project invoice metadata loads, upgrade the selectedInvoice label
+    // from "bare id" to "invoice_no — ₹amount". Does not change membership.
+    useEffect(() => {
+        if (invoiceOptions.length === 0) return;
+        setSelectedInvoice(prev => {
+            if (!prev) return prev;
+            const fresh = invoiceOptions.find(opt => opt.value === prev.value);
+            if (!fresh || fresh.label === prev.label) return prev;
+            return fresh;
+        });
+    }, [invoiceOptions]);
 
     const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;
@@ -175,6 +226,8 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
             amount: parseNumber(formState.amount),
             payment_date: formState.payment_date,
             utr: formState.utr.trim(),
+            // Single Link to a Project Invoice; passing null clears the link.
+            invoice: selectedInvoice?.value ?? null as any,
         };
 
         try {
@@ -195,7 +248,7 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
             console.error("Error updating inflow payment:", error);
             toast({ title: "Failed!", description: error.message || "Failed to update payment.", variant: "destructive" });
         }
-    }, [updateDoc, inflowToEdit.name, formState, newPaymentScreenshot, attachmentAction, upload, validateForm, toast, onSuccess]);
+    }, [updateDoc, inflowToEdit.name, formState, newPaymentScreenshot, attachmentAction, selectedInvoice, upload, validateForm, toast, onSuccess]);
 
     const handleDialogCloseAttempt = () => {
         setFormState({ project: "", customer: "", amount: "", payment_date: "", utr: "" });
@@ -203,6 +256,7 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
         setNewPaymentScreenshot(null);
         setExistingAttachmentUrl(undefined);
         setAttachmentAction("keep");
+        setSelectedInvoice(null);
     };
 
     const isLoadingAny = updateLoading || uploadLoading || projectsLoading || customersLoading;
@@ -298,6 +352,35 @@ export const EditInflowPayment: React.FC<EditInflowPaymentProps> = ({ inflowToEd
                                 </AlertDescription>
                             </Alert>
                         )}
+
+                        {/* Linked Invoice — single-select, scoped to this inflow's project.
+                            One inflow pays against one invoice; one invoice can receive many inflows. */}
+                        <div className="space-y-1.5">
+                            <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                Linked Invoice
+                                <span className="text-xs font-normal text-slate-400 ml-1">(Optional)</span>
+                            </Label>
+                            <ReactSelect
+                                options={invoiceOptions}
+                                value={selectedInvoice}
+                                onChange={(opt) => setSelectedInvoice((opt as InvoiceOption | null) ?? null)}
+                                isClearable
+                                placeholder={
+                                    projectInvoicesLoading
+                                        ? "Loading invoices…"
+                                        : invoiceOptions.length === 0
+                                            ? "No invoices found for this project"
+                                            : "Select the invoice this payment covers…"
+                                }
+                                isDisabled={projectInvoicesLoading}
+                                isLoading={projectInvoicesLoading}
+                                classNamePrefix="react-select"
+                                menuPortalTarget={typeof document !== "undefined" ? document.body : undefined}
+                                menuPosition="fixed"
+                                styles={getSelectStyles<InvoiceOption, false>()}
+                                noOptionsMessage={() => "No invoices found for this project"}
+                            />
+                        </div>
                     </div>
 
                     {/* Divider */}

--- a/frontend/src/pages/inflow-payments/components/NewInflowPayment.tsx
+++ b/frontend/src/pages/inflow-payments/components/NewInflowPayment.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState, useContext } from "react";
-import { FrappeConfig, FrappeContext, useFrappeCreateDoc, useFrappeFileUpload, useFrappeGetDocList, useFrappeDocTypeEventListener } from "frappe-react-sdk";
+import React, { useCallback, useEffect, useMemo, useRef, useState, useContext } from "react";
+import { FrappeConfig, FrappeContext, useFrappeCreateDoc, useFrappeFileUpload, useFrappeGetDocList, useFrappeDocTypeEventListener, useFrappePostCall } from "frappe-react-sdk";
 import memoize from 'lodash/memoize';
-import { AlertCircle, ArrowDownToLine, Building2, Calendar, CreditCard, FileText, Hash, IndianRupee } from "lucide-react";
+import { AlertCircle, ArrowDownToLine, Building2, Calendar, CreditCard, FileText, Hash, IndianRupee, Loader2, Sparkles } from "lucide-react";
 import { TailSpin } from "react-loader-spinner";
+import ReactSelect from "react-select";
 
 // --- UI Components ---
 import ProjectSelect from "@/components/custom-select/project-select";
@@ -20,10 +21,14 @@ import { Separator } from "@/components/ui/separator";
 
 // --- Types ---
 import { ProjectInflows as ProjectInflowsType } from "@/types/NirmaanStack/ProjectInflows"; // Alias for clarity
+import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
 import { Projects } from "@/types/NirmaanStack/Projects";
 import { Customers } from "@/types/NirmaanStack/Customers";
 
+type InvoiceOption = { value: string; label: string };
+
 // --- Utils & State ---
+import { getSelectStyles } from "@/config/selectTheme";
 import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { getTotalInflowAmount } from "@/utils/getAmounts";
 import { parseNumber } from "@/utils/parseNumber";
@@ -69,9 +74,29 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
     const [isProjectValidForPayment, setIsProjectValidForPayment] = useState(false); // Project has a customer
     const [formErrors, setFormErrors] = useState<Partial<Record<keyof NewInflowFormState, string>>>({});
 
+    // --- Autofill state ---
+    // Gated reveal inside Payment Details: pick project → upload pitch → autofill →
+    // pre-filled form. `uploadedFileUrl` caches the upload done at file-select time so
+    // submit doesn't re-upload. `autofilledFields` drives amber tint + clears as user edits.
+    const [receiptStage, setReceiptStage] = useState<"upload" | "form">("upload");
+    const [isAutofilling, setIsAutofilling] = useState(false);
+    const [uploadedFileUrl, setUploadedFileUrl] = useState<string | null>(null);
+    const [autofilledFields, setAutofilledFields] = useState<Set<string>>(new Set());
+    // Session counter that invalidates in-flight extractions on cancel /
+    // project change / dialog close. Without this, a slow Document AI response
+    // can land after the user has already moved on and silently repopulate
+    // the form with stale data.
+    const extractionSessionRef = useRef(0);
+
+    // --- Linked invoice (single — one inflow pays against one invoice) ---
+    const [selectedInvoice, setSelectedInvoice] = useState<InvoiceOption | null>(null);
+
     // --- Data Mutators ---
     const { createDoc, loading: createLoading } = useFrappeCreateDoc();
     const { upload, loading: uploadLoading } = useFrappeFileUpload();
+    const { call: extractPaymentFields } = useFrappePostCall(
+        "nirmaan_stack.api.payment_autofill.extract_payment_fields"
+    );
 
     // --- Supporting Data Fetches ---
     // Fetch all projects for selection, and customers for display mapping
@@ -91,6 +116,28 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
     const { data: projectInflows, isLoading: projectInflowsLoading, mutate: projectInflowsMutate } = useFrappeGetDocList<ProjectInflowsType>(
         "Project Inflows", { fields: ["project", "amount"], limit: 100000 }, // Fetch all, only needed fields
         "AllProjectInflowsForValidation" // Specific key for SWR
+    );
+
+    // Invoices belonging to the currently selected project — populates the
+    // "Linked Invoices" multi-select. Only fires once a project is picked.
+    const { data: projectInvoicesForLink, isLoading: projectInvoicesLoading } = useFrappeGetDocList<ProjectInvoice>(
+        "Project Invoices",
+        {
+            filters: formState.project ? [["project", "=", formState.project]] : undefined,
+            fields: ["name", "invoice_no", "amount", "invoice_date"],
+            limit: 1000,
+            orderBy: { field: "invoice_date", order: "desc" },
+        },
+        formState.project ? `ProjectInvoicesForInflow_${formState.project}` : null
+    );
+
+    const invoiceOptions = useMemo<InvoiceOption[]>(
+        () =>
+            (projectInvoicesForLink ?? []).map(inv => ({
+                value: inv.name,
+                label: `${inv.invoice_no || inv.name} — ${formatToRoundedIndianRupee(inv.amount || 0)}`,
+            })),
+        [projectInvoicesForLink]
     );
 
     // --- Event Listener for Realtime Updates ---
@@ -129,6 +176,17 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
             setIsProjectValidForPayment(false);
         }
         setFormErrors({}); // Clear errors on project change
+        // Reset receipt / autofill state — different project means different receipt context.
+        // Bump the session counter so any in-flight extraction (e.g., user changed
+        // their mind mid-autofill) lands silently and doesn't overwrite the reset.
+        extractionSessionRef.current++;
+        setPaymentScreenshot(null);
+        setUploadedFileUrl(null);
+        setAutofilledFields(new Set());
+        setIsAutofilling(false);
+        setReceiptStage("upload");
+        // Linked invoice is project-scoped — clear it when the project changes.
+        setSelectedInvoice(null);
     }, [projects, customers, toast]);
 
     const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -137,7 +195,85 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
         if (formErrors[name as keyof NewInflowFormState]) {
             setFormErrors(prev => ({...prev, [name]: undefined })); // Clear error on change
         }
-    }, [formErrors]);
+        // If user manually edits an auto-filled field, drop its amber tint.
+        if (autofilledFields.has(name)) {
+            setAutofilledFields(prev => {
+                const next = new Set(prev);
+                next.delete(name);
+                return next;
+            });
+        }
+    }, [formErrors, autofilledFields]);
+
+    const runAutofillExtraction = useCallback(async (file: File) => {
+        // Claim a session for this extraction. Any reset / cancel / project
+        // change bumps the ref, so by the time the promise resolves we can
+        // tell whether the user has moved on and skip state updates.
+        const session = ++extractionSessionRef.current;
+        setIsAutofilling(true);
+        try {
+            const tempDocName = `temp-inflow-${Date.now()}`;
+            const uploaded = await upload(file, {
+                doctype: "Project Inflows",
+                docname: tempDocName,
+                fieldname: "inflow_attachment",
+                isPrivate: true,
+            });
+            if (session !== extractionSessionRef.current) return;
+            setUploadedFileUrl(uploaded.file_url);
+
+            const res = await extractPaymentFields({ file_url: uploaded.file_url });
+            if (session !== extractionSessionRef.current) return;
+            const data = (res as any)?.message ?? res;
+
+            const filled = new Set<string>();
+            const updates: Partial<NewInflowFormState> = {};
+            if (data?.utr) { updates.utr = data.utr; filled.add("utr"); }
+            if (data?.payment_date) { updates.payment_date = data.payment_date; filled.add("payment_date"); }
+            if (data?.transfer_amount) { updates.amount = data.transfer_amount; filled.add("amount"); }
+            if (Object.keys(updates).length > 0) {
+                setFormState(prev => ({ ...prev, ...updates }));
+            }
+            setAutofilledFields(filled);
+
+            if (filled.size > 0) {
+                toast({
+                    title: "Auto-filled from receipt",
+                    description: `Filled ${filled.size} field${filled.size > 1 ? "s" : ""}. Please verify before recording.`,
+                    variant: "success",
+                });
+            } else {
+                toast({
+                    title: "Couldn't auto-fill",
+                    description: "Please enter Amount, UTR, and Date manually.",
+                });
+            }
+        } catch (e: any) {
+            if (session !== extractionSessionRef.current) return;
+            toast({
+                title: "Auto-fill failed",
+                description: e?.message || "Please enter details manually.",
+                variant: "destructive",
+            });
+        } finally {
+            // Only flip stage/spinner if we're still the current session —
+            // otherwise the reset path has already moved us back to "upload".
+            if (session === extractionSessionRef.current) {
+                setIsAutofilling(false);
+                setReceiptStage("form");
+            }
+        }
+    }, [upload, extractPaymentFields, toast]);
+
+    const handleFileSelect = useCallback((file: File | null) => {
+        setPaymentScreenshot(file);
+        // Any previously-uploaded file becomes stale the moment the user picks a new one.
+        setUploadedFileUrl(null);
+        setAutofilledFields(new Set());
+        if (file) {
+            runAutofillExtraction(file);
+        }
+    }, [runAutofillExtraction]);
 
     const validateForm = useCallback((): boolean => {
         const errors: Partial<Record<keyof NewInflowFormState, string>> = {};
@@ -161,18 +297,18 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
 
         let fileUrl: string | undefined = undefined;
         try {
-            if (paymentScreenshot) {
-                // Frappe requires a temporary docname if the main doc isn't created yet for file attachment.
-                // Using a placeholder; the file will be re-linked upon successful doc creation if needed,
-                // or a better approach is to create doc first, then attach.
-                // For simplicity with createDoc, we'll create, then update with file URL if needed.
-                const tempDocName = `temp-inflow-${Date.now()}`; // Temporary name
+            if (uploadedFileUrl) {
+                // Already uploaded during the autofill flow — reuse the same File record.
+                fileUrl = uploadedFileUrl;
+            } else if (paymentScreenshot) {
+                // Fallback: a screenshot is selected but never went through autofill upload
+                // (e.g., autofill failed mid-upload). Upload now under the same temp-docname pattern.
+                const tempDocName = `temp-inflow-${Date.now()}`;
                 const fileArgs = {
-                    doctype: "Project Inflows", // Target doctype
-                    docname: tempDocName,      // Temporary name, file is public by default
-                    fieldname: "inflow_attachment", // Field to attach to
-                    // file: paymentScreenshot,
-                    isPrivate: true, // Make it private
+                    doctype: "Project Inflows",
+                    docname: tempDocName,
+                    fieldname: "inflow_attachment",
+                    isPrivate: true,
                 };
                 const uploadedFile = await upload(paymentScreenshot, fileArgs);
                 fileUrl = uploadedFile.file_url;
@@ -185,6 +321,8 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
                 payment_date: formState.payment_date,
                 utr: formState.utr.trim(),
                 inflow_attachment: fileUrl, // Will be undefined if no screenshot
+                // Single Link to a Project Invoice; one invoice can be paid by multiple inflows.
+                invoice: selectedInvoice?.value || undefined,
             };
 
             await createDoc("Project Inflows", docToCreate);
@@ -200,27 +338,42 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
             console.error("Error adding inflow payment:", error);
             toast({ title: "Failed!", description: error.message || "Failed to add payment.", variant: "destructive" });
         }
-    }, [createDoc, formState, paymentScreenshot, toggleNewInflowDialog, projectInflowsMutate, upload, validateForm, toast]);
+    }, [createDoc, formState, paymentScreenshot, uploadedFileUrl, selectedInvoice, toggleNewInflowDialog, projectInflowsMutate, upload, validateForm, toast]);
 
     const closeDialogAndReset = () => {
+        // Invalidate any in-flight autofill so its eventual response doesn't
+        // leak into the next dialog session.
+        extractionSessionRef.current++;
         setFormState(INITIAL_FORM_STATE);
         setPaymentScreenshot(null);
         setFormErrors({});
+        setUploadedFileUrl(null);
+        setAutofilledFields(new Set());
+        setIsAutofilling(false);
+        setReceiptStage("upload");
+        setSelectedInvoice(null);
         toggleNewInflowDialog(); // From Zustand store
     };
 
     // Effect to reset form when dialog opens/closes (if newInflowDialog state changes externally)
     useEffect(() => {
         if (newInflowDialog) {
+            // Bump session so any orphaned autofill from a prior open can't land here.
+            extractionSessionRef.current++;
             setFormState(INITIAL_FORM_STATE); // Reset form when dialog is to be shown
             setPaymentScreenshot(null);
             setFormErrors({});
             setIsProjectValidForPayment(false); // Reset validation
+            setUploadedFileUrl(null);
+            setAutofilledFields(new Set());
+            setIsAutofilling(false);
+            setReceiptStage("upload");
+            setSelectedInvoice(null);
         }
     }, [newInflowDialog]);
 
 
-    const isSubmitDisabled = !formState.project || !formState.amount || !formState.utr || !formState.payment_date || !isProjectValidForPayment || Object.keys(formErrors).length > 0;
+    const isSubmitDisabled = !formState.project || !formState.amount || !formState.utr || !formState.payment_date || !isProjectValidForPayment || Object.keys(formErrors).length > 0 || isAutofilling;
     const isLoadingAny = createLoading || uploadLoading || projectsLoading || customersLoading || projectInflowsLoading;
 
     return (
@@ -312,6 +465,39 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
                                 </AlertDescription>
                             </Alert>
                         )}
+
+                        {/* Linked Invoice — single-select, scoped to selected project.
+                            One inflow pays against one invoice; one invoice can receive many inflows. */}
+                        {formState.project && isProjectValidForPayment && (
+                            <div className="space-y-1.5">
+                                <Label className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                                    Linked Invoice
+                                    <span className="text-xs font-normal text-slate-400 ml-1">(Optional)</span>
+                                </Label>
+                                <ReactSelect
+                                    options={invoiceOptions}
+                                    value={selectedInvoice}
+                                    onChange={(opt) => setSelectedInvoice((opt as InvoiceOption | null) ?? null)}
+                                    isClearable
+                                    placeholder={
+                                        projectInvoicesLoading
+                                            ? "Loading invoices…"
+                                            : invoiceOptions.length === 0
+                                                ? "No invoices found for this project"
+                                                : "Select the invoice this payment covers…"
+                                    }
+                                    isDisabled={projectInvoicesLoading}
+                                    isLoading={projectInvoicesLoading}
+                                    classNamePrefix="react-select"
+                                    menuPortalTarget={typeof document !== "undefined" ? document.body : undefined}
+                                    menuPosition="fixed"
+                                    // Centralized theme sets `pointer-events: auto` on every menu
+                                    // layer — required so clicks land inside Radix dialogs.
+                                    styles={getSelectStyles<InvoiceOption, false>()}
+                                    noOptionsMessage={() => "No invoices found for this project"}
+                                />
+                            </div>
+                        )}
                     </div>
 
                     {/* Divider */}
@@ -326,115 +512,171 @@ export const NewInflowPayment: React.FC<NewInflowPaymentProps> = ({ refetch }) =
                         </div>
                     </div>
 
-                    {/* Payment Details Section */}
+                    {/* Payment Details Section — gated by project validity AND receipt stage.
+                        Stage 1 ("upload"): receipt picker + Skip; Stage 2 ("form"): the actual fields. */}
                     <div className={cn(
                         "space-y-4 transition-opacity",
                         !isProjectValidForPayment && "opacity-50 pointer-events-none"
                     )}>
-                        {/* Amount */}
-                        <div className="space-y-1.5">
-                            <Label htmlFor="amount" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                <IndianRupee className="w-3.5 h-3.5 text-slate-400" />
-                                Amount <span className="text-red-500">*</span>
-                            </Label>
-                            <div className="relative">
-                                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">₹</span>
-                                <Input
-                                    id="amount"
-                                    name="amount"
-                                    type="number"
-                                    placeholder="0.00"
-                                    value={formState.amount}
-                                    onChange={handleInputChange}
-                                    disabled={!isProjectValidForPayment}
-                                    className={cn(
-                                        "pl-7 h-10 text-base font-medium transition-all",
-                                        "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
-                                        formErrors.amount && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
-                                    )}
-                                />
-                            </div>
-                            {formErrors.amount && (
-                                <p className="text-xs text-red-500 flex items-center gap-1">
-                                    <AlertCircle className="w-3 h-3" />
-                                    {formErrors.amount}
-                                </p>
-                            )}
-                        </div>
-
-                        {/* UTR and Date - Side by side */}
-                        <div className="grid grid-cols-2 gap-3">
-                            {/* UTR */}
-                            <div className="space-y-1.5">
-                                <Label htmlFor="utr" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                    <Hash className="w-3.5 h-3.5 text-slate-400" />
-                                    UTR/Ref <span className="text-red-500">*</span>
-                                </Label>
-                                <Input
-                                    id="utr"
-                                    name="utr"
-                                    type="text"
-                                    placeholder="Reference No."
-                                    value={formState.utr}
-                                    onChange={handleInputChange}
-                                    disabled={!isProjectValidForPayment}
-                                    className={cn(
-                                        "h-10 transition-all",
-                                        "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
-                                        formErrors.utr && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
-                                    )}
-                                />
-                                {formErrors.utr && (
-                                    <p className="text-xs text-red-500 flex items-center gap-1">
-                                        <AlertCircle className="w-3 h-3" />
-                                        {formErrors.utr}
-                                    </p>
+                        {receiptStage === "upload" ? (
+                            // ───────── Stage 1: Upload receipt ─────────
+                            <div className="space-y-4">
+                                {!isAutofilling ? (
+                                    <>
+                                        <div className="text-center space-y-1">
+                                            <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                                Upload Payment Receipt
+                                            </h3>
+                                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                                                We'll read the receipt and fill in Amount, UTR, and Date for you.
+                                            </p>
+                                        </div>
+                                        <CustomAttachment
+                                            label="Choose Receipt (PDF or image)"
+                                            selectedFile={paymentScreenshot}
+                                            onFileSelect={handleFileSelect}
+                                            disabled={!isProjectValidForPayment}
+                                            maxFileSize={5 * 1024 * 1024}
+                                        />
+                                        <p className="text-[11px] text-center text-slate-400 dark:text-slate-500">
+                                            Supported: PDF, PNG, JPG · max 5 MB
+                                        </p>
+                                    </>
+                                ) : (
+                                    <div className="flex flex-col items-center gap-3 py-6">
+                                        <Loader2 className="h-8 w-8 text-emerald-600 animate-spin" />
+                                        <div className="text-center space-y-1">
+                                            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                                                Reading your receipt…
+                                            </p>
+                                            <p className="text-xs text-slate-500 dark:text-slate-400">
+                                                AI is extracting payment details. This usually takes a few seconds.
+                                            </p>
+                                        </div>
+                                    </div>
                                 )}
                             </div>
-
-                            {/* Payment Date */}
-                            <div className="space-y-1.5">
-                                <Label htmlFor="payment_date" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                    <Calendar className="w-3.5 h-3.5 text-slate-400" />
-                                    Date <span className="text-red-500">*</span>
-                                </Label>
-                                <Input
-                                    id="payment_date"
-                                    name="payment_date"
-                                    type="date"
-                                    value={formState.payment_date}
-                                    onChange={handleInputChange}
-                                    disabled={!isProjectValidForPayment}
-                                    max={formatDate(new Date(), "yyyy-MM-dd")}
-                                    className={cn(
-                                        "h-10 transition-all",
-                                        "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
-                                        formErrors.payment_date && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
-                                    )}
-                                />
-                                {formErrors.payment_date && (
-                                    <p className="text-xs text-red-500 flex items-center gap-1">
-                                        <AlertCircle className="w-3 h-3" />
-                                        {formErrors.payment_date}
-                                    </p>
+                        ) : (
+                            // ───────── Stage 2: Form (prefilled if autofill ran) ─────────
+                            <>
+                                {autofilledFields.size > 0 && (
+                                    <div className="flex items-center gap-2 rounded-md bg-amber-50 border border-amber-300 px-3 py-2">
+                                        <Sparkles className="h-3.5 w-3.5 text-amber-700 flex-shrink-0" />
+                                        <span className="text-xs text-amber-900 leading-snug">
+                                            Auto-filled from receipt — please review and edit if anything is wrong.
+                                        </span>
+                                    </div>
                                 )}
-                            </div>
-                        </div>
 
-                        {/* Attachment */}
-                        <div className="space-y-1.5">
-                            <Label className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
-                                <FileText className="w-3.5 h-3.5 text-slate-400" />
-                                Payment Proof
-                                <span className="text-xs font-normal text-slate-400">(Optional)</span>
-                            </Label>
-                            <CustomAttachment
-                                selectedFile={paymentScreenshot}
-                                onFileSelect={setPaymentScreenshot}
-                                disabled={!isProjectValidForPayment}
-                                maxFileSize={5 * 1024 * 1024}
-                            />
-                        </div>
+                                {/* Amount */}
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="amount" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                        <IndianRupee className="w-3.5 h-3.5 text-slate-400" />
+                                        Amount <span className="text-red-500">*</span>
+                                    </Label>
+                                    <div className="relative">
+                                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 text-sm font-medium">₹</span>
+                                        <Input
+                                            id="amount"
+                                            name="amount"
+                                            type="number"
+                                            placeholder="0.00"
+                                            value={formState.amount}
+                                            onChange={handleInputChange}
+                                            disabled={!isProjectValidForPayment}
+                                            className={cn(
+                                                "pl-7 h-10 text-base font-medium transition-all",
+                                                "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
+                                                autofilledFields.has("amount") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400",
+                                                formErrors.amount && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
+                                            )}
+                                        />
+                                    </div>
+                                    {formErrors.amount && (
+                                        <p className="text-xs text-red-500 flex items-center gap-1">
+                                            <AlertCircle className="w-3 h-3" />
+                                            {formErrors.amount}
+                                        </p>
+                                    )}
+                                </div>
+
+                                {/* UTR and Date - Side by side */}
+                                <div className="grid grid-cols-2 gap-3">
+                                    {/* UTR */}
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="utr" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                            <Hash className="w-3.5 h-3.5 text-slate-400" />
+                                            UTR/Ref <span className="text-red-500">*</span>
+                                        </Label>
+                                        <Input
+                                            id="utr"
+                                            name="utr"
+                                            type="text"
+                                            placeholder="Reference No."
+                                            value={formState.utr}
+                                            onChange={handleInputChange}
+                                            disabled={!isProjectValidForPayment}
+                                            className={cn(
+                                                "h-10 transition-all",
+                                                "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
+                                                autofilledFields.has("utr") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400",
+                                                formErrors.utr && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
+                                            )}
+                                        />
+                                        {formErrors.utr && (
+                                            <p className="text-xs text-red-500 flex items-center gap-1">
+                                                <AlertCircle className="w-3 h-3" />
+                                                {formErrors.utr}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    {/* Payment Date */}
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor="payment_date" className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                            <Calendar className="w-3.5 h-3.5 text-slate-400" />
+                                            Date <span className="text-red-500">*</span>
+                                        </Label>
+                                        <Input
+                                            id="payment_date"
+                                            name="payment_date"
+                                            type="date"
+                                            value={formState.payment_date}
+                                            onChange={handleInputChange}
+                                            disabled={!isProjectValidForPayment}
+                                            max={formatDate(new Date(), "yyyy-MM-dd")}
+                                            className={cn(
+                                                "h-10 transition-all",
+                                                "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500",
+                                                autofilledFields.has("payment_date") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400",
+                                                formErrors.payment_date && "border-red-300 focus:border-red-500 focus:ring-red-500/20"
+                                            )}
+                                        />
+                                        {formErrors.payment_date && (
+                                            <p className="text-xs text-red-500 flex items-center gap-1">
+                                                <AlertCircle className="w-3 h-3" />
+                                                {formErrors.payment_date}
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+
+                                {/* Attachment (replaceable; re-pick re-runs autofill) */}
+                                <div className="space-y-1.5">
+                                    <Label className="text-sm font-medium text-slate-700 dark:text-slate-300 flex items-center gap-2">
+                                        <FileText className="w-3.5 h-3.5 text-slate-400" />
+                                        Payment Proof
+                                        <span className="text-xs font-normal text-slate-400">(Optional)</span>
+                                    </Label>
+                                    <CustomAttachment
+                                        selectedFile={paymentScreenshot}
+                                        onFileSelect={handleFileSelect}
+                                        disabled={!isProjectValidForPayment}
+                                        maxFileSize={5 * 1024 * 1024}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </div>
                 </div>
 

--- a/frontend/src/pages/inflow-payments/config/inflowPaymentsTable.config.ts
+++ b/frontend/src/pages/inflow-payments/config/inflowPaymentsTable.config.ts
@@ -5,6 +5,7 @@ import { ProjectInflows } from '@/types/NirmaanStack/ProjectInflows';
 export const DEFAULT_INFLOW_FIELDS_TO_FETCH: (keyof ProjectInflows | 'name')[] = [
     "name", "creation", "modified", "owner", "project",
     "customer",
+    "invoice",
     "amount", "payment_date", "utr", "inflow_attachment"
 ];
 

--- a/frontend/src/pages/tasks/invoices/components/InvoiceApprovalComparison.tsx
+++ b/frontend/src/pages/tasks/invoices/components/InvoiceApprovalComparison.tsx
@@ -181,8 +181,10 @@ export const InvoiceApprovalComparison: React.FC<Props> = ({
         : null;
     // Amount: not a strict match (partial invoices are normal). Just show both;
     // mark mismatch only if the AI total exceeds PO total.
+    // Tolerate up to ₹10 of rounding drift — must match the backend hard-block
+    // threshold in update_invoice_data._check_po_amount_overage.
     const aiTotalExceeds =
-        aiTotalAmount > 0 && systemPoTotal > 0 && aiTotalAmount > systemPoTotal + 0.01;
+        aiTotalAmount > 0 && systemPoTotal > 0 && aiTotalAmount > systemPoTotal + 10;
     const amountMatch: boolean | null = aiTotalAmount > 0 ? !aiTotalExceeds : null;
 
     const usedAutofill = !!invoice.autofill_used;

--- a/frontend/src/types/NirmaanStack/ProjectInflows.ts
+++ b/frontend/src/types/NirmaanStack/ProjectInflows.ts
@@ -21,4 +21,6 @@ export interface ProjectInflows{
 	inflow_attachment: string
   /** UTR : Data */
   utr: string
+  /** Project Invoice this inflow paid against (one invoice may receive many inflows). */
+  invoice?: string
 }

--- a/nirmaan_stack/api/delivery_notes/update_invoice_data.py
+++ b/nirmaan_stack/api/delivery_notes/update_invoice_data.py
@@ -452,7 +452,10 @@ def _check_po_amount_overage(po_name: str, new_amount, exclude_invoice_id: Optio
     existing = float(rows[0].get("total") or 0) if rows else 0.0
 
     would_be_total = existing + new_amount_float
-    if would_be_total > po_total + 0.01:  # tolerate float fuzz
+    # Tolerate up to ₹10 of rounding drift (GST/freight rounding on real invoices
+    # commonly differ from PO totals by a few rupees). Tighter than this triggered
+    # spurious blocks on legitimate ₹0.10–₹5 deltas.
+    if would_be_total > po_total + 10:
         frappe.throw(
             f"Total invoiced amount would be ₹{would_be_total:,.2f}, which exceeds "
             f"the PO total of ₹{po_total:,.2f}. Already invoiced ₹{existing:,.2f}. "

--- a/nirmaan_stack/api/payment_autofill.py
+++ b/nirmaan_stack/api/payment_autofill.py
@@ -1,0 +1,262 @@
+import re
+
+import frappe
+
+from nirmaan_stack.services.document_ai import (
+    SUPPORTED_EXTS,
+    extract_with_document_ai,
+    fetch_file_content,
+    get_document_ai_settings,
+)
+
+MIN_CONFIDENCE = 0.70
+
+# Rounding tolerance when comparing Transfer_Amount from the receipt against
+# the requested payment amount. Banks sometimes round paise differently and
+# some receipts strip the decimal; ₹2 absorbs that noise without hiding a
+# real discrepancy.
+AMOUNT_DELTA = 2.0
+
+UTR_KEYS = ("utr",)
+PAYMENT_DATE_KEYS = ("payment_date",)
+TRANSFER_AMOUNT_KEYS = ("transfer_amount",)
+
+
+@frappe.whitelist()
+def extract_payment_fields(file_url):
+    """Extract UTR and payment date from an uploaded payment receipt.
+
+    Called from the New Payments → Pay dialog when the user selects an
+    attachment. Routes through the Expense Processor (custom-trained on
+    bank-transfer receipts) regardless of how the Document AI Settings
+    target-doctype lists are configured — this endpoint is hard-coded to
+    expense_processor_id because the receipt format is distinct from
+    invoices.
+
+    Only fields with confidence >= MIN_CONFIDENCE are returned populated;
+    lower-confidence fields are returned as empty strings so the frontend
+    leaves them blank for manual entry.
+    """
+    if not file_url:
+        frappe.throw("file_url is required")
+
+    file_doc = _get_file_doc_by_url(file_url)
+    if not file_doc:
+        frappe.throw(f"No File record found for url: {file_url}")
+
+    if not file_doc.file_name:
+        frappe.throw("File has no file_name; cannot determine type.")
+
+    file_ext = file_doc.file_name.rsplit(".", 1)[-1].lower()
+    if file_ext not in SUPPORTED_EXTS:
+        frappe.throw(f"Unsupported file type: .{file_ext}. Allowed: {sorted(SUPPORTED_EXTS)}")
+
+    settings = get_document_ai_settings()
+    if not settings.get("enabled"):
+        frappe.throw("Document AI is disabled. Please enable it in Document AI Settings.")
+
+    processor_id = (settings.get("expense_processor_id") or "").strip()
+    if not processor_id:
+        frappe.throw("No Expense Processor configured. Set expense_processor_id in Document AI Settings.")
+
+    content = fetch_file_content(file_doc, file_doc.name)
+    if not content:
+        frappe.throw("Could not read file content.")
+
+    try:
+        _, entities = extract_with_document_ai(content, file_ext, settings, processor_id)
+    except Exception as exc:
+        frappe.log_error(
+            title=f"Payment Autofill Error: {file_doc.name}",
+            message=frappe.get_traceback(),
+        )
+        frappe.throw(f"Document AI extraction failed: {exc}")
+
+    utr, utr_conf = _pick_entity(entities, UTR_KEYS)
+    payment_date, payment_date_conf = _pick_entity(entities, PAYMENT_DATE_KEYS, prefer_normalized=True)
+    transfer_amount, transfer_amount_conf = _pick_entity(entities, TRANSFER_AMOUNT_KEYS, prefer_normalized=True)
+
+    all_entities = [
+        {
+            "type": (entity.get("type") or "").strip(),
+            "value": (entity.get("normalized_text") or entity.get("mention_text") or "").strip(),
+            "confidence": round(float(entity.get("confidence") or 0), 3),
+        }
+        for entity in (entities or [])
+        if (entity.get("type") or "").strip()
+        and ((entity.get("normalized_text") or entity.get("mention_text") or "").strip())
+    ]
+
+    normalized_transfer_amount = (
+        _normalize_amount(transfer_amount) if transfer_amount_conf >= MIN_CONFIDENCE else ""
+    )
+    validation = _build_validation(file_doc, normalized_transfer_amount)
+
+    return {
+        "utr": _normalize_utr(utr) if utr_conf >= MIN_CONFIDENCE else "",
+        "payment_date": _normalize_date(payment_date) if payment_date_conf >= MIN_CONFIDENCE else "",
+        "transfer_amount": normalized_transfer_amount,
+        "confidence": {
+            "utr": round(utr_conf, 3),
+            "payment_date": round(payment_date_conf, 3),
+            "transfer_amount": round(transfer_amount_conf, 3),
+        },
+        "entities": all_entities,
+        "min_confidence": MIN_CONFIDENCE,
+        "processor_id": processor_id,
+        "validation": validation,
+    }
+
+
+def _build_validation(file_doc, extracted_transfer_amount):
+    """Return raw values for an amount-mismatch soft-check.
+
+    The frontend does the actual comparison because the effective expected
+    amount depends on TDS (which is entered after autofill runs). The server
+    just looks up the gross requested amount and surfaces the extracted
+    transfer amount + tolerance so the frontend can recompute the match
+    reactively as the user types TDS.
+
+    If the file isn't attached to a Project Payments row, `applicable` is
+    False and the frontend hides the banner.
+    """
+    parent_doctype = (file_doc.attached_to_doctype or "").strip()
+    parent_name = (file_doc.attached_to_name or "").strip()
+
+    result = {
+        "applicable": False,
+        "doctype": parent_doctype,
+        "docname": parent_name,
+        "amount": None,
+    }
+
+    if parent_doctype != "Project Payments" or not parent_name:
+        return result
+
+    try:
+        expected_amount = frappe.db.get_value("Project Payments", parent_name, "amount")
+    except Exception:
+        return result
+    if expected_amount is None:
+        return result
+
+    try:
+        expected = float(expected_amount or 0)
+    except (TypeError, ValueError):
+        expected = 0.0
+
+    extracted = None
+    if extracted_transfer_amount:
+        try:
+            extracted = round(float(extracted_transfer_amount), 2)
+        except (TypeError, ValueError):
+            extracted = None
+
+    result["applicable"] = True
+    result["amount"] = {
+        "expected": round(expected, 2),
+        "extracted": extracted,
+        "delta_threshold": AMOUNT_DELTA,
+    }
+    return result
+
+
+def _get_file_doc_by_url(file_url):
+    name = frappe.db.get_value("File", {"file_url": file_url}, "name")
+    if not name:
+        return None
+    return frappe.get_doc("File", name)
+
+
+def _pick_entity(entities, candidate_keys, prefer_normalized=False):
+    """Return (value, confidence) for the highest-confidence entity matching any candidate key."""
+    best_value = ""
+    best_conf = 0.0
+    candidates = {k.lower() for k in candidate_keys}
+
+    for entity in entities or []:
+        entity_type = (entity.get("type") or "").lower().strip()
+        if entity_type not in candidates:
+            continue
+
+        confidence = float(entity.get("confidence") or 0)
+        if confidence <= best_conf:
+            continue
+
+        normalized = (entity.get("normalized_text") or "").strip()
+        mention = (entity.get("mention_text") or "").strip()
+
+        if prefer_normalized:
+            value = normalized or mention
+        else:
+            value = mention or normalized
+
+        if not value:
+            continue
+
+        best_value = value
+        best_conf = confidence
+
+    return best_value, best_conf
+
+
+def _normalize_utr(value):
+    """Strip surrounding whitespace and internal spaces from a UTR string.
+
+    Banks sometimes pretty-print UTRs with spaces every 4 chars; the
+    backend uniqueness check compares exact strings, so we collapse
+    whitespace before returning.
+    """
+    if not value:
+        return ""
+    return re.sub(r"\s+", "", value.strip())
+
+
+def _normalize_date(value):
+    """Normalize a date string into YYYY-MM-DD for an HTML <input type='date'>."""
+    if not value:
+        return ""
+
+    value = value.strip()
+
+    from datetime import datetime
+
+    candidate_formats = (
+        "%Y-%m-%d",
+        "%Y/%m/%d",
+        "%d-%m-%Y",
+        "%d/%m/%Y",
+        "%d.%m.%Y",
+        "%m/%d/%Y",
+        "%d %b %Y",
+        "%d %B %Y",
+        "%d-%b-%Y",
+        "%d-%B-%Y",
+        "%b %d, %Y",
+        "%B %d, %Y",
+        "%d %b, %Y",
+        "%d %B, %Y",
+        "%d-%b-%y",
+        "%d/%m/%y",
+    )
+    for fmt in candidate_formats:
+        try:
+            return datetime.strptime(value, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return ""
+
+
+def _normalize_amount(value):
+    """Return a parseable numeric string or '' if value can't be cleanly parsed."""
+    if not value:
+        return ""
+
+    cleaned = re.sub(r"[^\d.\-]", "", value.strip())
+    if not cleaned or not re.search(r"\d", cleaned):
+        return ""
+
+    try:
+        return str(float(cleaned))
+    except ValueError:
+        return ""

--- a/nirmaan_stack/nirmaan_stack/doctype/document_ai_settings/document_ai_settings.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/document_ai_settings/document_ai_settings.json
@@ -58,14 +58,14 @@
    "label": "Expense Processor ID"
   },
   {
-   "default": "Project Invoices, Vendor Invoices, Project Payments",
+   "default": "Project Invoices, Vendor Invoices",
    "description": "Comma-separated DocTypes that should use Invoice Processor ID.",
    "fieldname": "invoice_target_doctypes",
    "fieldtype": "Small Text",
    "label": "Invoice Target DocTypes"
   },
   {
-   "default": "Non Project Expenses",
+   "default": "Non Project Expenses, Project Payments",
    "description": "Comma-separated DocTypes that should use Expense Processor ID.",
    "fieldname": "expense_target_doctypes",
    "fieldtype": "Small Text",

--- a/nirmaan_stack/nirmaan_stack/doctype/project_inflows/project_inflows.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/project_inflows/project_inflows.json
@@ -9,6 +9,7 @@
   "links_section",
   "project",
   "customer",
+  "invoice",
   "inflow_details_section",
   "utr",
   "inflow_attachment",
@@ -32,6 +33,12 @@
    "fieldtype": "Link",
    "label": "Customer",
    "options": "Customers"
+  },
+  {
+   "fieldname": "invoice",
+   "fieldtype": "Link",
+   "label": "Invoice",
+   "options": "Project Invoices"
   },
   {
    "fieldname": "inflow_details_section",


### PR DESCRIPTION
Document AI autofill (Expense processor) on three dialogs:
- Project Payments → Pay: UTR / Payment Date / soft amount-mismatch banner (±₹2 tolerance, recomputed against amount − TDS).
- Inflow Payments → Record Inflow Payment: UTR / Payment Date / Amount with two-stage upload → form gated reveal and race-safe session ref.
- Non Project Expenses → New: UTR / Payment Date / Amount inline in the Payment Details block, skips Document AI for csv/xlsx.

Supporting work:
- New `api/payment_autofill.py` whitelisted endpoint using the Expense Processor from Document AI Settings.
- Reuse shared GCP helpers in `services/document_ai.py`.
- Document AI Settings JSON defaults updated for target-doctype routing.
- Fix: dialog state leaking between rows on the vendor Pay dialog.

Inflow ↔ Project Invoice link:
- Add `invoice` Link field on Project Inflows (1 invoice → N inflows).
- New / Edit Inflow dialogs: single-select scoped to project.
- Inflow Payments table: clickable "Linked Invoice" column.
- Project Invoices table: reverse "Inflows" column — count pill with hover list of clickable inflow proofs.