### PR TITLE
feat(itm): add Edit/Delete to ITM Delivery Notes

### DIFF
--- a/frontend/src/pages/DeliveryNotes/ITMDeliveryNote.tsx
+++ b/frontend/src/pages/DeliveryNotes/ITMDeliveryNote.tsx
@@ -5,7 +5,7 @@ import {
   useFrappeGetDocList,
   useFrappePostCall,
 } from "frappe-react-sdk";
-import { ArrowLeft, Plus } from "lucide-react";
+import { ArrowLeft, Pencil, Plus, Trash2 } from "lucide-react";
 import { TailSpin } from "react-loader-spinner";
 
 import {
@@ -31,9 +31,15 @@ import {
 import { toast } from "@/components/ui/use-toast";
 
 import { useUserData } from "@/hooks/useUserData";
-import { formatDate } from "@/utils/FormatDate";
+import { formatDate, isCreatedToday } from "@/utils/FormatDate";
 import { decodeFrappeId } from "./constants";
 import { ITMDeliveryMetadataBar } from "./components/ITMDeliveryMetadataBar";
+import { useITMDeliveryEdit } from "./hooks/useITMDeliveryEdit";
+import { useITMDeliveryDelete } from "./hooks/useITMDeliveryDelete";
+import {
+  SameDayDNWarningDialog,
+  WarningDN,
+} from "./components/SameDayDNWarningDialog";
 import type { ITMDetailPayload } from "@/pages/InternalTransferMemos/hooks/useITM";
 import type { DeliveryNote } from "@/types/NirmaanStack/DeliveryNotes";
 import type { NirmaanUsers } from "@/types/NirmaanStack/NirmaanUsers";
@@ -76,6 +82,10 @@ const ITMDeliveryNote: React.FC = () => {
   const userData = useUserData();
   const isProjectManager =
     userData?.role === "Nirmaan Project Manager Profile";
+  // Delete button is Admin-only in the UI — mirrors the PO DN convention.
+  const isAdmin =
+    userData?.role === "Nirmaan Admin Profile" ||
+    userData?.user_id === "Administrator";
   const hideTotalReceived = isProjectManager && viewMode === "create";
 
   // In "create" mode the input row is auto-open. In "view" it stays
@@ -133,6 +143,33 @@ const ITMDeliveryNote: React.FC = () => {
     return map;
   }, [usersList]);
 
+  // Edit + Delete hooks — same role gate as PO DN (Admin/PMO/PL/Procurement
+  // always; PM same-day + creator). Delete UI is gated separately on isAdmin.
+  const {
+    editingDnName,
+    editedQuantities,
+    isEditSubmitting,
+    initEdit,
+    cancelEdit: cancelEditHook,
+    handleEditQuantityChange,
+    submitEdit,
+    canEditDn,
+    hasEditChanges,
+  } = useITMDeliveryEdit({
+    onDnRefetch: () => refetchDNs(),
+  });
+
+  const {
+    isDeleting,
+    deleteConfirmDialog,
+    setDeleteConfirmDialog,
+    dnToDelete,
+    handleDeleteClick,
+    handleConfirmDelete,
+  } = useITMDeliveryDelete({
+    onRefresh: () => refetchDNs(),
+  });
+
   const payload = itmData?.message;
   const itm = payload?.itm;
   // Sort DNs oldest → newest so columns read left-to-right in chronological
@@ -183,6 +220,56 @@ const ITMDeliveryNote: React.FC = () => {
     () => itemRows.some((r) => r.new_qty > 0),
     [itemRows]
   );
+
+  // Duplicate / same-day warning — mirrors PO's DeliveryPivotTable. Keys
+  // are composite (`item_id|make`) because ITM aggregation is by (item_id, make).
+  const sameDayDNs = useMemo(
+    () => dns.filter((dn) => isCreatedToday(dn.creation)),
+    [dns]
+  );
+
+  const duplicateDNs = useMemo(() => {
+    const newSig: Record<string, number> = {};
+    for (const r of itemRows) {
+      if (r.new_qty > 0) {
+        newSig[rowKey(r.item_id, r.make)] = r.new_qty;
+      }
+    }
+    const newKeys = Object.keys(newSig);
+    if (newKeys.length === 0) return [] as DeliveryNote[];
+
+    return dns.filter((dn) => {
+      if (dn.is_return) return false;
+      const existingSig: Record<string, number> = {};
+      for (const item of dn.items || []) {
+        const qty = Number(item.delivered_quantity) || 0;
+        if (qty <= 0) continue;
+        existingSig[rowKey(item.item_id, (item as any).make ?? null)] = qty;
+      }
+      const existingKeys = Object.keys(existingSig);
+      if (existingKeys.length !== newKeys.length) return false;
+      return newKeys.every((k) => existingSig[k] === newSig[k]);
+    });
+  }, [dns, itemRows]);
+
+  const warningDNs = useMemo<WarningDN[]>(() => {
+    const sameDayNames = new Set(sameDayDNs.map((dn) => dn.name));
+    const duplicateNames = new Set(duplicateDNs.map((dn) => dn.name));
+    const seen = new Set<string>();
+    const merged: WarningDN[] = [];
+    for (const dn of [...sameDayDNs, ...duplicateDNs]) {
+      if (seen.has(dn.name)) continue;
+      seen.add(dn.name);
+      const isSameDay = sameDayNames.has(dn.name);
+      const isDuplicate = duplicateNames.has(dn.name);
+      const reason: WarningDN["reason"] =
+        isSameDay && isDuplicate ? "both" : isSameDay ? "same-day" : "duplicate";
+      merged.push({ dn, reason });
+    }
+    return merged;
+  }, [sameDayDNs, duplicateDNs]);
+
+  const [warningOpen, setWarningOpen] = useState(false);
 
   // Lifecycle gate matching the PO page: only Dispatched / Partially Delivered
   // ITMs can have a DN added. The backend `create_itm_delivery_note` endpoint
@@ -316,38 +403,63 @@ const ITMDeliveryNote: React.FC = () => {
       )}
 
       <div className="border rounded-lg bg-card">
-        {/* Action bar — matches PO's `DeliveryPivotTable` action layout */}
-        {canEdit && (
-          <div className="flex flex-col sm:flex-row items-end sm:items-center justify-end gap-2 px-4 py-3 border-b">
-            {showEdit ? (
-              <>
+        {/* Action bar — matches PO's `DeliveryPivotTable` action layout.
+            Three modes share the bar: create-new-DN, edit-existing-DN, idle. */}
+        <div className="flex flex-col sm:flex-row items-end sm:items-center justify-end gap-2 px-4 py-3 border-b">
+          {editingDnName ? (
+            <>
+              <Button
+                size="sm"
+                onClick={submitEdit}
+                disabled={!hasEditChanges || isEditSubmitting}
+              >
+                {isEditSubmitting ? "Updating..." : "Update"}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={cancelEditHook}
+                disabled={isEditSubmitting}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : canEdit && showEdit ? (
+            <>
+              <Button
+                size="sm"
+                onClick={() => {
+                  // Gate behind duplicate / same-day warning — same UX as PO.
+                  if (warningDNs.length > 0) {
+                    setWarningOpen(true);
+                  } else {
+                    setConfirmOpen(true);
+                  }
+                }}
+                disabled={!hasValidInput || submitting}
+              >
+                Update
+              </Button>
+              {viewMode !== "create" && (
                 <Button
                   size="sm"
-                  onClick={() => setConfirmOpen(true)}
-                  disabled={!hasValidInput || submitting}
+                  variant="ghost"
+                  onClick={handleToggleEdit}
                 >
-                  Update
+                  Cancel
                 </Button>
-                {viewMode !== "create" && (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={handleToggleEdit}
-                  >
-                    Cancel
-                  </Button>
-                )}
-              </>
-            ) : (
-              viewMode !== "create" && (
-                <Button size="sm" variant="outline" onClick={handleToggleEdit}>
-                  <Plus className="h-4 w-4 mr-1" />
-                  Add New Delivery Note
-                </Button>
-              )
-            )}
-          </div>
-        )}
+              )}
+            </>
+          ) : (
+            canEdit &&
+            viewMode !== "create" && (
+              <Button size="sm" variant="outline" onClick={handleToggleEdit}>
+                <Plus className="h-4 w-4 mr-1" />
+                Add New Delivery Note
+              </Button>
+            )
+          )}
+        </div>
 
         {/* Pivot-style table — one column per DN, optional New Entry column */}
         <div className="relative overflow-x-auto">
@@ -374,10 +486,20 @@ const ITMDeliveryNote: React.FC = () => {
                         : updatedBy.split("@")[0])
                     : null;
                   const noteNo = (dn as any).note_no ?? idx + 1;
+                  const dnCol = {
+                    dnName: dn.name,
+                    updatedBy,
+                    creationDate: dn.creation,
+                  };
+                  const isEditingThis = editingDnName === dn.name;
+                  // Match PO: pencil/trash stay visible while user types
+                  // a new DN; only hide when another DN is being edited.
+                  const showEditBtn = !editingDnName && canEditDn(dnCol);
+                  const showDeleteBtn = !editingDnName && isAdmin;
                   return (
                     <TableHead
                       key={dn.name}
-                      className="text-right text-xs font-medium text-muted-foreground min-w-[100px]"
+                      className={`text-right text-xs font-medium text-muted-foreground min-w-[100px] ${isEditingThis ? "bg-primary/5" : ""}`}
                     >
                       <div className="flex flex-col items-end gap-0.5 py-0.5">
                         <span className="uppercase tracking-wider font-semibold text-foreground/80">
@@ -391,11 +513,46 @@ const ITMDeliveryNote: React.FC = () => {
                             by {displayName.split(" ")[0]}
                           </span>
                         )}
+                        {(showEditBtn || showDeleteBtn) && (
+                          <div className="flex items-center gap-1 mt-0.5">
+                            {showEditBtn && (
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-5 w-5"
+                                title="Edit this delivery note"
+                                onClick={() => {
+                                  const initial: Record<string, number> = {};
+                                  for (const row of itemRows) {
+                                    const qty = row.dnQuantities[dn.name];
+                                    if (qty && qty > 0) {
+                                      initial[rowKey(row.item_id, row.make)] = qty;
+                                    }
+                                  }
+                                  initEdit(dnCol, initial);
+                                }}
+                              >
+                                <Pencil className="h-3 w-3" />
+                              </Button>
+                            )}
+                            {showDeleteBtn && (
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-5 w-5 text-destructive hover:text-destructive"
+                                title="Delete this delivery note"
+                                onClick={() => handleDeleteClick({ dnName: dn.name })}
+                              >
+                                <Trash2 className="h-3 w-3" />
+                              </Button>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </TableHead>
                   );
                 })}
-                {showEdit && canEdit && (
+                {showEdit && canEdit && !editingDnName && (
                   <TableHead className="text-center text-xs font-medium uppercase tracking-wider text-muted-foreground bg-primary/5 min-w-[80px]">
                     New Entry
                   </TableHead>
@@ -438,10 +595,36 @@ const ITMDeliveryNote: React.FC = () => {
                     )}
                     {dns.map((dn) => {
                       const qty = row.dnQuantities[dn.name] || 0;
+                      const isEditingThis = editingDnName === dn.name;
+                      // Only the items present on the DN being edited get an
+                      // input; rows not on the DN render "--" so the user
+                      // can see what's not part of this DN. Adding new rows
+                      // to an existing DN isn't supported here (mirrors PO).
+                      if (isEditingThis && qty > 0) {
+                        const k = rowKey(row.item_id, row.make);
+                        const inputVal = editedQuantities[k] ?? "";
+                        return (
+                          <TableCell
+                            key={dn.name}
+                            className="text-center bg-primary/5"
+                          >
+                            <Input
+                              type="text"
+                              inputMode="decimal"
+                              value={inputVal}
+                              onChange={(e) =>
+                                handleEditQuantityChange(k, e.target.value)
+                              }
+                              className="w-[80px] mx-auto text-center"
+                              placeholder="0"
+                            />
+                          </TableCell>
+                        );
+                      }
                       return (
                         <TableCell
                           key={dn.name}
-                          className="text-right tabular-nums text-sm"
+                          className={`text-right tabular-nums text-sm ${isEditingThis ? "bg-primary/5" : ""}`}
                         >
                           {qty > 0 ? (
                             qty
@@ -451,7 +634,7 @@ const ITMDeliveryNote: React.FC = () => {
                         </TableCell>
                       );
                     })}
-                    {showEdit && canEdit && (
+                    {showEdit && canEdit && !editingDnName && (
                       <TableCell className="text-center bg-primary/5">
                         <Input
                           type="number"
@@ -490,6 +673,50 @@ const ITMDeliveryNote: React.FC = () => {
           </Table>
         </div>
       </div>
+
+      {/* Duplicate / same-day warning — parity with PO DeliveryPivotTable. */}
+      <SameDayDNWarningDialog
+        warningDNs={warningDNs}
+        open={warningOpen}
+        onCancel={() => setWarningOpen(false)}
+        onContinue={() => {
+          setWarningOpen(false);
+          setConfirmOpen(true);
+        }}
+      />
+
+      {/* Delete confirmation dialog — Admin-only action (button gated above). */}
+      <AlertDialog
+        open={deleteConfirmDialog}
+        onOpenChange={setDeleteConfirmDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Delivery Note?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete{" "}
+              <span className="font-semibold">{dnToDelete?.dnName}</span>.
+              ITM received quantities, status, and (for warehouse-target ITMs)
+              warehouse stock will be recalculated. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {isDeleting ? (
+              <TailSpin color="red" width={40} height={40} />
+            ) : (
+              <>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <Button
+                  variant="destructive"
+                  onClick={handleConfirmDelete}
+                >
+                  Delete
+                </Button>
+              </>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Submit confirmation dialog — date picker lives here, matching PO */}
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>

--- a/frontend/src/pages/DeliveryNotes/hooks/useITMDeliveryDelete.ts
+++ b/frontend/src/pages/DeliveryNotes/hooks/useITMDeliveryDelete.ts
@@ -1,0 +1,75 @@
+import { useState, useCallback } from "react";
+import { useFrappeDeleteDoc } from "frappe-react-sdk";
+import { useToast } from "@/components/ui/use-toast";
+
+export interface ITMDNDeleteTarget {
+  dnName: string;
+}
+
+interface UseITMDeliveryDeleteProps {
+  onSuccess?: () => void;
+  onRefresh?: () => void;
+}
+
+// Pull the user-facing message out of a Frappe error response. Server-side
+// `frappe.throw(...)` messages arrive in `_server_messages` (JSON-encoded
+// list of stringified payloads). Fall back to standard fields.
+function extractFrappeErrorMessage(error: unknown): string {
+  const err = error as { _server_messages?: string; message?: string; exception?: string };
+  if (err?._server_messages) {
+    try {
+      const messages = JSON.parse(err._server_messages);
+      if (Array.isArray(messages) && messages.length > 0) {
+        const first = typeof messages[0] === "string" ? JSON.parse(messages[0]) : messages[0];
+        if (first?.message) return String(first.message);
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return err?.message || err?.exception || "Failed to delete delivery note";
+}
+
+export function useITMDeliveryDelete({
+  onSuccess,
+  onRefresh,
+}: UseITMDeliveryDeleteProps) {
+  const { deleteDoc, isPending: isDeleting } = useFrappeDeleteDoc();
+  const { toast } = useToast();
+
+  const [deleteConfirmDialog, setDeleteConfirmDialog] = useState(false);
+  const [dnToDelete, setDnToDelete] = useState<ITMDNDeleteTarget | null>(null);
+
+  const handleDeleteClick = useCallback((target: ITMDNDeleteTarget) => {
+    setDnToDelete(target);
+    setDeleteConfirmDialog(true);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!dnToDelete) return;
+    try {
+      await deleteDoc("Delivery Notes", dnToDelete.dnName);
+      setDeleteConfirmDialog(false);
+      setDnToDelete(null);
+      if (onRefresh) onRefresh();
+      if (onSuccess) onSuccess();
+    } catch (error) {
+      console.error("Failed to delete ITM DN", error);
+      toast({
+        title: "Delete Failed",
+        description: extractFrappeErrorMessage(error),
+        variant: "destructive",
+      });
+    }
+  }, [dnToDelete, deleteDoc, onRefresh, onSuccess, toast]);
+
+  return {
+    isDeleting,
+    deleteConfirmDialog,
+    setDeleteConfirmDialog,
+    dnToDelete,
+    setDnToDelete,
+    handleDeleteClick,
+    handleConfirmDelete,
+  };
+}

--- a/frontend/src/pages/DeliveryNotes/hooks/useITMDeliveryEdit.ts
+++ b/frontend/src/pages/DeliveryNotes/hooks/useITMDeliveryEdit.ts
@@ -1,0 +1,226 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useFrappePostCall } from "frappe-react-sdk";
+import { useToast } from "@/components/ui/use-toast";
+import { useUserData } from "@/hooks/useUserData";
+import { isCreatedToday } from "@/utils/FormatDate";
+import { parseNumber } from "@/utils/parseNumber";
+
+const ALWAYS_EDIT_ROLES = [
+  "Nirmaan Admin Profile",
+  "Nirmaan PMO Executive Profile",
+  "Nirmaan Project Lead Profile",
+  "Nirmaan Procurement Executive Profile",
+];
+
+// ITM DNs aggregate by (item_id, make) — the row key encodes both so two ITM
+// rows with the same item in different makes don't collide. Format must stay
+// in sync with the `rowKey` helper in the ITM pivot components.
+const splitRowKey = (rowKey: string): { itemId: string; make: string | null } => {
+  const idx = rowKey.indexOf("|");
+  if (idx === -1) return { itemId: rowKey, make: null };
+  const itemId = rowKey.slice(0, idx);
+  const make = rowKey.slice(idx + 1);
+  return { itemId, make: make === "" ? null : make };
+};
+
+export interface ITMDNColumn {
+  dnName: string;
+  /** User who last updated the DN — for the same-day PM check. */
+  updatedBy?: string | null;
+  /** Frappe `creation` timestamp — for the same-day check. */
+  creationDate?: string;
+}
+
+interface UseITMDeliveryEditOptions {
+  onSuccess?: () => void;
+  onDnRefetch?: () => void;
+}
+
+export interface UseITMDeliveryEditReturn {
+  editingDnName: string | null;
+  editedQuantities: Record<string, string>;
+  isEditSubmitting: boolean;
+  initEdit: (
+    dn: ITMDNColumn,
+    initialQuantitiesByRowKey: Record<string, number>
+  ) => void;
+  cancelEdit: () => void;
+  handleEditQuantityChange: (rowKey: string, value: string) => void;
+  submitEdit: () => Promise<void>;
+  canEditDn: (col: ITMDNColumn) => boolean;
+  hasEditChanges: boolean;
+}
+
+export function useITMDeliveryEdit({
+  onSuccess,
+  onDnRefetch,
+}: UseITMDeliveryEditOptions): UseITMDeliveryEditReturn {
+  const userData = useUserData();
+  const { toast } = useToast();
+
+  const [editingDnName, setEditingDnName] = useState<string | null>(null);
+  const [editedQuantities, setEditedQuantities] = useState<
+    Record<string, string>
+  >({});
+  const initialQuantitiesRef = useRef<Record<string, string>>({});
+
+  const { call: editDNCall, loading: editLoading } = useFrappePostCall(
+    "nirmaan_stack.api.delivery_notes.edit_itm_delivery_note.edit_itm_delivery_note"
+  );
+
+  const isEditSubmitting = editLoading;
+
+  const canEditDn = useCallback(
+    (col: ITMDNColumn): boolean => {
+      const role = userData?.role;
+      if (!role || role === "Loading" || role === "Error") return false;
+
+      if (
+        userData.user_id === "Administrator" ||
+        ALWAYS_EDIT_ROLES.includes(role)
+      ) {
+        return true;
+      }
+
+      if (role === "Nirmaan Project Manager Profile") {
+        return (
+          col.updatedBy === userData.user_id &&
+          isCreatedToday(col.creationDate)
+        );
+      }
+
+      return false;
+    },
+    [userData?.role, userData?.user_id]
+  );
+
+  const initEdit = useCallback(
+    (
+      dn: ITMDNColumn,
+      initialQuantitiesByRowKey: Record<string, number>
+    ) => {
+      setEditingDnName(dn.dnName);
+
+      const initial: Record<string, string> = {};
+      for (const [rowKey, qty] of Object.entries(initialQuantitiesByRowKey)) {
+        if (qty != null && qty > 0) {
+          initial[rowKey] = String(qty);
+        }
+      }
+      setEditedQuantities(initial);
+      initialQuantitiesRef.current = { ...initial };
+    },
+    []
+  );
+
+  const cancelEdit = useCallback(() => {
+    setEditingDnName(null);
+    setEditedQuantities({});
+    initialQuantitiesRef.current = {};
+  }, []);
+
+  const handleEditQuantityChange = useCallback(
+    (rowKey: string, value: string) => {
+      if (value === "") {
+        setEditedQuantities((prev) => {
+          const updated = { ...prev };
+          delete updated[rowKey];
+          return updated;
+        });
+        return;
+      }
+
+      if (!/^[0-9]*\.?[0-9]*$/.test(value)) return;
+
+      setEditedQuantities((prev) => ({ ...prev, [rowKey]: value }));
+    },
+    []
+  );
+
+  const hasEditChanges = useMemo(() => {
+    const initial = initialQuantitiesRef.current;
+    const currentKeys = new Set(Object.keys(editedQuantities));
+    const initialKeys = new Set(Object.keys(initial));
+
+    for (const k of initialKeys) {
+      if (!currentKeys.has(k) && parseNumber(initial[k]) > 0) return true;
+    }
+    for (const k of currentKeys) {
+      if (parseNumber(editedQuantities[k]) !== parseNumber(initial[k])) return true;
+    }
+    return false;
+  }, [editedQuantities]);
+
+  const submitEdit = useCallback(async () => {
+    if (!editingDnName) return;
+
+    // Build the payload as [{item_id, make, delivered_quantity}, ...] using
+    // the composite row keys. Items present in the initial set but cleared
+    // are sent with qty=0 so the backend removes them.
+    const payloadMap: Record<string, number> = {};
+    for (const [rowKey, qtyStr] of Object.entries(editedQuantities)) {
+      payloadMap[rowKey] = parseNumber(qtyStr);
+    }
+    for (const rowKey of Object.keys(initialQuantitiesRef.current)) {
+      if (!(rowKey in payloadMap)) {
+        payloadMap[rowKey] = 0;
+      }
+    }
+
+    const modifiedItems = Object.entries(payloadMap).map(([rowKey, qty]) => {
+      const { itemId, make } = splitRowKey(rowKey);
+      return { item_id: itemId, make, delivered_quantity: qty };
+    });
+
+    if (modifiedItems.length === 0) {
+      toast({
+        title: "No Changes",
+        description: "No quantities were modified.",
+      });
+      return;
+    }
+
+    try {
+      const response = await editDNCall({
+        dn_name: editingDnName,
+        modified_items: JSON.stringify(modifiedItems),
+      });
+
+      if (response.message.status === 200) {
+        onSuccess?.();
+        onDnRefetch?.();
+        cancelEdit();
+        toast({
+          title: "Success!",
+          description: response.message.message,
+          variant: "success",
+        });
+      } else {
+        toast({
+          title: "Failed!",
+          description: response.message.error || "Unexpected error",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Error editing ITM delivery note:", error);
+      toast({
+        title: "Edit Failed",
+        description: "Failed to update delivery note",
+        variant: "destructive",
+      });
+    }
+  }, [editingDnName, editedQuantities, editDNCall, onSuccess, onDnRefetch, cancelEdit, toast]);
+
+  return {
+    editingDnName,
+    editedQuantities,
+    isEditSubmitting,
+    initEdit,
+    cancelEdit,
+    handleEditQuantityChange,
+    submitEdit,
+    canEditDn,
+    hasEditChanges,
+  };
+}

--- a/frontend/src/pages/InternalTransferMemos/components/ITMDeliverySection.tsx
+++ b/frontend/src/pages/InternalTransferMemos/components/ITMDeliverySection.tsx
@@ -1,7 +1,16 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { useFrappeGetCall, useFrappeGetDocList, useFrappePostCall } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
-import { Check, Download, Plus, TriangleAlert } from "lucide-react";
+import { Check, Pencil, Plus, Trash2, TriangleAlert } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   Table,
   TableBody,
@@ -13,8 +22,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
+import { useUserData } from "@/hooks/useUserData";
 import { formatDate } from "@/utils/FormatDate";
 import { cn } from "@/lib/utils";
+import { useITMDeliveryEdit } from "@/pages/DeliveryNotes/hooks/useITMDeliveryEdit";
+import { useITMDeliveryDelete } from "@/pages/DeliveryNotes/hooks/useITMDeliveryDelete";
 import type { NirmaanUsers } from "@/types/NirmaanStack/NirmaanUsers";
 import type { InternalTransferMemoItem } from "@/types/NirmaanStack/InternalTransferMemo";
 
@@ -64,6 +76,12 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
   items,
   onDNCreated,
 }) => {
+  const userData = useUserData();
+  // Delete button mirrors PO DN convention — Admin role / Administrator user only.
+  const isAdmin =
+    userData?.role === "Nirmaan Admin Profile" ||
+    userData?.user_id === "Administrator";
+
   const [isAdding, setIsAdding] = useState(false);
   const [newEntries, setNewEntries] = useState<Record<string, number>>({});
 
@@ -94,6 +112,34 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
     });
     return map;
   }, [usersList]);
+
+  // Edit + Delete hooks — same role gate as PO DN. Delete UI is Admin-only.
+  const {
+    editingDnName,
+    editedQuantities,
+    isEditSubmitting,
+    initEdit,
+    cancelEdit: cancelEditHook,
+    handleEditQuantityChange,
+    submitEdit,
+    canEditDn,
+    hasEditChanges,
+  } = useITMDeliveryEdit({
+    onDnRefetch: () => mutateDNs(),
+    onSuccess: () => onDNCreated?.(),
+  });
+
+  const {
+    isDeleting,
+    deleteConfirmDialog,
+    setDeleteConfirmDialog,
+    dnToDelete,
+    handleDeleteClick,
+    handleConfirmDelete,
+  } = useITMDeliveryDelete({
+    onRefresh: () => mutateDNs(),
+    onSuccess: () => onDNCreated?.(),
+  });
 
   const dnList: DNRecord[] = dnData?.message ?? [];
   const existingDN = dnList.length > 0 ? dnList[0] : null;
@@ -226,11 +272,41 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
     ? userNameMap.get(dnUpdatedBy) ?? (dnUpdatedBy === "Administrator" ? "Admin" : dnUpdatedBy.split("@")[0])
     : undefined;
 
+  const existingDNCol = existingDN
+    ? {
+        dnName: existingDN.name,
+        updatedBy: existingDN.updated_by_user || existingDN.owner,
+        creationDate: existingDN.creation,
+      }
+    : null;
+
+  const isEditingExisting =
+    !!editingDnName && !!existingDN && editingDnName === existingDN.name;
+
   return (
     <div className="space-y-3">
       {/* Action buttons */}
       <div className="flex items-center justify-end gap-2">
-        {isAdding ? (
+        {isEditingExisting ? (
+          <>
+            <Button
+              size="sm"
+              onClick={submitEdit}
+              disabled={!hasEditChanges || isEditSubmitting}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {isEditSubmitting ? "Updating..." : "Update"}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={cancelEditHook}
+              disabled={isEditSubmitting}
+            >
+              Cancel
+            </Button>
+          </>
+        ) : isAdding ? (
           <>
             <Button
               size="sm"
@@ -251,12 +327,6 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
           </>
         ) : (
           <>
-            {/* {existingDN && (
-              <Button size="sm" className="bg-red-600 hover:bg-red-700" onClick={handleDownloadDN}>
-                <Download className="h-3.5 w-3.5 mr-1.5" />
-                Download DN
-              </Button>
-            )} */}
             {canCreateDN && (
               <Button size="sm" onClick={handleStartAdding}>
                 <Plus className="h-3.5 w-3.5 mr-1.5" />
@@ -282,9 +352,15 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
                 Ordered
               </TableHead>
 
-              {/* Existing DN column — hidden when editing */}
-              {existingDN && (
-                <TableHead className="text-right text-xs font-medium text-muted-foreground min-w-[100px]">
+              {/* Existing DN column — header shows Edit/Delete actions
+                  when not creating or editing. */}
+              {existingDN && existingDNCol && (
+                <TableHead
+                  className={cn(
+                    "text-right text-xs font-medium text-muted-foreground min-w-[100px]",
+                    isEditingExisting && "bg-primary/5"
+                  )}
+                >
                   <div className="flex flex-col items-end gap-0.5 py-0.5">
                     <span className="uppercase tracking-wider font-semibold text-foreground/80">
                       DN
@@ -296,6 +372,44 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
                       <span className="text-[10px] text-muted-foreground truncate max-w-[100px]" title={dnUserName}>
                         by {dnUserName.split(" ")[0]}
                       </span>
+                    )}
+                    {/* Match PO: keep pencil/trash visible during create
+                        mode; only hide when this DN is being edited. */}
+                    {!editingDnName && (
+                      <div className="flex items-center gap-1 mt-0.5">
+                        {canEditDn(existingDNCol) && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-5 w-5"
+                            title="Edit this delivery note"
+                            onClick={() => {
+                              const initial: Record<string, number> = {};
+                              for (const it of items) {
+                                const k = rowKey(it.item_id, it.make);
+                                const qty = dnQtyByItem[k];
+                                if (qty && qty > 0) initial[k] = qty;
+                              }
+                              initEdit(existingDNCol, initial);
+                            }}
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </Button>
+                        )}
+                        {isAdmin && (
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="h-5 w-5 text-destructive hover:text-destructive"
+                            title="Delete this delivery note"
+                            onClick={() =>
+                              handleDeleteClick({ dnName: existingDN.name })
+                            }
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </div>
                     )}
                   </div>
                 </TableHead>
@@ -345,11 +459,33 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
                     {item.transfer_quantity}
                   </TableCell>
 
-                  {/* Existing DN qty — hidden when editing */}
+                  {/* Existing DN qty — turns into an input when editing
+                      this DN (only for rows already on the DN; new rows
+                      can't be added via edit). */}
                   {existingDN && (
-                    <TableCell className="text-right tabular-nums text-sm">
-                      {dnQty > 0 ? dnQty : <span className="text-muted-foreground">--</span>}
-                    </TableCell>
+                    isEditingExisting && dnQty > 0 ? (
+                      <TableCell className="text-center bg-primary/5">
+                        <Input
+                          type="text"
+                          inputMode="decimal"
+                          value={editedQuantities[k] ?? ""}
+                          onChange={(e) =>
+                            handleEditQuantityChange(k, e.target.value)
+                          }
+                          className="h-8 w-20 text-center text-sm tabular-nums mx-auto"
+                          placeholder="0"
+                        />
+                      </TableCell>
+                    ) : (
+                      <TableCell
+                        className={cn(
+                          "text-right tabular-nums text-sm",
+                          isEditingExisting && "bg-primary/5"
+                        )}
+                      >
+                        {dnQty > 0 ? dnQty : <span className="text-muted-foreground">--</span>}
+                      </TableCell>
+                    )
                   )}
 
                   {/* Input column (add or edit) */}
@@ -388,6 +524,36 @@ export const ITMDeliverySection: React.FC<ITMDeliverySectionProps> = ({
           </TableBody>
         </Table>
       </div>
+
+      {/* Delete confirmation dialog — Admin-only action (button gated above). */}
+      <AlertDialog
+        open={deleteConfirmDialog}
+        onOpenChange={setDeleteConfirmDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Delivery Note?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete{" "}
+              <span className="font-semibold">{dnToDelete?.dnName}</span>.
+              ITM received quantities, status, and (for warehouse-target ITMs)
+              warehouse stock will be recalculated. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {isDeleting ? (
+              <TailSpin color="red" width={32} height={32} />
+            ) : (
+              <>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <Button variant="destructive" onClick={handleConfirmDelete}>
+                  Delete
+                </Button>
+              </>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/nirmaan_stack/api/delivery_notes/_permission_utils.py
+++ b/nirmaan_stack/api/delivery_notes/_permission_utils.py
@@ -1,0 +1,49 @@
+import frappe
+from datetime import date
+
+
+ALWAYS_EDIT_ROLES = [
+    "Nirmaan Admin Profile",
+    "Nirmaan PMO Executive Profile",
+    "Nirmaan Project Lead Profile",
+    "Nirmaan Procurement Executive Profile",
+]
+
+
+def check_dn_edit_permission(dn):
+    """
+    Shared permission check for Delivery Note edit endpoints (PO + ITM).
+
+    Rules:
+        - Admin, PMO, Procurement Exec, Project Lead: always allowed
+        - Project Manager: only if they created the DN AND it was created today
+        - All others: denied
+    """
+    current_user = frappe.session.user
+
+    if current_user == "Administrator":
+        return
+
+    role_profile = frappe.db.get_value(
+        "Nirmaan Users", current_user, "role_profile"
+    )
+
+    if role_profile in ALWAYS_EDIT_ROLES:
+        return
+
+    if role_profile == "Nirmaan Project Manager Profile":
+        is_creator = dn.updated_by_user == current_user
+        is_created_today = dn.creation.date() == date.today()
+
+        if is_creator and is_created_today:
+            return
+
+        frappe.throw(
+            "Project Managers can only edit delivery notes they created on the same day",
+            frappe.PermissionError,
+        )
+
+    frappe.throw(
+        "Insufficient permissions to edit this delivery note",
+        frappe.PermissionError,
+    )

--- a/nirmaan_stack/api/delivery_notes/edit_delivery_note.py
+++ b/nirmaan_stack/api/delivery_notes/edit_delivery_note.py
@@ -1,53 +1,12 @@
 import frappe
-from datetime import date
+
+from nirmaan_stack.api.delivery_notes._permission_utils import (
+    check_dn_edit_permission,
+)
 
 
-ALWAYS_EDIT_ROLES = [
-    "Nirmaan Admin Profile",
-    "Nirmaan PMO Executive Profile",
-    "Nirmaan Project Lead Profile",
-    "Nirmaan Procurement Executive Profile",
-]
-
-
-def _check_edit_permission(dn):
-    """
-    Validate that the current user has permission to edit this Delivery Note.
-
-    Rules:
-        - Admin, PMO, Procurement Exec, Project Lead: always allowed
-        - Project Manager: only if they created the DN AND it was created today
-        - All others: denied
-    """
-    current_user = frappe.session.user
-
-    # Administrator is always allowed
-    if current_user == "Administrator":
-        return
-
-    role_profile = frappe.db.get_value(
-        "Nirmaan Users", current_user, "role_profile"
-    )
-
-    if role_profile in ALWAYS_EDIT_ROLES:
-        return
-
-    if role_profile == "Nirmaan Project Manager Profile":
-        is_creator = dn.updated_by_user == current_user
-        is_created_today = dn.creation.date() == date.today()
-
-        if is_creator and is_created_today:
-            return
-
-        frappe.throw(
-            "Project Managers can only edit delivery notes they created on the same day",
-            frappe.PermissionError,
-        )
-
-    frappe.throw(
-        "Insufficient permissions to edit this delivery note",
-        frappe.PermissionError,
-    )
+# Backwards-compatible alias — older imports referenced `_check_edit_permission`.
+_check_edit_permission = check_dn_edit_permission
 
 
 @frappe.whitelist()

--- a/nirmaan_stack/api/delivery_notes/edit_itm_delivery_note.py
+++ b/nirmaan_stack/api/delivery_notes/edit_itm_delivery_note.py
@@ -1,0 +1,145 @@
+import json
+import frappe
+
+from nirmaan_stack.api.delivery_notes._permission_utils import (
+    check_dn_edit_permission,
+)
+
+
+def _norm_make(value):
+    if isinstance(value, str):
+        return value.strip() or None
+    return value or None
+
+
+def _safe_float(value, default=0.0):
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
+
+@frappe.whitelist()
+def edit_itm_delivery_note(dn_name: str, modified_items):
+    """
+    Edit quantities of an existing ITM-backed Delivery Note.
+
+    Aggregation on ITM DNs is keyed by (item_id, make), so modified_items
+    must be a list of `{item_id, make, delivered_quantity}` rather than a
+    flat dict (a dict keyed by item_id alone would collide for ITMs holding
+    the same item in two makes).
+
+    Items with `delivered_quantity <= 0` are removed. If no items remain,
+    the DN is deleted entirely. ITM delivery fields (received quantities,
+    status, warehouse stock) are recalculated via on_update / after_delete
+    hooks on the `Delivery Notes` doctype.
+
+    Args:
+        dn_name: Name of the Delivery Note (e.g. "DN/ITM/<itm-id>/<n>")
+        modified_items: List of {item_id, make, delivered_quantity}, or a
+            JSON-encoded string of the same.
+    """
+    try:
+        frappe.db.begin()
+
+        if isinstance(modified_items, str):
+            modified_items = json.loads(modified_items)
+
+        if not isinstance(modified_items, list):
+            frappe.throw(
+                "modified_items must be a list of {item_id, make, delivered_quantity}",
+                frappe.ValidationError,
+            )
+
+        dn = frappe.get_doc("Delivery Notes", dn_name)
+
+        check_dn_edit_permission(dn)
+
+        if dn.is_return:
+            frappe.throw(
+                "Return notes cannot be edited. Create a new delivery note instead.",
+                frappe.ValidationError,
+            )
+
+        if dn.parent_doctype != "Internal Transfer Memo":
+            frappe.throw(
+                "This delivery note is not linked to an Internal Transfer Memo "
+                "and cannot be edited here.",
+                frappe.ValidationError,
+            )
+
+        # Build the requested-quantity map keyed by (item_id, make)
+        requested = {}
+        for req in modified_items:
+            key = (req["item_id"], _norm_make(req.get("make")))
+            requested[key] = _safe_float(req.get("delivered_quantity"))
+
+        # Lookup parent ITM items by (item_id, make) for any newly-added rows
+        itm = frappe.get_doc("Internal Transfer Memo", dn.parent_docname)
+        itm_items_by_key = {
+            (it.item_id, _norm_make(it.make)): it for it in itm.items
+        }
+
+        processed_keys = set()
+
+        # Update existing DN rows in place
+        for item in dn.items:
+            key = (item.item_id, _norm_make(item.make))
+            if key in requested:
+                item.delivered_quantity = requested[key]
+                processed_keys.add(key)
+
+        # Append any requested rows that weren't already present on the DN
+        for key, qty in requested.items():
+            if key in processed_keys:
+                continue
+            if qty <= 0:
+                continue
+            itm_item = itm_items_by_key.get(key)
+            if not itm_item:
+                # Unknown (item, make) for this ITM — skip rather than error
+                # so a partial edit can still go through.
+                continue
+            dn.append("items", {
+                "item_id": itm_item.item_id,
+                "item_name": itm_item.item_name,
+                "make": itm_item.make,
+                "unit": itm_item.unit,
+                "category": itm_item.category,
+                "delivered_quantity": qty,
+            })
+
+        # Drop rows where qty <= 0
+        dn.items = [item for item in dn.items if item.delivered_quantity > 0]
+
+        if not dn.items:
+            # No items left — delete the DN. The after_delete hook recalculates
+            # ITM delivery fields (received qty, status, warehouse stock).
+            frappe.delete_doc(
+                "Delivery Notes", dn_name, ignore_permissions=True
+            )
+            frappe.db.commit()
+            return {
+                "status": 200,
+                "message": f"Delivery note {dn_name} deleted (all items removed)",
+            }
+
+        # Save updated rows. The on_update hook recalculates ITM delivery
+        # fields, including warehouse stock deltas for warehouse-target ITMs.
+        dn.save(ignore_permissions=True)
+        frappe.db.commit()
+
+        return {
+            "status": 200,
+            "message": "Delivery note updated successfully",
+        }
+
+    except Exception as e:
+        frappe.db.rollback()
+        frappe.log_error("ITM Delivery Note Edit Error", str(e))
+        return {
+            "status": 400,
+            "error": str(e),
+        }

--- a/nirmaan_stack/integrations/controllers/delivery_notes.py
+++ b/nirmaan_stack/integrations/controllers/delivery_notes.py
@@ -34,14 +34,24 @@ def on_update(doc, method):
 
 
 
-    """Recalculate PO delivery fields when a DN is deleted."""
 def on_trash(doc, method):
-    """Recalculate delivery fields when a DN is deleted."""
+    """No-op — recalc must run after the row is gone from the DB.
+
+    Previously this hook called `recalculate_itm_delivery_fields` for ITM-
+    parented DNs, but `on_trash` fires *before* the SQL DELETE. The recalc
+    query therefore still saw the doomed row and the deletion had no effect
+    on received quantities, ITM status, or warehouse stock. Recalc lives in
+    `after_delete` for both PO and ITM now.
+    """
+    pass
+
+
+def after_delete(doc, method):
+    """Recalculate delivery fields after a DN is deleted."""
     if getattr(doc, "parent_doctype", None) == "Internal Transfer Memo":
         recalculate_itm_delivery_fields(doc.parent_docname)
         return
-        
-def after_delete(doc, method):
+
     if doc.procurement_order:
         recalculate_po_delivery_fields(doc.procurement_order)
         # Vendor credit recalculation after DN deletion
@@ -95,6 +105,8 @@ def recalculate_po_delivery_fields(po_name):
     # regardless of delivery progress. Normal status calc only resumes once all items are dispatched.
     if _has_undispatched_items(po):
         po.status = "Partially Dispatched"
+    elif not remaining_dns:
+        po.status = "Dispatched"
     else:
         po.status = calculate_order_status(po.get("items"))
 
@@ -183,8 +195,17 @@ def recalculate_itm_delivery_fields(itm_name):
         itm.status = "Delivered"
     elif any_received:
         itm.status = "Partially Delivered"
-    # else: stay at current status (Dispatched)
+    elif itm.status in ("Partially Delivered", "Delivered"):
+        # All DNs were deleted (received_quantity == 0 across all items).
+        # Revert to Dispatched so the state machine matches reality.
+        itm.status = "Dispatched"
+    # else: leave as-is (Approved / Dispatched)
 
+    # Signal to the ITM `validate` hook that this save is system-initiated
+    # from a DN recalculation — backward transitions (e.g. Delivered →
+    # Partially Delivered when a DN qty is reduced) are legitimate here and
+    # must bypass the forward-only state machine.
+    itm.flags.from_dn_recalc = True
     itm.save(ignore_permissions=True)
 
     # For warehouse-target ITMs, adjust Warehouse Stock Item by delivery delta

--- a/nirmaan_stack/integrations/controllers/internal_transfer_memo.py
+++ b/nirmaan_stack/integrations/controllers/internal_transfer_memo.py
@@ -165,6 +165,13 @@ def _get_old_status(doc):
 
 
 def _validate_state_transition(doc, old_status, new_status):
+    # System-initiated recalculation (DN edit / delete) is the only legitimate
+    # source of backward transitions like Delivered → Partially Delivered or
+    # → Dispatched. Trust the aggregation in that path and skip the forward-
+    # only state-machine check.
+    if doc.flags.get("from_dn_recalc"):
+        return
+
     allowed = ALLOWED_TRANSITIONS.get(old_status)
     if allowed is None or new_status not in allowed:
         frappe.throw(

--- a/nirmaan_stack/integrations/controllers/warehouse_stock.py
+++ b/nirmaan_stack/integrations/controllers/warehouse_stock.py
@@ -90,7 +90,23 @@ def apply_warehouse_delta(itm, item_row, delta: float):
         "make": item_row.make,
         "estimated_rate": item_row.estimated_rate,
     })
-    wsi.quantity = flt(wsi.quantity) + delta
+    new_quantity = flt(wsi.quantity) + delta
+
+    # Negative-stock guard: a DN delete or qty reduction can't drive warehouse
+    # stock below zero. If it would, downstream consumption has already drawn
+    # against this delivery and must be reversed first.
+    if new_quantity < 0:
+        make_suffix = f" ({item_row.make})" if item_row.make else ""
+        frappe.throw(
+            f"Cannot apply delivery change for {item_row.item_id}{make_suffix}: "
+            f"would drive warehouse stock to {new_quantity:.2f} (current "
+            f"{flt(wsi.quantity):.2f}, change {delta:+.2f}). Reverse any "
+            f"transfers that consumed this delivery before reducing or "
+            f"deleting the delivery note.",
+            frappe.ValidationError,
+        )
+
+    wsi.quantity = new_quantity
 
     if delta > 0:
         if item_row.estimated_rate and flt(item_row.estimated_rate) > flt(wsi.estimated_rate or 0):


### PR DESCRIPTION
- Edit + Delete with same role gate as PO (Admin/PMO/PL/Procurement; PM same-day + own DN; Delete UI Admin-only)
- Fix ITM recalc to run in after_delete (was on dead on_trash)
- Revert ITM/PO status to Dispatched when all DNs removed
- Bypass ITM forward-only state machine for DN-driven recalc
- Negative-stock guard in warehouse delta
- Duplicate / same-day DN warning on ITM standalone page