### PR TITLE
feat: add PMO task auto-renewal with submission history

### DIFF
--- a/frontend/src/pages/PMODashboard/components/EditTaskModal.tsx
+++ b/frontend/src/pages/PMODashboard/components/EditTaskModal.tsx
@@ -40,6 +40,7 @@ interface TaskData {
   completion_date: string | null;
   attachment: string | null;
   assigned_to?: string | null;
+  is_recurring?: 0 | 1 | null;
 }
 
 interface EditTaskModalProps {
@@ -57,6 +58,7 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({
 }) => {
   const { user_id, role } = useUserData();
   const isAdmin = role === "Nirmaan Admin Profile" || user_id === "Administrator";
+  const isRecurring = task?.is_recurring === 1;
 
   const [status, setStatus] = useState<string>("");
   const [completionDate, setCompletionDate] = useState("");
@@ -124,7 +126,12 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({
       return;
     }
 
-    if ((status === "Sent/Submision" || status === "Approve by client") && !attachment && !task?.attachment) {
+    if (
+      !isRecurring &&
+      (status === "Sent/Submision" || status === "Approve by client") &&
+      !attachment &&
+      !task?.attachment
+    ) {
       toast({
         title: "Validation Error",
         description: `Attachment is required for ${status}.`,
@@ -207,15 +214,33 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({
                 <SelectValue placeholder="Select status" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="WIP">WIP</SelectItem>
-                <SelectItem value="Sent/Submision">Sent/Submision</SelectItem>
-                <SelectItem value="Approve by client">Approve by client</SelectItem>
+                {isRecurring ? (
+                  <>
+                    <SelectItem value="Done">Done</SelectItem>
+                    <SelectItem value="Not Done">Not Done</SelectItem>
+                  </>
+                ) : (
+                  <>
+                    <SelectItem value="WIP">WIP</SelectItem>
+                    <SelectItem value="Sent/Submision">Sent/Submision</SelectItem>
+                    <SelectItem value="Approve by client">Approve by client</SelectItem>
+                  </>
+                )}
               </SelectContent>
             </Select>
           </div>
 
-          {/* Submison Date — shown when "Sent/Submision" */}
-          {status === "Sent/Submision" && (
+          {/* Recurring task context */}
+          {isRecurring && status === "Done" && (
+            <div className="rounded-md p-3 bg-green-50 border border-green-200">
+              <p className="text-sm text-green-800">
+                You've finished this one. A fresh task will show up here once the due date passes.
+              </p>
+            </div>
+          )}
+
+          {/* Submison Date — shown when "Sent/Submision" (legacy non-recurring flow) */}
+          {!isRecurring && status === "Sent/Submision" && (
             <div>
               <label className="text-sm font-medium text-gray-700 block mb-1.5">
                 Submison Date
@@ -228,8 +253,8 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({
               />
             </div>
           )}
-          {/* Info shown for "Approve by client" */}
-          {status === "Approve by client" && (
+          {/* Info shown for "Approve by client" (legacy non-recurring flow) */}
+          {!isRecurring && status === "Approve by client" && (
             <div className="bg-green-50 border border-green-200 rounded-md p-3">
               <p className="text-sm text-green-800">
                 This will approve the task and update status progress.
@@ -238,13 +263,31 @@ const EditTaskModal: React.FC<EditTaskModalProps> = ({
             </div>
           )}
 
-          {/* Attachment UI — shown for "Sent/Submision" or "Approve by client" */}
-          {(status === "Sent/Submision" || status === "Approve by client") && (
+          {/* Attachment UI */}
+          {!isRecurring && (status === "Sent/Submision" || status === "Approve by client") && (
             <div className="space-y-1.5 mt-4">
               <label className="text-sm font-medium text-gray-700 block mb-1.5 flex items-center gap-2">
                 <FileText className="w-3.5 h-3.5 text-gray-400" />
                 Proof of Submission / Approval
-                {(status === "Sent/Submision" || status === "Approve by client") && <span className="text-red-500">*</span>}
+                <span className="text-red-500">*</span>
+              </label>
+              <CustomAttachment
+                selectedFile={attachment}
+                onFileSelect={setAttachment}
+                maxFileSize={5 * 1024 * 1024}
+              />
+              {task?.attachment && (
+                <p className="text-[10px] text-gray-500 italic mt-1">
+                  Current attachment: {task.attachment.split("/").pop()}
+                </p>
+              )}
+            </div>
+          )}
+          {isRecurring && status === "Done" && (
+            <div className="space-y-1.5 mt-4">
+              <label className="text-sm font-medium text-gray-700 block mb-1.5 flex items-center gap-2">
+                <FileText className="w-3.5 h-3.5 text-gray-400" />
+                Proof of Submission (optional)
               </label>
               <CustomAttachment
                 selectedFile={attachment}

--- a/frontend/src/pages/PMODashboard/components/PMOPackagesMaster.tsx
+++ b/frontend/src/pages/PMODashboard/components/PMOPackagesMaster.tsx
@@ -65,6 +65,7 @@ interface PMOTaskMaster {
   category_link: string;
   order?: number;
   deadline_offset?: number;
+  is_recurring?: 0 | 1;
 }
 
 // --- Zod Schemas ---
@@ -77,6 +78,7 @@ type CategoryFormValues = z.infer<typeof categoryFormSchema>;
 const taskFormSchema = z.object({
   task_name: z.string().min(1, "Task Name is required."),
   deadline_offset: z.coerce.number().min(0, "Offset must be positive").optional(),
+  is_recurring: z.boolean().default(false),
 });
 type TaskFormValues = z.infer<typeof taskFormSchema>;
 
@@ -104,7 +106,7 @@ export const PMOPackagesMaster: React.FC = () => {
     error: taskError,
     mutate: mutateTasks,
   } = useFrappeGetDocList<PMOTaskMaster>("PMO Task Master", {
-    fields: ["name", "task_name", "category_link", "order", "deadline_offset"],
+    fields: ["name", "task_name", "category_link", "order", "deadline_offset", "is_recurring"],
     limit: 0,
     orderBy: { field: "`order`", order: "asc" },
   });
@@ -699,15 +701,16 @@ const EditCategoryDialog: React.FC<{
 // --- Create Task Dialog ---
 const CreateTaskDialog: React.FC<{
   categoryId: string;
+  categoryIsHandoverRestricted: boolean;
   mutate: () => Promise<any>;
   maxOrder: number;
-}> = ({ categoryId, mutate, maxOrder }) => {
+}> = ({ categoryId, categoryIsHandoverRestricted, mutate, maxOrder }) => {
   const [open, setOpen] = useState(false);
   const { createDoc, loading } = useFrappeCreateDoc();
 
   const form = useForm<TaskFormValues>({
     resolver: zodResolver(taskFormSchema),
-    defaultValues: { task_name: "", deadline_offset: 0 },
+    defaultValues: { task_name: "", deadline_offset: 0, is_recurring: false },
   });
 
   const onSubmit = async (values: TaskFormValues) => {
@@ -717,13 +720,14 @@ const CreateTaskDialog: React.FC<{
         category_link: categoryId,
         order: maxOrder + 1,
         deadline_offset: values.deadline_offset || 0,
+        is_recurring: values.is_recurring ? 1 : 0,
       });
       toast({
         title: "Success",
         description: "Task added successfully.",
         variant: "success",
       });
-      form.reset({ task_name: "", deadline_offset: 0 });
+      form.reset({ task_name: "", deadline_offset: 0, is_recurring: false });
       await mutate();
       setOpen(false);
     } catch (error: any) {
@@ -740,7 +744,7 @@ const CreateTaskDialog: React.FC<{
       open={open}
       onOpenChange={(val) => {
         setOpen(val);
-        if (!val) form.reset({ task_name: "", deadline_offset: 0 });
+        if (!val) form.reset({ task_name: "", deadline_offset: 0, is_recurring: false });
       }}
     >
       <DialogTrigger asChild>
@@ -804,6 +808,31 @@ const CreateTaskDialog: React.FC<{
                 </FormItem>
               )}
             />
+            <FormField
+              control={form.control}
+              name="is_recurring"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-slate-200 p-3">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      disabled={categoryIsHandoverRestricted}
+                      onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel className="text-sm font-medium text-slate-700">
+                      Auto-Renew After Each Cycle
+                    </FormLabel>
+                    <p className="text-xs text-slate-500">
+                      {categoryIsHandoverRestricted
+                        ? "Can't be turned on for handover-only categories."
+                        : "Turn this on for tasks that should repeat — like a weekly update. When the due date passes, a fresh one starts automatically."}
+                    </p>
+                  </div>
+                </FormItem>
+              )}
+            />
             <div className="flex justify-end gap-2 pt-2">
               <Button
                 type="button"
@@ -838,20 +867,36 @@ const CreateTaskDialog: React.FC<{
 // --- Edit Task Dialog ---
 const EditTaskDialog: React.FC<{
   task: PMOTaskMaster;
+  categoryIsHandoverRestricted: boolean;
   mutate: () => Promise<any>;
-}> = ({ task, mutate }) => {
+}> = ({ task, categoryIsHandoverRestricted, mutate }) => {
   const [open, setOpen] = useState(false);
   const { updateDoc, loading } = useFrappeUpdateDoc();
   const form = useForm<TaskFormValues>({
     resolver: zodResolver(taskFormSchema),
-    defaultValues: { task_name: task.task_name, deadline_offset: task.deadline_offset || 0 },
+    defaultValues: {
+      task_name: task.task_name,
+      deadline_offset: task.deadline_offset || 0,
+      is_recurring: Boolean(task.is_recurring),
+    },
   });
+
+  React.useEffect(() => {
+    if (open) {
+      form.reset({
+        task_name: task.task_name,
+        deadline_offset: task.deadline_offset || 0,
+        is_recurring: Boolean(task.is_recurring),
+      });
+    }
+  }, [open, task]);
 
   const onSubmit = async (values: TaskFormValues) => {
     try {
       await updateDoc("PMO Task Master", task.name, {
         task_name: values.task_name,
         deadline_offset: values.deadline_offset || 0,
+        is_recurring: values.is_recurring ? 1 : 0,
       });
       toast({
         title: "Success",
@@ -923,6 +968,31 @@ const EditTaskDialog: React.FC<{
                     />
                   </FormControl>
                   <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="is_recurring"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-slate-200 p-3">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      disabled={categoryIsHandoverRestricted}
+                      onCheckedChange={(checked) => field.onChange(Boolean(checked))}
+                    />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel className="text-sm font-medium text-slate-700">
+                      Auto-Renew After Each Cycle
+                    </FormLabel>
+                    <p className="text-xs text-slate-500">
+                      {categoryIsHandoverRestricted
+                        ? "Can't be turned on for handover-only categories."
+                        : "Turn this on for tasks that should repeat — like a weekly update. When the due date passes, a fresh one starts automatically."}
+                    </p>
+                  </div>
                 </FormItem>
               )}
             />
@@ -1174,7 +1244,12 @@ const CategoryCard: React.FC<{
                 <GripVertical className="w-3.5 h-3.5 mr-1" />
                 Reorder
               </Button>
-              <CreateTaskDialog categoryId={category.name} mutate={mutateTasks} maxOrder={maxTaskOrder} />
+              <CreateTaskDialog
+                categoryId={category.name}
+                categoryIsHandoverRestricted={Boolean(category.is_handover_restricted)}
+                mutate={mutateTasks}
+                maxOrder={maxTaskOrder}
+              />
             </>
           )}
         </div>
@@ -1231,13 +1306,22 @@ const CategoryCard: React.FC<{
                         T + {task.deadline_offset}d
                       </span>
                     )}
+                    {task.is_recurring === 1 && (
+                      <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded bg-blue-50 text-blue-700 text-xs font-medium border border-blue-100">
+                        Recurring
+                      </span>
+                    )}
                   </TableCell>
                   <TableCell className="text-right">
                     {isReorderingTasks ? (
                        <GripVertical className="w-4 h-4 text-slate-300 ml-auto" />
                     ) : (
                       <div className="flex items-center justify-end gap-0.5">
-                        <EditTaskDialog task={task} mutate={mutateTasks} />
+                        <EditTaskDialog
+                          task={task}
+                          categoryIsHandoverRestricted={Boolean(category.is_handover_restricted)}
+                          mutate={mutateTasks}
+                        />
                         <DeleteTaskDialog task={task} mutate={mutateTasks} />
                       </div>
                     )}

--- a/frontend/src/pages/PMODashboard/components/TaskHistoryDrawer.tsx
+++ b/frontend/src/pages/PMODashboard/components/TaskHistoryDrawer.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { TailSpin } from "react-loader-spinner";
+import { Check, X, FileText, History } from "lucide-react";
+import { useFrappeGetDocList } from "frappe-react-sdk";
+
+interface SubmissionLogRow {
+  name: string;
+  cycle_number: number;
+  cycle_start_date: string | null;
+  cycle_end_date: string | null;
+  result: "Done" | "Not Done";
+  was_force_marked: 0 | 1;
+  closed_on: string | null;
+  attachment: string | null;
+}
+
+interface TaskHistoryDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskName: string | null;
+  taskLabel?: string;
+}
+
+const formatDate = (d: string | null) => {
+  if (!d) return "---";
+  try {
+    return new Date(d).toLocaleDateString("en-IN", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return d;
+  }
+};
+
+const TaskHistoryDrawer: React.FC<TaskHistoryDrawerProps> = ({
+  open,
+  onOpenChange,
+  taskName,
+  taskLabel,
+}) => {
+  const { data, isLoading, error } = useFrappeGetDocList<SubmissionLogRow>(
+    "PMO Task Submission Log",
+    {
+      filters: taskName ? [["task", "=", taskName]] : [],
+      fields: [
+        "name",
+        "cycle_number",
+        "cycle_start_date",
+        "cycle_end_date",
+        "result",
+        "was_force_marked",
+        "closed_on",
+        "attachment",
+      ],
+      orderBy: { field: "cycle_number", order: "desc" },
+      limit: 0,
+    },
+    open && taskName ? undefined : null
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="sm:max-w-2xl w-full overflow-auto">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2 text-lg">
+            <History className="h-4 w-4 text-red-500" />
+            Submission History
+          </SheetTitle>
+          <SheetDescription className="text-sm text-gray-500">
+            {taskLabel ? `All past entries for "${taskLabel}".` : "All past entries for this task."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-10">
+              <TailSpin height={28} width={28} color="#dc2626" />
+            </div>
+          )}
+
+          {!isLoading && error && (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              Failed to load history.
+            </div>
+          )}
+
+          {!isLoading && !error && (!data || data.length === 0) && (
+            <div className="rounded-md border border-dashed border-gray-200 px-4 py-8 text-center text-sm text-gray-500">
+              Nothing here yet. Past entries will show up once the first due
+              date passes.
+            </div>
+          )}
+
+          {!isLoading && !error && data && data.length > 0 && (
+            <div className="overflow-hidden rounded-lg border border-gray-200">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-gray-50 hover:bg-gray-50">
+                    <TableHead className="text-xs font-semibold uppercase text-gray-500">
+                      #
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase text-gray-500">
+                      From → To
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase text-gray-500">
+                      Status
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase text-gray-500">
+                      Marked On
+                    </TableHead>
+                    <TableHead className="text-xs font-semibold uppercase text-gray-500">
+                      Attachment
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.map((row) => (
+                    <TableRow key={row.name} className="hover:bg-gray-50/50">
+                      <TableCell className="text-sm font-medium text-gray-900">
+                        #{row.cycle_number}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600 whitespace-nowrap">
+                        {formatDate(row.cycle_start_date)} → {formatDate(row.cycle_end_date)}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1.5">
+                          {row.result === "Done" ? (
+                            <span className="inline-flex items-center gap-1 rounded-md border border-green-100 bg-green-50 px-2 py-1 text-xs font-medium text-green-600">
+                              <Check className="h-3 w-3" />
+                              Done
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1 rounded-md border border-red-100 bg-red-50 px-2 py-1 text-xs font-medium text-red-600">
+                              <X className="h-3 w-3" />
+                              Not Done
+                            </span>
+                          )}
+                          {row.was_force_marked === 1 && (
+                            <Badge
+                              variant="secondary"
+                              className="px-1.5 py-0 text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200"
+                              title="Marked automatically — nobody updated this before the due date."
+                            >
+                              auto
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600 whitespace-nowrap">
+                        {formatDate(row.closed_on)}
+                      </TableCell>
+                      <TableCell className="text-sm text-gray-600">
+                        {row.attachment ? (
+                          <a
+                            href={row.attachment}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 text-blue-600 hover:text-blue-800"
+                          >
+                            <FileText className="h-3.5 w-3.5" />
+                            View
+                          </a>
+                        ) : (
+                          <span className="text-gray-400">---</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default TaskHistoryDrawer;

--- a/frontend/src/pages/PMODashboard/pmo-project-detail.tsx
+++ b/frontend/src/pages/PMODashboard/pmo-project-detail.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useFrappeGetDoc, useFrappePostCall } from "frappe-react-sdk";
 import { useUserData } from "@/hooks/useUserData";
-import { ArrowLeft, Pencil, Check, FileText, ExternalLink, Activity, LayoutDashboard, PenTool, BarChart2, PencilRuler, Download, Loader2, UserCheck, Users, UserX, MapPin, CalendarRange } from "lucide-react";
+import { ArrowLeft, Pencil, Check, X, FileText, ExternalLink, Activity, LayoutDashboard, PenTool, BarChart2, PencilRuler, Download, Loader2, UserCheck, Users, UserX, MapPin, CalendarRange, History } from "lucide-react";
 import { useProjectScheduler } from "@/pages/Manpower-and-WorkMilestones/hooks/useProjectScheduler";
 import { ProjectDetailSkeleton } from "@/components/ui/skeleton";
 import { toast } from "@/components/ui/use-toast";
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import EditTaskModal from "./components/EditTaskModal";
 import { AssignPMODialog } from "./components/AssignPMODialog";
+import TaskHistoryDrawer from "./components/TaskHistoryDrawer";
 import { parseAssignedFromField, type AssignedPMODetail } from "./utils";
 
 interface TaskItem {
@@ -31,6 +32,7 @@ interface TaskItem {
   completion_date: string | null;
   attachment: string | null;
   assigned_to?: string | null;
+  is_recurring?: 0 | 1 | null;
 }
 
 interface StatusOverview {
@@ -103,6 +105,10 @@ const PMOProjectDetail: React.FC = () => {
   // Edit modal state
   const [editOpen, setEditOpen] = useState(false);
   const [editTask, setEditTask] = useState<TaskItem | null>(null);
+
+  // History drawer state
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyTask, setHistoryTask] = useState<TaskItem | null>(null);
 
   // Bulk assign state (admin)
   const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
@@ -417,7 +423,9 @@ const PMOProjectDetail: React.FC = () => {
   // Compute progress
   const allTasks = Object.values(visibleTasks).flat();
   const totalTasks = allTasks.length;
-  const completedTasks = allTasks.filter((t) => t.status === "Approve by client").length;
+  const completedTasks = allTasks.filter(
+    (t) => t.status === "Approve by client" || t.status === "Done"
+  ).length;
   const pendingTasks = totalTasks - completedTasks;
   const progress = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
 
@@ -442,6 +450,20 @@ const PMOProjectDetail: React.FC = () => {
           <span className="inline-flex min-w-[84px] items-center justify-center gap-1 rounded-md bg-green-50 border border-green-100 px-2 py-1 text-xs font-medium text-green-600">
             <Check className="h-3 w-3" />
             Approved
+          </span>
+        );
+      case "Done":
+        return (
+          <span className="inline-flex min-w-[84px] items-center justify-center gap-1 rounded-md bg-green-50 border border-green-100 px-2 py-1 text-xs font-medium text-green-600">
+            <Check className="h-3 w-3" />
+            Done
+          </span>
+        );
+      case "Not Done":
+        return (
+          <span className="inline-flex min-w-[84px] items-center justify-center gap-1 rounded-md bg-red-50 border border-red-100 px-2 py-1 text-xs font-medium text-red-600">
+            <X className="h-3 w-3" />
+            Not Done
           </span>
         );
       case "Sent/Submision":
@@ -679,13 +701,16 @@ const PMOProjectDetail: React.FC = () => {
                         <TableCell className="text-sm text-gray-900">
                           <div className="flex items-center gap-2">
                             <span
-                              className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${task.status === "Approve by client"
-                                ? "bg-green-500"
-                                : task.status === "Sent/Submision"
-                                  ? "bg-blue-500"
-                                  : task.status === "WIP"
-                                    ? "bg-orange-500"
-                                    : "bg-gray-300"
+                              className={`h-2.5 w-2.5 flex-shrink-0 rounded-full ${
+                                task.status === "Approve by client" || task.status === "Done"
+                                  ? "bg-green-500"
+                                  : task.status === "Not Done"
+                                    ? "bg-red-500"
+                                    : task.status === "Sent/Submision"
+                                      ? "bg-blue-500"
+                                      : task.status === "WIP"
+                                        ? "bg-orange-500"
+                                        : "bg-gray-300"
                                 }`}
                             />
                             {task.task_name}
@@ -733,20 +758,34 @@ const PMOProjectDetail: React.FC = () => {
                           )}
                         </TableCell>
                         <TableCell className="text-right">
-                          <button
-                            disabled={isPMO && !canPMOEdit(task)}
-                            onClick={() => {
-                              if (isPMO && !canPMOEdit(task)) return;
-                              setEditTask(task);
-                              setEditOpen(true);
-                            }}
-                            className={`p-1 ${isPMO && !canPMOEdit(task)
-                                ? "text-gray-300 cursor-not-allowed"
-                                : "text-gray-400 hover:text-gray-600"
-                              }`}
-                          >
-                            <Pencil className="h-4 w-4" />
-                          </button>
+                          <div className="inline-flex items-center justify-end gap-1">
+                            {task.is_recurring === 1 && (
+                              <button
+                                onClick={() => {
+                                  setHistoryTask(task);
+                                  setHistoryOpen(true);
+                                }}
+                                title="View submission history"
+                                className="p-1 text-gray-400 hover:text-red-500"
+                              >
+                                <History className="h-4 w-4" />
+                              </button>
+                            )}
+                            <button
+                              disabled={isPMO && !canPMOEdit(task)}
+                              onClick={() => {
+                                if (isPMO && !canPMOEdit(task)) return;
+                                setEditTask(task);
+                                setEditOpen(true);
+                              }}
+                              className={`p-1 ${isPMO && !canPMOEdit(task)
+                                  ? "text-gray-300 cursor-not-allowed"
+                                  : "text-gray-400 hover:text-gray-600"
+                                }`}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </button>
+                          </div>
                         </TableCell>
                       </TableRow>
                     );
@@ -1008,6 +1047,14 @@ const PMOProjectDetail: React.FC = () => {
         onOpenChange={setEditOpen}
         task={editTask}
         onSuccess={loadTasks}
+      />
+
+      {/* Submission History Drawer (recurring tasks) */}
+      <TaskHistoryDrawer
+        open={historyOpen}
+        onOpenChange={setHistoryOpen}
+        taskName={historyTask?.name || null}
+        taskLabel={historyTask?.task_name}
       />
 
       {/* Bulk Assign Dialog (admin) */}

--- a/nirmaan_stack/api/pmo_dashboard.py
+++ b/nirmaan_stack/api/pmo_dashboard.py
@@ -167,7 +167,7 @@ def get_pmo_projects():
                 category_summary[cat] = {"total": 0, "done": 0}
 
             project_task_counts[cat] = project_task_counts.get(cat, 0) + 1
-            if task.status == "Approve by client":
+            if task.status in ("Approve by client", "Done"):
                 category_summary[cat]["done"] += 1
 
         # Keep package totals by default, but if project has more rows than master
@@ -219,21 +219,35 @@ def get_project_tasks(project):
     handover_visible = _is_handover_phase(project_status)
 
     tasks = frappe.db.sql(f"""
-        SELECT 
+        SELECT
             pt.name, pt.task_name, pt.category, pt.status,
             pt.expected_completion_date, pt.completion_date, pt.attachment,
             pt.task_master, pt.assigned_to, tm.deadline_offset, pc.is_handover_restricted
-        FROM 
+        FROM
             `tabPMO Project Task` pt
-        LEFT JOIN 
+        LEFT JOIN
             `tabPMO Task Category` pc ON pt.category = pc.category_name
-        LEFT JOIN 
+        LEFT JOIN
             `tabPMO Task Master` tm ON pt.task_master = tm.name
-        WHERE 
+        WHERE
             pt.project = %s
-        ORDER BY 
+        ORDER BY
             pc.`order` ASC, tm.`order` ASC
     """, (project,), as_dict=True)
+
+    # Build a lookup of which task_masters are recurring — pre-migration safe.
+    # If the is_recurring column doesn't exist yet (migrate not run), treat all
+    # tasks as non-recurring so the legacy flow continues to work.
+    recurring_master_ids = set()
+    if frappe.db.has_column("PMO Task Master", "is_recurring"):
+        recurring_master_ids = {
+            row["name"]
+            for row in frappe.get_all(
+                "PMO Task Master",
+                filters={"is_recurring": 1},
+                fields=["name"],
+            )
+        }
 
     # Group by category maintaining order
     grouped = {}
@@ -247,6 +261,8 @@ def get_project_tasks(project):
             task.expected_completion_date = _compute_expected_date(
                 handover_status_date, task.deadline_offset
             )
+
+        task["is_recurring"] = 1 if task.task_master in recurring_master_ids else 0
 
         cat = task.category
         if cat not in grouped:
@@ -280,6 +296,11 @@ def update_task_status(task_name, status, completion_date=None, attachment=None)
     elif status == "Sent/Submision":
         doc.completion_date = completion_date or today()
         # Keep expected_completion_date as is
+    elif status in ("Done", "Not Done"):
+        # Recurring cycle verdict — record when the user made the call so
+        # the dashboard reflects it during the open cycle. Resets to None
+        # on the next cron rollover.
+        doc.completion_date = completion_date or today()
     elif status == "WIP":
         # Keep expected_completion_date as is (set from master offset)
         doc.completion_date = None
@@ -359,11 +380,18 @@ def initialize_project_tasks(project):
                     "task_name": task.task_name,
                     "category": cat.category_name,
                 }
-                # Keep expected date synced with the active date anchor.
-                if expected_date:
-                    update_vals["expected_completion_date"] = expected_date
-                elif is_handover_restricted:
-                    update_vals["expected_completion_date"] = None
+                # Date sync: only seed the date when the row has none yet.
+                # Preserves both (a) cron-advanced dates on recurring tasks, and
+                # (b) any manual override an admin made via Desk. The original
+                # "always re-sync" behavior silently clobbered both.
+                existing_date = frappe.db.get_value(
+                    "PMO Project Task", existing_name, "expected_completion_date"
+                )
+                if not existing_date:
+                    if expected_date:
+                        update_vals["expected_completion_date"] = expected_date
+                    elif is_handover_restricted:
+                        update_vals["expected_completion_date"] = None
                 frappe.db.set_value("PMO Project Task", existing_name, update_vals, update_modified=False)
             else:
                 doc = frappe.new_doc("PMO Project Task")

--- a/nirmaan_stack/api/pmo_recurrence.py
+++ b/nirmaan_stack/api/pmo_recurrence.py
@@ -1,0 +1,103 @@
+"""
+Recurrence helper for PMO Project Tasks.
+
+A PMO Task Master flagged `is_recurring` repeats on its own `deadline_offset`
+cadence. This module provides `close_and_renew(task_doc)` — called from the
+daily cron (`nirmaan_stack.tasks.pmo_task_renewal`) — which:
+
+1. Inserts a PMO Task Submission Log row capturing the closing cycle.
+2. Resets the task row (status, attachment, completion_date) and advances
+   `expected_completion_date` to `today() + deadline_offset`.
+
+Renewal halts when the project is in a stop status (Completed, CEO Hold).
+"""
+
+import frappe
+from frappe.utils import add_days, getdate, today
+
+STOP_STATUSES = {"Completed", "CEO Hold", "Halted"}
+CYCLE_DONE_VALUES = {"Approve by client", "Done"}
+
+
+def _next_cycle_number(task_name):
+	row = frappe.db.sql(
+		"""
+		SELECT COALESCE(MAX(cycle_number), 0)
+		FROM `tabPMO Task Submission Log`
+		WHERE task = %s
+		""",
+		(task_name,),
+	)
+	return (row[0][0] or 0) + 1
+
+
+def _previous_cycle_end(task_name):
+	row = frappe.db.sql(
+		"""
+		SELECT cycle_end_date
+		FROM `tabPMO Task Submission Log`
+		WHERE task = %s
+		ORDER BY cycle_number DESC
+		LIMIT 1
+		""",
+		(task_name,),
+	)
+	return getdate(row[0][0]) if row and row[0][0] else None
+
+
+def close_and_renew(task_doc, project_status=None):
+	"""
+	Close the current cycle and start a fresh one.
+
+	Mutates `task_doc` in place; caller is responsible for `task_doc.save()`.
+	The Submission Log row is persisted by this function directly.
+
+	Returns True if a cycle was closed, False if no-op (not recurring, project
+	stopped, zero/missing cadence, or task_master missing).
+	"""
+	if not task_doc.task_master:
+		return False
+
+	master = frappe.get_cached_doc("PMO Task Master", task_doc.task_master)
+	if not master.get("is_recurring"):
+		return False
+
+	if project_status is None:
+		project_status = frappe.db.get_value("Projects", task_doc.project, "status")
+	if project_status in STOP_STATUSES:
+		return False
+
+	interval = int(master.deadline_offset or 0)
+	if interval <= 0:
+		return False  # zero cadence would infinite-loop on subsequent cron runs
+
+	was_done = (task_doc.status or "") in CYCLE_DONE_VALUES
+	was_force_marked = 0 if was_done or task_doc.status == "Not Done" else 1
+	result = "Done" if was_done else "Not Done"
+
+	cycle_end = (
+		getdate(task_doc.expected_completion_date)
+		if task_doc.expected_completion_date
+		else getdate(today())
+	)
+	prev_end = _previous_cycle_end(task_doc.name)
+	cycle_start = prev_end or add_days(cycle_end, -interval)
+
+	log = frappe.new_doc("PMO Task Submission Log")
+	log.task = task_doc.name
+	log.project = task_doc.project
+	log.task_master = task_doc.task_master
+	log.cycle_number = _next_cycle_number(task_doc.name)
+	log.cycle_start_date = cycle_start
+	log.cycle_end_date = cycle_end
+	log.result = result
+	log.was_force_marked = was_force_marked
+	log.closed_on = today()
+	log.attachment = task_doc.attachment
+	log.insert(ignore_permissions=True)
+
+	task_doc.status = "Not Defined"
+	task_doc.completion_date = None
+	task_doc.attachment = None
+	task_doc.expected_completion_date = add_days(today(), interval)
+	return True

--- a/nirmaan_stack/hooks.py
+++ b/nirmaan_stack/hooks.py
@@ -291,6 +291,9 @@ scheduler_events = {
 		"30 4 * * *": [
 			"nirmaan_stack.tasks.vendor_credit_update.update_all_vendor_credits",
 			# "nirmaan_stack.tasks.project_cashflow_hold_update.update_projects_cashflow_hold"
+		],
+		"0 1 * * *": [
+			"nirmaan_stack.tasks.pmo_task_renewal.renew_due_recurring_tasks"
 		]
 	}
 }

--- a/nirmaan_stack/nirmaan_stack/doctype/pmo_task_master/pmo_task_master.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/pmo_task_master/pmo_task_master.json
@@ -10,7 +10,8 @@
         "task_name",
         "category_link",
         "order",
-        "deadline_offset"
+        "deadline_offset",
+        "is_recurring"
     ],
     "fields": [
         {
@@ -41,6 +42,12 @@
             "fieldtype": "Int",
             "label": "Deadline Offset (Days)",
             "description": "Number of days after project creation date to set as expected completion date"
+        },
+        {
+            "fieldname": "is_recurring",
+            "fieldtype": "Check",
+            "label": "Auto-Renew After Each Cycle",
+            "description": "When checked, the per-project task automatically opens a new cycle of Deadline Offset days each time the deadline elapses. Halts when project status is Completed or CEO Hold."
         }
     ],
     "index_web_pages_for_search": 1,

--- a/nirmaan_stack/nirmaan_stack/doctype/pmo_task_master/pmo_task_master.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/pmo_task_master/pmo_task_master.py
@@ -1,8 +1,20 @@
 # Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
 class PMOTaskMaster(Document):
-	pass
+	def validate(self):
+		if not self.is_recurring or not self.category_link:
+			return
+		is_handover_restricted = frappe.db.get_value(
+			"PMO Task Category", self.category_link, "is_handover_restricted"
+		)
+		if int(is_handover_restricted or 0) == 1:
+			frappe.throw(
+				"Recurring tasks cannot belong to a handover-restricted category. "
+				"The handover anchor recomputes the expected date on every fetch, "
+				"which would overwrite the renewal-advanced date."
+			)

--- a/nirmaan_stack/nirmaan_stack/doctype/pmo_task_submission_log/pmo_task_submission_log.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/pmo_task_submission_log/pmo_task_submission_log.json
@@ -1,0 +1,184 @@
+{
+ "actions": [],
+ "allow_rename": 0,
+ "autoname": "hash",
+ "creation": "2026-05-19 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "task_section",
+  "task",
+  "project",
+  "task_master",
+  "cycle_section",
+  "cycle_number",
+  "cycle_start_date",
+  "cycle_end_date",
+  "result_section",
+  "result",
+  "was_force_marked",
+  "closed_on",
+  "attachment"
+ ],
+ "fields": [
+  {
+   "fieldname": "task_section",
+   "fieldtype": "Section Break",
+   "label": "Task"
+  },
+  {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Task",
+   "options": "PMO Project Task",
+   "reqd": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project",
+   "options": "Projects",
+   "reqd": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "task_master",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Task Master",
+   "options": "PMO Task Master",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cycle_section",
+   "fieldtype": "Section Break",
+   "label": "Cycle"
+  },
+  {
+   "fieldname": "cycle_number",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Cycle #",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cycle_start_date",
+   "fieldtype": "Date",
+   "label": "Cycle Start Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cycle_end_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Cycle End Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "result_section",
+   "fieldtype": "Section Break",
+   "label": "Result"
+  },
+  {
+   "fieldname": "result",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Result",
+   "options": "Done\nNot Done",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "was_force_marked",
+   "fieldtype": "Check",
+   "label": "Auto Force-Marked",
+   "description": "1 if cron flipped a non-Done status to Not Done at close time.",
+   "read_only": 1
+  },
+  {
+   "fieldname": "closed_on",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Closed On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "attachment",
+   "fieldtype": "Attach",
+   "label": "Attachment",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-05-19 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Nirmaan Stack",
+ "name": "PMO Task Submission Log",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nirmaan Admin Profile",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nirmaan PMO Executive",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nirmaan Project Lead",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Nirmaan Project Manager",
+   "share": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/nirmaan_stack/nirmaan_stack/doctype/pmo_task_submission_log/pmo_task_submission_log.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/pmo_task_submission_log/pmo_task_submission_log.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class PMOTaskSubmissionLog(Document):
+	pass

--- a/nirmaan_stack/tasks/pmo_task_renewal.py
+++ b/nirmaan_stack/tasks/pmo_task_renewal.py
@@ -1,0 +1,57 @@
+"""
+Daily cron entry point for PMO recurring-task rollover.
+
+Scans all PMO Project Task rows belonging to recurring masters whose deadline
+has elapsed, and rolls them over via `pmo_recurrence.close_and_renew`. Halts
+per task when the parent project is in a stop status (Completed, CEO Hold).
+"""
+
+import frappe
+from frappe.utils import today
+
+from nirmaan_stack.api.pmo_recurrence import close_and_renew
+
+
+def renew_due_recurring_tasks():
+	# Pre-migration safety: skip silently if schema additions aren't applied yet.
+	if not frappe.db.has_column("PMO Task Master", "is_recurring"):
+		return {"renewed": 0, "scanned": 0, "skipped": "is_recurring column missing"}
+	if not frappe.db.table_exists("PMO Task Submission Log"):
+		return {"renewed": 0, "scanned": 0, "skipped": "submission log table missing"}
+
+	rows = frappe.db.sql(
+		"""
+		SELECT pt.name
+		FROM `tabPMO Project Task` pt
+		INNER JOIN `tabPMO Task Master` tm ON pt.task_master = tm.name
+		INNER JOIN `tabProjects` p ON pt.project = p.name
+		WHERE tm.is_recurring = 1
+		  AND p.status NOT IN ('Completed', 'CEO Hold', 'Halted')
+		  AND pt.expected_completion_date IS NOT NULL
+		  AND pt.expected_completion_date < %s
+		""",
+		(today(),),
+		as_dict=True,
+	)
+
+	renewed = 0
+	for r in rows:
+		try:
+			doc = frappe.get_doc("PMO Project Task", r.name)
+			project_status = frappe.db.get_value("Projects", doc.project, "status")
+			if close_and_renew(doc, project_status=project_status):
+				doc.save(ignore_permissions=True)
+				# Commit per-iteration so one bad row can't poison the batch
+				# (close_and_renew inserts a Submission Log row before mutating
+				# the task — both must persist atomically per cycle).
+				frappe.db.commit()
+				renewed += 1
+		except Exception:
+			# Rollback the partial cycle insert/save before moving on.
+			frappe.db.rollback()
+			frappe.log_error(
+				frappe.get_traceback(),
+				f"PMO recurrence rollover failed for {r.name}",
+			)
+
+	return {"renewed": renewed, "scanned": len(rows)}


### PR DESCRIPTION
- New `is_recurring` flag on PMO Task Master + daily cron that rolls expected_completion_date forward by deadline_offset
- Cycles closed by cron are logged to new PMO Task Submission Log doctype; force-marks untouched cycles as Not Done
- Halts on project status Completed / CEO Hold / halted
- Done/Not Done UI in EditTaskModal for recurring tasks
- "View History" drawer + Recurring badge on PMO Packages
- initialize_project_tasks now preserves manual / cron-set dates instead of always overwriting