### PR TITLE
Develop

### DIFF
--- a/frontend/src/pages/ProjectDesignTracker/design-tracker-list.tsx
+++ b/frontend/src/pages/ProjectDesignTracker/design-tracker-list.tsx
@@ -319,7 +319,7 @@ const ExpandedProjectTasks: React.FC<ExpandedProjectTasksProps> = ({ trackerId, 
                     subStatusOptions={subStatusOptions}
                     existingTaskNames={getExistingTaskNames(trackerDoc)}
                     isRestrictedMode={isDesignExecutive}
-                    disableTaskNameEdit={!isAdmin}
+                    disableTaskNameEdit={true}
                 />
             )}
         </div>

--- a/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
+++ b/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
@@ -1913,7 +1913,7 @@ export const ProjectDesignTrackerDetailV2: React.FC<ProjectDesignTrackerDetailPr
                     subStatusOptions={subStatusOptions}
                     existingTaskNames={getExistingTaskNames(trackerDoc)}
                     isRestrictedMode={isDesignExecutive}
-                    disableTaskNameEdit={!isAdmin}
+                    disableTaskNameEdit={true}
                 />
             )}
 

--- a/nirmaan_stack/hooks.py
+++ b/nirmaan_stack/hooks.py
@@ -285,7 +285,8 @@ scheduler_events = {
 	# ],
 	"daily": [
 		"nirmaan_stack.populate_target_rates.populate_target_rates_by_unit",
-        "nirmaan_stack.tasks.item_status_update.update_item_status"
+        "nirmaan_stack.tasks.item_status_update.update_item_status",
+        "nirmaan_stack.tasks.cashflow_gap_limit_default.set_default_cashflow_gap_limit"
 	],
 	"cron": {
 		"30 4 * * *": [

--- a/nirmaan_stack/tasks/cashflow_gap_limit_default.py
+++ b/nirmaan_stack/tasks/cashflow_gap_limit_default.py
@@ -1,0 +1,47 @@
+import frappe
+from frappe.utils import flt
+
+from nirmaan_stack.integrations.controllers.project_cashflow_hold_update import trigger_check
+
+
+def set_default_cashflow_gap_limit():
+    """Daily cron (2 AM IST): seed cashflow_gap_limit at 20% of project_value_gst
+    for projects that don't have a meaningful limit yet (NULL or < 1). Skips
+    Completed projects and projects whose project value isn't set yet.
+
+    After seeding, runs trigger_check so CEO Hold gets evaluated against the
+    new limit (mirrors the on_update hook in projects.py).
+    """
+    rows = frappe.db.sql(
+        """
+        SELECT name, project_value_gst
+        FROM "tabProjects"
+        WHERE (cashflow_gap_limit IS NULL OR cashflow_gap_limit < 1)
+          AND status NOT IN ('Completed')
+        """,
+        as_dict=True,
+    )
+
+    updated = 0
+    for row in rows:
+        project_value = flt(row.project_value_gst)
+        if project_value <= 0:
+            continue
+
+        new_limit = round(project_value * 0.20, 2)
+
+        try:
+            frappe.db.set_value(
+                "Projects",
+                row.name,
+                "cashflow_gap_limit",
+                new_limit,
+            )
+            trigger_check(row.name)
+            updated += 1
+        except Exception as e:
+            print(f"set_default_cashflow_gap_limit failed for {row.name}: {e}")
+
+    if updated:
+        frappe.db.commit()
+        print(f"set_default_cashflow_gap_limit: seeded {updated} project(s)")


### PR DESCRIPTION
- Disable task name editing for all roles in project design tracker views.
- seed default cashflow_gap_limit via daily cron, set 20% value of project (cashflow limited <1 & project value >0 mean not in completed project )