### PR TITLE
feat(project-payments): color bulk action buttons + skip CEO Hold tri…

### DIFF
--- a/frontend/src/pages/ProjectPayments/approve-payments/components/BulkActionBar.tsx
+++ b/frontend/src/pages/ProjectPayments/approve-payments/components/BulkActionBar.tsx
@@ -116,7 +116,7 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
         variant="default"
         disabled={loading}
         onClick={() => openDialog("approve")}
-        className="h-8 gap-1"
+        className="h-8 gap-1 bg-green-600 hover:bg-green-700 text-white"
       >
         {loading && dialogAction === "approve" ? (
           <Loader2 className="h-4 w-4 animate-spin" />
@@ -127,7 +127,7 @@ export const BulkActionBar: React.FC<BulkActionBarProps> = ({
       </Button>
       <Button
         size="sm"
-        variant="destructive"
+        variant="default"
         disabled={loading}
         onClick={() => openDialog("reject")}
         className="h-8 gap-1"

--- a/frontend/src/pages/ProjectPayments/approve-payments/components/BulkConfirmDialog.tsx
+++ b/frontend/src/pages/ProjectPayments/approve-payments/components/BulkConfirmDialog.tsx
@@ -48,11 +48,13 @@ export const BulkConfirmDialog: React.FC<BulkConfirmDialogProps> = ({
   vendorLabelFor,
 }) => {
   const [reason, setReason] = useState("");
+  const [reasonTouched, setReasonTouched] = useState(false);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!open) {
       setReason("");
+      setReasonTouched(false);
       setExpanded(new Set());
     }
   }, [open]);
@@ -215,17 +217,30 @@ export const BulkConfirmDialog: React.FC<BulkConfirmDialogProps> = ({
               htmlFor="bulk-reject-reason"
               className="text-xs font-medium text-muted-foreground"
             >
-              Reason (required, applied to all)
+              Reason <span className="text-red-600">*</span> (applied to all)
             </label>
             <Textarea
               id="bulk-reject-reason"
               rows={2}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
+              onBlur={() => setReasonTouched(true)}
               disabled={isLoading}
+              required
+              aria-required="true"
+              aria-invalid={reasonTouched && trimmedReason.length === 0}
               placeholder="e.g. Vendor invoice missing"
-              className="mt-1 resize-none"
+              className={`mt-1 resize-none ${
+                reasonTouched && trimmedReason.length === 0
+                  ? "border-red-500 focus-visible:ring-red-500"
+                  : ""
+              }`}
             />
+            {reasonTouched && trimmedReason.length === 0 && (
+              <p className="text-[11px] text-red-600 mt-1">
+                Reason is required to reject.
+              </p>
+            )}
           </div>
         )}
 
@@ -243,7 +258,8 @@ export const BulkConfirmDialog: React.FC<BulkConfirmDialogProps> = ({
               </AlertDialogCancel>
               <Button
                 disabled={!canSubmit}
-                variant={isReject ? "destructive" : "default"}
+                variant="default"
+                className={isReject ? undefined : "bg-green-600 hover:bg-green-700 text-white"}
                 onClick={() => onConfirm(isReject ? trimmedReason : undefined)}
               >
                 {isReject ? "Reject" : "Approve"} {count}

--- a/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
+++ b/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
@@ -216,7 +216,23 @@ def trigger_check(project_id):
 
 
 def on_project_payment(doc, method=None):
-	trigger_check(doc.project)
+	"""
+	Cashflow gap counts only Paid payments (see _compute_cashflow_gap).
+	Skip the evaluation for any status that doesn't touch the gap
+	(Requested / CEO Pending / Approved / Rejected).
+
+	Fires only when:
+	  * a row enters Paid (status flipped to 'Paid')
+	  * a row leaves  Paid (status flipped away from 'Paid')
+	  * a Paid row is trashed
+	"""
+	
+	if not doc.has_value_changed("status"):
+		return
+
+	prev_status = (doc.get_doc_before_save() or {}).get("status") if not doc.is_new() else None
+	if doc.status == "Paid" or prev_status == "Paid":
+		trigger_check(doc.project)
 
 
 def on_project_expense(doc, method=None):


### PR DESCRIPTION
…gger on non-Paid status flips

* BulkActionBar / BulkConfirmDialog: Approve buttons turn green, Reject buttons use the primary variant. Reject reason gets a required marker with on-blur validation styling so the missing-reason case surfaces before submit.
* project_cashflow_hold_update.on_project_payment now early-exits when the save doesn't change status, and only triggers the CEO Hold evaluator when status is moving into or out of 'Paid'. Approvals, CEO Pending promotions and rejections no longer fire the cashflow recompute -- since _compute_cashflow_gap counts only Paid rows, those saves can never move the gap.