### PR TITLE
feat(commission-report): snapshot report_type from master across task…

### DIFF
--- a/frontend/src/pages/CommissionReport/hooks/useCommissionTrackerLogic.ts
+++ b/frontend/src/pages/CommissionReport/hooks/useCommissionTrackerLogic.ts
@@ -27,7 +27,7 @@ export interface UseCommissionTrackerLogicReturn {
     setEditingTask: (task: CommissionReportTask | null) => void;
 
     usersList: User[];
-    categoryData: { category_name: string; tasks: { task_name: string; deadline_offset?: number }[] }[];
+    categoryData: { category_name: string; tasks: { task_name: string; deadline_offset?: number; report_type?: 'Field' | 'Vendor' }[] }[];
     statusOptions: { label: string; value: string }[];
 
     refetchTracker: () => void;

--- a/frontend/src/pages/CommissionReport/project-commission-report-details.tsx
+++ b/frontend/src/pages/CommissionReport/project-commission-report-details.tsx
@@ -57,7 +57,7 @@ const DOCTYPE = 'Project Commission Report';
 // --- TYPE DEFINITION for Category Items ---
 interface CategoryItem {
     category_name: string;
-    tasks: { task_name: string; deadline_offset?: number }[];
+    tasks: { task_name: string; deadline_offset?: number; report_type?: 'Field' | 'Vendor' }[];
 }
 
 // --- Project Overview Edit Modal ---
@@ -425,7 +425,7 @@ const AddCategoryModal: React.FC<AddCategoryModalProps> = ({
                         task_name: taskDef.task_name,
                         commission_category: cat.category_name,
                         task_status: 'Pending',
-                        report_type: (taskDef as any).report_type || 'Field',
+                        report_type: taskDef.report_type || 'Field',
                         deadline: calculatedDeadline || handoverDeadline.toISOString().split('T')[0],
                         task_zone: zoneName,
                         task_phase: "Handover",
@@ -1115,7 +1115,7 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
                         task_name: taskDef.task_name,
                         commission_category: cat.category_name,
                         task_status: 'Pending',
-                        report_type: (taskDef as any).report_type || 'Field',
+                        report_type: taskDef.report_type || 'Field',
                         deadline: calculatedDeadline || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
                         task_zone: zoneName,
                         task_phase: "Handover",

--- a/frontend/src/pages/projects/project.tsx
+++ b/frontend/src/pages/projects/project.tsx
@@ -1329,6 +1329,7 @@ const ProjectView = ({ projectId, data, project_mutate, projectCustomer, po_item
                   commissionTasks.push({
                     task_name: taskName,
                     commission_category: categoryName,
+                    report_type: taskTemplate?.report_type || "Field",
                     task_status: "Pending",
                     deadline,
                     task_zone: zoneName,

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -119,3 +119,4 @@ nirmaan_stack.patches.v3_0.rename_cashflow_gap_limited #1
 nirmaan_stack.patches.v3_0.backfill_work_order_items #2
 nirmaan_stack.patches.v3_0.purge_document_ai_credentials
 nirmaan_stack.patches.v3_0.sync_commission_master_changes
+nirmaan_stack.patches.v3_0.backfill_commission_report_type

--- a/nirmaan_stack/patches/v3_0/backfill_commission_report_type.py
+++ b/nirmaan_stack/patches/v3_0/backfill_commission_report_type.py
@@ -1,0 +1,39 @@
+"""Back-fill `report_type` on existing Commission Report child rows from the master.
+
+Old `Commission Report Task Child Table` rows were created before the tracker
+started snapshotting `report_type`, so they all sit on the field default ("Field")
+even where the `Commission Report Tasks` master says "Vendor". The on_update hook
+only cascades task_name/category renames — not report_type — so existing trackers
+never received the master's report type. This patch aligns them once.
+
+Idempotent — safe to re-run:
+  1. Align child rows to their master's report_type (matched by task_name + category).
+  2. Default any remaining blank report_type (no master match) to "Field".
+"""
+
+import frappe
+
+CHILD = "Commission Report Task Child Table"
+MASTER = "Commission Report Tasks"
+
+
+def execute():
+    # 1) Align to master where a matching master task exists.
+    frappe.db.sql(
+        '''UPDATE "tabCommission Report Task Child Table" AS child
+           SET report_type = master.report_type
+           FROM "tabCommission Report Tasks" AS master
+           WHERE child.task_name = master.task_name
+             AND child.commission_category = master.category_link
+             AND COALESCE(master.report_type, '') <> ''
+             AND COALESCE(child.report_type, '') <> COALESCE(master.report_type, '')'''
+    )
+
+    # 2) Anything still blank (no master match) gets the field default.
+    frappe.db.sql(
+        '''UPDATE "tabCommission Report Task Child Table"
+           SET report_type = 'Field'
+           WHERE COALESCE(report_type, '') = '' '''
+    )
+
+    frappe.db.commit()


### PR DESCRIPTION
…-creation paths

- project.tsx: handover creation now sets report_type from master task (fallback "Field")
- details.tsx: add-zone/task-gen paths read report_type from master; dropped (taskDef as any) casts
- Typed report_type on CategoryItem & categoryData task shapes for end-to-end type safety
- v3_0/backfill_commission_report_type: align existing child rows to master by task_name+category, child-table SQL only (parent modified untouched), idempotent