### PR TITLE
Billing status

### DIFF
--- a/frontend/src/pages/DeliveryChallansAndMirs/DeliveryChallansAndMirs.tsx
+++ b/frontend/src/pages/DeliveryChallansAndMirs/DeliveryChallansAndMirs.tsx
@@ -253,6 +253,7 @@ export const DeliveryChallansAndMirs = () => {
           unit: item.unit,
           category: item.category,
           make: item.make,
+          billing_status: item.billing_status,
         })),
         parentDoctype: "Procurement Orders",
       });

--- a/frontend/src/pages/DeliveryChallansAndMirs/components/UploadDCMIRDialog.tsx
+++ b/frontend/src/pages/DeliveryChallansAndMirs/components/UploadDCMIRDialog.tsx
@@ -42,6 +42,7 @@ interface POItemForSelector {
   unit: string;
   category?: string;
   make?: string;
+  billing_status?: "Billable" | "Non-Billable" | "";
 }
 
 interface UploadDCMIRDialogProps {
@@ -98,9 +99,23 @@ export const UploadDCMIRDialog = ({
   const [attachmentAction, setAttachmentAction] = useState<"keep" | "replace">("keep");
   const typeLabel = dcType === "Delivery Challan" ? "DC" : "MIR";
 
+  // For POs, only Billable items are shown — Non-Billable items are hidden from the
+  // DC/MIR upload. In edit mode, keep any item already on the existing doc (even if
+  // Non-Billable) so historical selections are never dropped. ITMs have no billing
+  // concept, so the billing filter is skipped for them.
+  const existingItemIds = useMemo(
+    () => new Set((mode === "edit" ? existingDoc?.items ?? [] : []).map((ei) => ei.item_id)),
+    [mode, existingDoc]
+  );
+
   const filteredPoItems = useMemo(
-    () => poItems.filter(item => item.category !== "Additional Charges"),
-    [poItems]
+    () =>
+      poItems.filter(
+        (item) =>
+          item.category !== "Additional Charges" &&
+          (isITM || item.billing_status === "Billable" || existingItemIds.has(item.item_id))
+      ),
+    [poItems, existingItemIds, isITM]
   );
 
   const form = useForm<UploadDCMIRFormValues>({

--- a/frontend/src/pages/ProcurementRequests/NewPR/hooks/useSubmitProcurementRequest.ts
+++ b/frontend/src/pages/ProcurementRequests/NewPR/hooks/useSubmitProcurementRequest.ts
@@ -36,6 +36,7 @@ const transformToBackendOrderList = (frontendProcList: ProcurementRequestItem[])
         status: feItem.status,
         tax: feItem.tax, // Ensure this matches backend expectation (optional or required)
         comment: feItem.comment,
+        // billing_status is set server-side from the Items master (see procurement_requests.validate)
         // Frappe handles parent, parentfield, parenttype, name, creation, modified for child table items
     }));
 };

--- a/frontend/src/pages/ProcurementRequests/NewPR/types/index.ts
+++ b/frontend/src/pages/ProcurementRequests/NewPR/types/index.ts
@@ -13,6 +13,7 @@ export interface ProcurementRequestItem {
   comment?: string;
   make?: string;     // Selected Make DocName for this item
   status: 'Pending' | 'Request' | 'Approved' | 'Rejected'; // Add other relevant statuses if needed
+  billing_status?: 'Billable' | 'Non-Billable'; // Set server-side from the Items master
 }
 
 // Represents a category selection derived from the procList

--- a/frontend/src/pages/ProcurementRequests/VendorQuotesSelection/hooks/useProcurementActions.ts
+++ b/frontend/src/pages/ProcurementRequests/VendorQuotesSelection/hooks/useProcurementActions.ts
@@ -92,6 +92,7 @@ export const useProcurementActions = ({ docId, docMutate, projectId }: UseProcur
                 status: docItem.status, // Keep original status unless RFQ logic changes it
                 tax: docItem.tax,
                 comment: docItem.comment,
+                billing_status: docItem.billing_status, // preserve — the full order_list save would otherwise wipe it (esp. on SB, which has no validate to restore it)
                 // Vendor, quote, make will be updated based on selections
             };
 

--- a/frontend/src/pages/projects/data/root/useProjectRootApi.ts
+++ b/frontend/src/pages/projects/data/root/useProjectRootApi.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   useFrappeCreateDoc,
   useFrappeDocumentEventListener,
@@ -40,6 +39,7 @@ export interface ProjectPOItemDataItem {
   item_name: string;
   work_package: string;
   is_dispatched?: number;
+  billing_status?: string | null;
 }
 
 export const projectRootKeys = {

--- a/frontend/src/pages/projects/hooks/useMaterialUsageData.ts
+++ b/frontend/src/pages/projects/hooks/useMaterialUsageData.ts
@@ -83,9 +83,12 @@ export function useMaterialUsageData(projectId: string, projectPayments?: Projec
     return map;
   }, [itemsData]);
 
-  // Resolve billing category: Items doctype lookup → "Additional Charges" = Non-Billable → default Billable
-  const resolveBillingCategory = (itemId: string, category: string): string => {
-    return billingCategoryMap.get(itemId)
+  // Resolve billing category. Prefer the PO line item's own billing_status when present
+  // (the live, per-PO value); otherwise fall back for non-PO rows (ITM / orphan DC) and
+  // legacy-blank items: Items master lookup → "Additional Charges" = Non-Billable → Billable.
+  const resolveBillingCategory = (itemId: string, category: string, poBillingStatus?: string | null): string => {
+    return poBillingStatus
+      || billingCategoryMap.get(itemId)
       || (category === "Additional Charges" ? "Non-Billable" : "Billable");
   };
 
@@ -243,7 +246,7 @@ export function useMaterialUsageData(projectId: string, projectPayments?: Projec
 
       if (!currentItemUsage) {
         const estimate = estimatesMap.get(poItem.item_id);
-          const itemBillingCategory = resolveBillingCategory(poItem.item_id, poItem.category);
+          const itemBillingCategory = resolveBillingCategory(poItem.item_id, poItem.category, poItem.billing_status);
         currentItemUsage = {
           uniqueKey: itemKey + `_item_${index}`,
           itemId: poItem.item_id,
@@ -464,7 +467,7 @@ export function useMaterialUsageData(projectId: string, projectPayments?: Projec
           itemName: poItem.item_name,
           categoryName: poItem.category,
           unit: poItem.unit,
-          billingCategory: resolveBillingCategory(poItem.item_id, poItem.category),
+          billingCategory: resolveBillingCategory(poItem.item_id, poItem.category, poItem.billing_status),
           orderedQuantity: qty,
           deliveredQuantity: recvQty,
           dcQuantity: delivery?.dcQty || 0,
@@ -590,11 +593,16 @@ export function useMaterialUsageData(projectId: string, projectPayments?: Projec
     const dcItems: DCMIRWiseDisplayItem[] = [];
     const mirItems: DCMIRWiseDisplayItem[] = [];
 
-    // Build PO-item received quantity lookup: "poNumber_category_itemId" → received_quantity
+    // Build PO-item lookups keyed by "poNumber_category_itemId":
+    //   - received quantity (existing)
+    //   - billing_status (so DC/MIR-wise rows use the live per-PO billing value,
+    //     falling back to the Items master only for stub/orphan rows not on a PO)
     const poItemReceivedMap = new Map<string, number>();
+    const poItemBillingMap = new Map<string, string>();
     allPoItems.forEach(item => {
       const key = `${item.po_number}_${item.category}_${item.item_id}`;
       poItemReceivedMap.set(key, (poItemReceivedMap.get(key) || 0) + safeParseFloat(item.received_quantity));
+      if (item.billing_status) poItemBillingMap.set(key, item.billing_status);
     });
 
     for (const doc of docs) {
@@ -611,7 +619,7 @@ export function useMaterialUsageData(projectId: string, projectPayments?: Projec
           receivedQuantity: poItemReceivedMap.get(recvKey) || 0,
           quantity: item.quantity || 0,
           make: item.make,
-          billingCategory: resolveBillingCategory(item.item_id, item.category || ""),
+          billingCategory: resolveBillingCategory(item.item_id, item.category || "", poItemBillingMap.get(recvKey)),
         };
       });
 

--- a/frontend/src/types/NirmaanStack/ProcurementOrders.ts
+++ b/frontend/src/types/NirmaanStack/ProcurementOrders.ts
@@ -31,6 +31,7 @@ export interface PurchaseOrderItem {
 	status: string;
 	tax: number;
 	comment?: string;
+	billing_status?: "Billable" | "Non-Billable" | "";
 	po?: string;
 	makes?: string
 }
@@ -142,6 +143,8 @@ export interface ProcurementOrder {
 	notes?: string
 	/**	Status : Data	*/
 	status: string
+	/**	Billing Status : Select (auto-calculated from item billing status)	*/
+	billing_status?: "Billable" | "Non-Billable" | ""
 	/**	Delivery Contact : Data	*/
 	delivery_contact?: string
 	custom?: string

--- a/frontend/src/types/NirmaanStack/ProcurementRequests.ts
+++ b/frontend/src/types/NirmaanStack/ProcurementRequests.ts
@@ -70,6 +70,7 @@ export interface ProcurementRequestItemDetail {
 	comment?: string;
 	vendor?: string;
 	quote?: number;
+	billing_status?: "Billable" | "Non-Billable";
 	parent?: string;
 	parentfield?: string;
 	parenttype?: string;

--- a/nirmaan_stack/api/approve_reject_sb_vendor_quotes.py
+++ b/nirmaan_stack/api/approve_reject_sb_vendor_quotes.py
@@ -287,7 +287,8 @@ def new_handle_approve(sb_id: str, selected_items: list, project_id: str, select
                     "quote": sb_row.quote, "amount": base_amount, "make": sb_row.make,
                     "tax": sb_row.tax, "tax_amount": tax_amount,
                     "total_amount": base_amount + tax_amount, "comment": sb_row.comment,
-                    "procurement_request_item": sb_row.name
+                    "procurement_request_item": sb_row.name,
+                    "billing_status": sb_row.get("billing_status") or "Non-Billable",  # carry source value (Items-derived); Non-Billable fallback
                 }
                 if vendor_name not in vendor_po_items:
                     vendor_po_items[vendor_name] = []
@@ -437,6 +438,7 @@ def new_handle_sent_back(sb_id: str, selected_items: list, comment: str = None):
                     "comment": item_in_source_sb.comment, # Carry over comment
                     "make": item_in_source_sb.make,
                     "vendor": item_in_source_sb.vendor, # Carry over selected vendor
+                    "billing_status": item_in_source_sb.get("billing_status"),  # hold the source SB item's billing status
                 })
 
                 # Copy RFQ details for this item to the new SB doc's RFQ data

--- a/nirmaan_stack/api/approve_vendor_quotes.py
+++ b/nirmaan_stack/api/approve_vendor_quotes.py
@@ -60,7 +60,8 @@ def generate_pos_from_selection(project_id: str, pr_name: str, selected_items: l
                         "quantity": item_quantity, "category": pr_child_item.category, "procurement_package": pr_child_item.procurement_package,
                         "quote": item_quote_rate, "amount": base_amount, "make": pr_child_item.make, "tax": item_tax_percentage,
                         "tax_amount": calculated_tax_amount, "total_amount": final_total_amount, "comment": pr_child_item.comment,
-                        "procurement_request_item": pr_child_item.name
+                        "procurement_request_item": pr_child_item.name,
+                        "billing_status": pr_child_item.get("billing_status") or "Non-Billable",  # carry PR value (Items-derived); Non-Billable fallback
                     }
                     if vendor_id_from_payload not in vendor_po_items_details:
                         vendor_po_items_details[vendor_id_from_payload] = []

--- a/nirmaan_stack/api/custom_pr_api.py
+++ b/nirmaan_stack/api/custom_pr_api.py
@@ -28,8 +28,9 @@ def new_custom_pr(project_id: str, order: list, categories: list = None, comment
                 "tax": fe_item.get("tax"),
                 "vendor": fe_item.get("vendor"),
                 "quote": fe_item.get("quote")
+                # billing_status set server-side from Items master (procurement_requests.validate)
             })
-        
+
         if tags:
             if isinstance(tags, str):
                 tags = json.loads(tags)
@@ -117,6 +118,7 @@ def resolve_custom_pr(project_id: str, pr_id: str, order: list, categories: list
                 "tax": fe_item.get("tax"),
                 "vendor": fe_item.get("vendor"),
                 "quote": fe_item.get("quote")
+                # billing_status set server-side from Items master (procurement_requests.validate)
             })
 
         if payment_terms:

--- a/nirmaan_stack/api/delivery_challans_data.py
+++ b/nirmaan_stack/api/delivery_challans_data.py
@@ -19,9 +19,13 @@ def get_delivery_challan_pos_with_categories(project_id=None):
 			"category_counts": Dict mapping category to number of POs containing it
 		}
 	"""
-	# Build filters for Procurement Orders
+	# Build filters for Procurement Orders.
+	# Only Billable POs are eligible for DC / MIR — Non-Billable POs are excluded
+	# entirely (not shown). The parent rollup is Billable when the PO has at least
+	# one Billable item.
 	filters = {
 		"status": ["in", ["Partially Dispatched", "Dispatched", "Partially Delivered", "Delivered"]],
+		"billing_status": "Billable",
 		# "total_amount": [">=", 5000]
 	}
 
@@ -38,6 +42,7 @@ def get_delivery_challan_pos_with_categories(project_id=None):
 			"vendor",
 			"vendor_name",
 			"status",
+			"billing_status",
 			"dispatch_date",
 			"latest_delivery_date",
 			"procurement_request",
@@ -91,7 +96,8 @@ def get_delivery_challan_pos_with_categories(project_id=None):
 					"amount": flt(item.amount) if item.amount else 0,
 					"procurement_package": item.procurement_package,
 					"comment": item.comment,
-				"is_dispatched": item.is_dispatched
+				"is_dispatched": item.is_dispatched,
+					"billing_status": item.billing_status
 				})
 
 			# Increment category counts for this PO
@@ -105,6 +111,7 @@ def get_delivery_challan_pos_with_categories(project_id=None):
 				"vendor": po.vendor,
 				"vendor_name": po.vendor_name,
 				"status": po.status,
+				"billing_status": po.billing_status,
 				"dispatch_date": po.dispatch_date,
 				"latest_delivery_date": po.latest_delivery_date,
 				"procurement_request": po.procurement_request,

--- a/nirmaan_stack/api/po_delivery_documentss.py
+++ b/nirmaan_stack/api/po_delivery_documentss.py
@@ -35,6 +35,10 @@ def create_po_delivery_documents(
     # Fetch parent for project/vendor denormalization
     if parent_doctype == "Procurement Orders":
         parent_doc = frappe.get_doc("Procurement Orders", parent_docname)
+        # Billing guard: DC/MIR may only be filed against a Billable PO. A PO whose
+        # rollup is Non-Billable has no billable items at all.
+        if (parent_doc.billing_status or "") == "Non-Billable":
+            frappe.throw(_("Cannot file a Delivery Challan / MIR for a Non-Billable PO."))
         project = parent_doc.project
         vendor = parent_doc.vendor
     elif parent_doctype == "Internal Transfer Memo":
@@ -54,6 +58,13 @@ def create_po_delivery_documents(
     # Parse items if JSON string
     if isinstance(items, str):
         items = json.loads(items)
+
+    # Item-level billing guard (PO only): a DC/MIR must not include Non-Billable items,
+    # even on a Billable PO that has a mix of billable and non-billable lines.
+    if parent_doctype == "Procurement Orders" and items:
+        po_item_billing = {it.item_id: (it.billing_status or "") for it in parent_doc.items}
+        if any(po_item_billing.get(i.get("item_id")) == "Non-Billable" for i in items):
+            frappe.throw(_("Cannot include Non-Billable items in a Delivery Challan / MIR."))
 
     # Note: legacy `procurement_order` Link field is deprecated. We no longer
     # populate it on new rows — `parent_docname` is the single source of truth.

--- a/nirmaan_stack/api/po_revisions/revision_logic.py
+++ b/nirmaan_stack/api/po_revisions/revision_logic.py
@@ -421,6 +421,9 @@ def sync_original_po_items(revision_doc):
             new_row.tax_amount = (new_row.amount * new_row.tax) / 100
             new_row.total_amount = new_row.amount + new_row.tax_amount
             new_row.received_quantity = 0.0
+            # New item → source billing status from the Items master; Non-Billable if not found.
+            new_row.billing_status = frappe.db.get_value(
+                "Items", new_row.item_id, "billing_category") or "Non-Billable"
 
             if original_po.status in ("Partially Dispatched", "Dispatched", "Partially Delivered", "Delivered"):
                 new_row.is_dispatched = 1
@@ -473,6 +476,9 @@ def sync_original_po_items(revision_doc):
 
                 orig_row.item_id = rev_item.revision_item_id
                 orig_row.item_name = rev_item.revision_item_name
+                # Item changed → re-source billing status from the Items master; Non-Billable if not found.
+                orig_row.billing_status = frappe.db.get_value(
+                    "Items", orig_row.item_id, "billing_category") or "Non-Billable"
 
                 orig_row.quantity = flt(rev_item.revision_qty)
                 orig_row.unit = rev_item.revision_unit

--- a/nirmaan_stack/api/procurement_orders.py
+++ b/nirmaan_stack/api/procurement_orders.py
@@ -60,6 +60,7 @@ def generate_po_summary(project_id: str):
                 "total_amount": item.get("total_amount"),
                 "make": item.get("make"),
                 "is_dispatched": item.get("is_dispatched", 0),
+                "billing_status": item.get("billing_status"),
             }
             print(f"DEBUGGPS7: item_data:{item}")
             # Append to the correct list

--- a/nirmaan_stack/api/reject_vendor_quotes.py
+++ b/nirmaan_stack/api/reject_vendor_quotes.py
@@ -61,6 +61,7 @@ def send_back_items(project_id: str, pr_name: str, selected_items: list, comment
                         "comment": item.get("comment"),
                         "make": item.get("make"),
                         "vendor": item.get("vendor"),
+                        "billing_status": item.get("billing_status"),  # hold the PR item's billing status
                     })
 
                     if item_name in rfq_details:

--- a/nirmaan_stack/api/send_vendor_quotes.py
+++ b/nirmaan_stack/api/send_vendor_quotes.py
@@ -84,6 +84,7 @@ def handle_delayed_items(pr_id: str, comments: dict = None):
                     "comment": item.get("comment"),
                     "procurement_package": item.get("procurement_package"),
                     "make": item.get("make"),
+                    "billing_status": item.get("billing_status"),  # hold the PR item's billing status
                     # Add other relevant fields needed by Sent Back Category
                 })
                 # Add item details to new_rfq_details for the Sent Back doc

--- a/nirmaan_stack/integrations/controllers/procurement_orders.py
+++ b/nirmaan_stack/integrations/controllers/procurement_orders.py
@@ -84,10 +84,31 @@ def validate(doc, method):
         if not item.item_id:
             item.item_id = item.name
 
+    _set_po_billing_status(doc)
+
     old_doc = doc.get_doc_before_save()
     if old_doc and old_doc.status in ("Partially Dispatched", "Dispatched") and doc.status == "PO Approved":
         if frappe.db.exists("Delivery Notes", {"procurement_order": doc.name}):
             frappe.throw("Cannot revert PO with existing Delivery Notes")
+
+
+def _set_po_billing_status(doc):
+    """Roll up the PO-level billing status from its items (in-memory, no query).
+
+    Item-level billing_status is set explicitly wherever a PO item is created or
+    its item changes (approve_vendor_quotes, sent-back, merge, revision), so this
+    only aggregates: Billable if ANY item is Billable; Non-Billable only if items
+    exist and ALL are Non-Billable; empty otherwise (e.g. no items).
+    """
+    items = doc.get("items") or []
+    statuses = [(item.get("billing_status") or "") for item in items]
+
+    if "Billable" in statuses:
+        doc.billing_status = "Billable"
+    elif statuses and all(s == "Non-Billable" for s in statuses):
+        doc.billing_status = "Non-Billable"
+    else:
+        doc.billing_status = ""
 
 
 def on_update(doc, method):

--- a/nirmaan_stack/integrations/controllers/procurement_requests.py
+++ b/nirmaan_stack/integrations/controllers/procurement_requests.py
@@ -541,9 +541,49 @@ def validate_procurement_request_for_po(doc: Document) -> bool:
     # return True
 
 def validate(doc, method):
-    for item in doc.get("order_list") or []:
+    items = doc.get("order_list") or []
+    for item in items:
         if not item.item_id:
             item.item_id = item.name
+
+    # Billing status is sourced from the Items master (billing_category). Items not
+    # in the master default to Billable when they are brand-new requests (a Custom PR,
+    # or a "Request"-status item the user is asking to be created), else Non-Billable.
+    # To avoid re-querying on every save, only source rows that are new or whose item
+    # identity (item_id / item_name) changed since the last save. Routine saves
+    # (status, comments, quote, qty) touch nothing and run no query.
+    is_custom_pr = doc.work_package == "Custom"
+    old_rows = {}
+    old_doc = doc.get_doc_before_save()
+    if old_doc:
+        old_rows = {row.name: row for row in (old_doc.get("order_list") or [])}
+
+    to_source = []
+    for item in items:
+        old = old_rows.get(item.name)
+        if (old is None
+                or not item.get("billing_status")
+                or item.item_id != old.item_id
+                or item.item_name != old.item_name):
+            to_source.append(item)
+
+    if to_source:
+        item_ids = list({item.item_id for item in to_source if item.item_id})
+        billing_map = {}
+        if item_ids:
+            for row in frappe.get_all(
+                "Items", filters={"name": ["in", item_ids]},
+                fields=["name", "billing_category"]
+            ):
+                billing_map[row.name] = row.billing_category
+        for item in to_source:
+            master_status = billing_map.get(item.item_id)
+            if master_status:
+                item.billing_status = master_status
+            elif is_custom_pr or item.status == "Request":
+                item.billing_status = "Billable"
+            else:
+                item.billing_status = "Non-Billable"
 
 
 def after_insert(doc, method):

--- a/nirmaan_stack/nirmaan_stack/doctype/items/items.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/items/items.py
@@ -31,6 +31,10 @@ class Items(Document):
 		if not old_doc:
 			return
 
+		# Propagate a billing_category change to the billing_status of every
+		# Procurement Request / Sent Back / Purchase Order line item for this item.
+		self._propagate_billing_status(old_doc)
+
 		# Build dict of changed fields: Items field -> TDS Repository field
 		updates = {}
 
@@ -59,3 +63,81 @@ class Items(Document):
 		if tds_records:
 			frappe.db.commit()
 			print(f"[Items on_update] '{self.name}': Synced {updates} to {len(tds_records)} TDS Repository record(s).")
+
+	# PR / SB parent workflow states that are still heading toward a PO ("upcoming PO").
+	# Terminal / done states are intentionally excluded so historical PR/SB rows are left
+	# alone (their PO already carries the value):
+	#   PR excluded: Vendor Approved, Rejected, Sent Back, Delayed, Hidden
+	#   SB excluded: Approved, Sent Back
+	_PR_UPCOMING_PO_STATES = (
+		"Draft", "Pending", "Approved", "RFQ Generated", "Quote Updated",
+		"In Progress", "Vendor Selected", "Partially Approved",
+	)
+	_SB_UPCOMING_PO_STATES = ("Pending", "Vendor Selected", "Partially Approved")
+
+	def _propagate_billing_status(self, old_doc):
+		"""When billing_category changes, mirror it onto billing_status:
+		  - Purchase Order Item: ALL rows for this item (the PO is the billing record).
+		  - Procurement Request Item Detail (PR + SB order_list): only rows whose parent
+		    PR/SB is still heading toward a PO (upcoming-PO workflow states). Terminal/done
+		    PR/SB rows are left untouched as history.
+		Then recompute the PO parent rollup. Raw SQL / update_modified=False, so no parent
+		timestamps are bumped."""
+		if (old_doc.get("billing_category") or "") == (self.billing_category or ""):
+			return
+
+		new_status = self.billing_category
+		# Don't propagate a blank: if billing_category was cleared, leave existing
+		# line-item billing_status as-is rather than wiping it to empty.
+		if not new_status:
+			return
+
+		# 1) PO items — update fully (every PO line for this item).
+		frappe.db.set_value(
+			"Purchase Order Item",
+			{"item_id": self.name},
+			"billing_status",
+			new_status,
+			update_modified=False,
+		)
+
+		# 2) PR / SB items — only where the parent doc is in an upcoming-PO state.
+		frappe.db.sql(
+			"""
+			UPDATE "tabProcurement Request Item Detail" t
+			SET billing_status = %(status)s
+			WHERE t.item_id = %(item)s
+			  AND (
+			        (t.parenttype = 'Procurement Requests' AND EXISTS (
+			            SELECT 1 FROM "tabProcurement Requests" pr
+			            WHERE pr.name = t.parent AND pr.workflow_state IN %(pr_states)s))
+			     OR (t.parenttype = 'Sent Back Category' AND EXISTS (
+			            SELECT 1 FROM "tabSent Back Category" sb
+			            WHERE sb.name = t.parent AND sb.workflow_state IN %(sb_states)s))
+			  )
+			""",
+			{
+				"status": new_status,
+				"item": self.name,
+				"pr_states": self._PR_UPCOMING_PO_STATES,
+				"sb_states": self._SB_UPCOMING_PO_STATES,
+			},
+		)
+
+		# 3) Recompute the PO-level rollup for any PO that contains this item.
+		frappe.db.sql(
+			"""
+			UPDATE "tabProcurement Orders" po
+			SET billing_status = CASE
+				WHEN EXISTS (SELECT 1 FROM "tabPurchase Order Item" it
+							 WHERE it.parent = po.name AND it.billing_status = 'Billable') THEN 'Billable'
+				WHEN EXISTS (SELECT 1 FROM "tabPurchase Order Item" it
+							 WHERE it.parent = po.name) THEN 'Non-Billable'
+				ELSE ''
+			END
+			WHERE po.name IN (
+				SELECT DISTINCT parent FROM "tabPurchase Order Item" WHERE item_id = %s
+			)
+			""",
+			(self.name,),
+		)

--- a/nirmaan_stack/nirmaan_stack/doctype/procurement_orders/procurement_orders.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/procurement_orders/procurement_orders.json
@@ -38,6 +38,7 @@
   "amount_paid",
   "tracking_details_section",
   "status",
+  "billing_status",
   "delivery_contact",
   "delivery_data",
   "invoice_data",
@@ -169,6 +170,16 @@
    "in_standard_filter": 1,
    "label": "Status",
    "search_index": 1
+  },
+  {
+   "description": "Auto-calculated from item billing status: Billable if any item is Billable, else Non-Billable.",
+   "fieldname": "billing_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Billing Status",
+   "options": "\nBillable\nNon-Billable",
+   "read_only": 1
   },
   {
    "fieldname": "category_list",

--- a/nirmaan_stack/nirmaan_stack/doctype/procurement_request_item_detail/procurement_request_item_detail.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/procurement_request_item_detail/procurement_request_item_detail.json
@@ -18,7 +18,8 @@
   "tax",
   "comment",
   "vendor",
-  "quote"
+  "quote",
+  "billing_status"
  ],
  "fields": [
   {
@@ -105,6 +106,13 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Quote"
+  },
+  {
+   "fieldname": "billing_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Billing Status",
+   "options": "Billable\nNon-Billable"
   }
  ],
  "grid_page_length": 50,

--- a/nirmaan_stack/nirmaan_stack/doctype/purchase_order_item/purchase_order_item.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/purchase_order_item/purchase_order_item.json
@@ -23,7 +23,8 @@
   "tax_amount",
   "total_amount",
   "comment",
-  "procurement_request_item"
+  "procurement_request_item",
+  "billing_status"
  ],
  "fields": [
   {
@@ -136,6 +137,13 @@
    "in_list_view": 1,
    "label": "Quoted Rate",
    "reqd": 1
+  },
+  {
+   "fieldname": "billing_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Billing Status",
+   "options": "Billable\nNon-Billable"
   }
  ],
  "grid_page_length": 50,

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -120,3 +120,4 @@ nirmaan_stack.patches.v3_0.backfill_work_order_items #2
 nirmaan_stack.patches.v3_0.purge_document_ai_credentials
 nirmaan_stack.patches.v3_0.sync_commission_master_changes
 nirmaan_stack.patches.v3_0.backfill_commission_report_type
+nirmaan_stack.patches.v3_0.backfill_billing_status

--- a/nirmaan_stack/patches/v3_0/backfill_billing_status.py
+++ b/nirmaan_stack/patches/v3_0/backfill_billing_status.py
@@ -1,0 +1,73 @@
+import frappe
+
+
+def execute():
+    # """
+    # Backfill billing_status on existing line items from the Items master.
+
+    # Targets the two child tables:
+    #   - Procurement Request Item Detail  (one child doctype for BOTH Procurement
+    #     Request order_list AND Sent Back Category order_list)
+    #   - Purchase Order Item              (Purchase Order items child table)
+
+    # Rule per row:
+    #   billing_status = the item's master billing_category, OR
+    #   'Billable' when the item is not in the master (legacy custom / Request items)
+    #   or the master value is blank.
+
+    # item_id is TRIM()'d before the master lookup so a handful of legacy rows with a
+    # stray leading/trailing space (e.g. ' ITEM-001482') still resolve to their real
+    # catalog value instead of falling back to Billable.
+
+    # After the line items are fixed, the PO parent rollup (Procurement Orders.
+    # billing_status) is recomputed from them: Billable if any item is Billable,
+    # Non-Billable if items exist and all are Non-Billable, else blank.
+
+    # Idempotent — safe to re-run. Uses bulk UPDATEs keyed by item_id / parent.
+    # """
+    for child in ("Procurement Request Item Detail", "Purchase Order Item"):
+        frappe.db.sql(
+            f"""
+            UPDATE "tab{child}" t
+            SET billing_status = COALESCE(
+                NULLIF(
+                    (SELECT i.billing_category FROM "tabItems" i WHERE i.name = TRIM(t.item_id)),
+                    ''
+                ),
+                'Billable'
+            )
+            """
+        )
+
+    # Recompute the PO-level rollup from the (now corrected) PO items.
+    frappe.db.sql(
+        """
+        UPDATE "tabProcurement Orders" po
+        SET billing_status = CASE
+            WHEN EXISTS (SELECT 1 FROM "tabPurchase Order Item" it
+                         WHERE it.parent = po.name AND it.billing_status = 'Billable') THEN 'Billable'
+            WHEN EXISTS (SELECT 1 FROM "tabPurchase Order Item" it
+                         WHERE it.parent = po.name) THEN 'Non-Billable'
+            ELSE ''
+        END
+        """
+    )
+
+    frappe.db.commit()
+
+    # Print a result summary so the run is never "blind" (shows in `bench migrate` output).
+    def _dist(table):
+        rows = frappe.db.sql(
+            f"""SELECT COALESCE(NULLIF(billing_status, ''), '(blank)') AS s, COUNT(*) AS n
+                FROM "{table}" GROUP BY 1 ORDER BY s""",
+            as_dict=True,
+        )
+        return {r.s: r.n for r in rows}
+
+    pr = _dist("tabProcurement Request Item Detail")
+    po = _dist("tabPurchase Order Item")
+    parent = _dist("tabProcurement Orders")
+    print("[backfill_billing_status] done — result counts:")
+    print(f"    PR + SB line items : total={sum(pr.values())}  {pr}")
+    print(f"    PO line items      : total={sum(po.values())}  {po}")
+    print(f"    PO parent rollup   : total={sum(parent.values())}  {parent}")


### PR DESCRIPTION
- Add a Billing Status (Billable / Non-Billable) field on PR/SB/PO line items + a PO-level rollup, sourced from the Items master, carried through every PR→SB→PO flow, and synced live when an item's billing_category changes.
- Gate DC/MIR to Billable POs/items (UI + backend guards) and drive Material Usage billing from the PO item's billing_status, with a one-time backfill patch for existing data.
