### PR TITLE
feat: surface manual vs system CEO Hold and notify holder when releas…

### DIFF
--- a/frontend/src/components/ui/ceo-hold-banner.tsx
+++ b/frontend/src/components/ui/ceo-hold-banner.tsx
@@ -1,6 +1,6 @@
 import { Hand } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { CEO_HOLD_AUTHORIZED_USER } from "@/constants/ceoHold";
+import { CEO_AUTHORIZED_USER, CEO_HOLD_SYSTEM_USER } from "@/constants/ceoHold";
 
 interface CEOHoldBannerProps {
   className?: string;
@@ -63,16 +63,29 @@ export function CEOHoldBanner({ className, compact = false, heldBy }: CEOHoldBan
 
         {/* Content */}
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-semibold text-amber-900 tracking-tight">
-            Project on CEO Hold
-          </h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-amber-900 tracking-tight">
+              Project on CEO Hold
+            </h3>
+            {heldBy && (
+              <span className="inline-flex items-center rounded-full bg-red-600 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white">
+                {heldBy === CEO_HOLD_SYSTEM_USER ? "System" : "Manual"}
+              </span>
+            )}
+          </div>
           <p className="mt-1 text-sm text-amber-700 leading-relaxed">
             Some procurement, payment, and expense operations are restricted.
-            <span className="block mt-1 text-amber-600 font-medium">
-              {heldBy
-                ? `Set by ${heldBy}. Only ${CEO_HOLD_AUTHORIZED_USER} can change the CEO Hold status.`
-                : `Only Admin can change the CEO Hold status.`}
-            </span>
+            {heldBy === CEO_HOLD_SYSTEM_USER ? (
+              <span className="block mt-1 text-amber-600 font-medium">
+                This hold clears on its own once cashflow is back within the
+                limit, or {CEO_AUTHORIZED_USER} can release it.
+              </span>
+            ) : heldBy ? (
+              <span className="block mt-1 text-amber-600 font-medium">
+                This hold won&rsquo;t clear on its own — only {CEO_AUTHORIZED_USER}{" "}
+                can release it.
+              </span>
+            ) : null}
           </p>
         </div>
       </div>

--- a/frontend/src/constants/ceoHold.ts
+++ b/frontend/src/constants/ceoHold.ts
@@ -7,3 +7,10 @@ export const CEO_AUTHORIZED_USER = "nitesh@nirmaan.app";
 
 /** @deprecated Use CEO_AUTHORIZED_USER. Kept as alias for back-compat with CEO Hold imports. */
 export const CEO_HOLD_AUTHORIZED_USER = CEO_AUTHORIZED_USER;
+
+/**
+ * Marker stored in Projects.ceo_hold_by when the cashflow cron auto-places a hold
+ * (vs a real user email for a manual hold). Must match the backend constant
+ * CEO_HOLD_SYSTEM_USER in nirmaan_stack/constants/authorized_users.py.
+ */
+export const CEO_HOLD_SYSTEM_USER = "System (Cashflow Cron)";

--- a/frontend/src/hooks/useCEOHoldGuard.ts
+++ b/frontend/src/hooks/useCEOHoldGuard.ts
@@ -7,6 +7,7 @@ interface CEOHoldGuardResult {
   isCEOHold: boolean;
   isLoading: boolean;
   projectStatus: string | undefined;
+  ceoHoldBy: string | undefined;  // Projects.ceo_hold_by — pass to <CEOHoldBanner heldBy={...} />
   showBlockedToast: () => void;
 }
 
@@ -39,6 +40,7 @@ export function useCEOHoldGuard(projectId: string | undefined): CEOHoldGuardResu
     isCEOHold,
     isLoading,
     projectStatus: project?.status,
+    ceoHoldBy: project?.ceo_hold_by,
     showBlockedToast
   };
 }

--- a/frontend/src/pages/ProcurementOrders/purchase-order/components/PODetails.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/components/PODetails.tsx
@@ -142,7 +142,7 @@ export const PODetails: React.FC<PODetailsProps> = ({
   const { role } = useUserData();
   const isProjectManager = role === "Nirmaan Project Manager Profile";
   const { errors, isValid, hasVendorIssues } = usePOValidation(po);
-  const { isCEOHold, showBlockedToast } = useCEOHoldGuard(po?.project);
+  const { isCEOHold, showBlockedToast, ceoHoldBy } = useCEOHoldGuard(po?.project);
   const { isOnHold: isVendorOnHold, showBlockedToast: showVendorBlockedToast } = useVendorHoldGuard(po?.vendor);
 
   const { updateDoc, loading: update_loading } = useFrappeUpdateDoc();
@@ -570,7 +570,7 @@ export const PODetails: React.FC<PODetailsProps> = ({
 
   return (
     <div>
-      {isCEOHold && <CEOHoldBanner className="mb-4" />}
+      {isCEOHold && <CEOHoldBanner className="mb-4" heldBy={ceoHoldBy} />}
       {isVendorOnHold && (
         <VendorHoldBanner className="mb-4" />
       )}

--- a/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
+++ b/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
@@ -1,9 +1,11 @@
 import json
 
 import frappe
+from frappe import _
 from frappe.utils import flt
 
 from nirmaan_stack.nirmaan_stack.doctype.projects.projects import CEO_HOLD_SYSTEM_USER
+from ..Notifications.pr_notifications import PrNotification
 
 EXCLUDED_STATUSES = ("CEO Hold", "Completed")
 FALLBACK_REVERT_STATUS = "WIP"
@@ -115,6 +117,13 @@ def evaluate_project_ceo_release(project_id: str) -> bool:
 	if not row or row.status != "CEO Hold":
 		return False
 	if row.ceo_hold_by != CEO_HOLD_SYSTEM_USER:
+		# Human-set hold: never auto-release. But if the cashflow gap has
+		# recovered to within the limit (an auto-hold would release here), give
+		# the holder a heads-up that it's now eligible for a manual release.
+		# The hold itself is left untouched.
+		manual_limit = flt(row.cashflow_gap_limit)
+		if manual_limit > 0 and _compute_cashflow_gap(project_id) <= manual_limit:
+			_notify_manual_hold_releasable(project_id, row.ceo_hold_by)
 		return False
 
 	limit = flt(row.cashflow_gap_limit)
@@ -150,6 +159,92 @@ def evaluate_project_ceo_release(project_id: str) -> bool:
 		% (project_id, gap, limit, revert_to)
 	)
 	return True
+
+
+def _notify_manual_hold_releasable(project_id: str, holder_user: str) -> None:
+	"""Heads-up to the human who manually placed a CEO Hold that the project's
+	cashflow gap has recovered to within its limit — i.e. an auto-hold would
+	release here, but we never auto-release human-set holds, so the holder must
+	release it by hand if appropriate. The hold itself is left untouched.
+
+	Deduped on an UNSEEN notification of this kind for this holder+project, so a
+	burst of payment / inflow / PO events while the project sits
+	releasable-but-held doesn't spam the holder.
+	"""
+	if not holder_user:
+		return
+
+	# Never notify during migrations / backfills / imports — the bulk evaluator
+	# calls the release path directly (bypassing trigger_check's guard), and we
+	# don't want a backfill to dump stale "ready to release" notes on the holder.
+	if frappe.flags.in_patch or frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_import:
+		return
+
+	if frappe.db.exists(
+		"Nirmaan Notifications",
+		{
+			"recipient": holder_user,
+			"project": project_id,
+			"event_id": "project:ceo_hold_releasable",
+			"seen": "false",
+		},
+	):
+		return
+
+	user = frappe.db.get_value(
+		"Nirmaan Users",
+		{"name": holder_user},
+		["fcm_token", "name", "full_name", "role_profile", "push_notification"],
+		as_dict=True,
+	)
+	if not user:
+		return
+
+	project_name = frappe.db.get_value("Projects", project_id, "project_name") or project_id
+	title = _("Project Ready to Release from CEO Hold")
+	description = _(
+		"{0}'s cashflow is now within its limit. It is on a manual CEO Hold placed by you — "
+		"please release it manually if appropriate."
+	).format(project_name)
+
+	# FCM push only if the holder opted in.
+	if user.get("push_notification") == "true":
+		PrNotification(
+			user, title, description,
+			f"{frappe.utils.get_url()}/frontend/projects/{project_id}",
+		)
+
+	# In-app Nirmaan Notification.
+	note = frappe.new_doc("Nirmaan Notifications")
+	note.update({
+		"recipient": user.get("name"),
+		"recipient_role": user.get("role_profile"),
+		"sender": frappe.session.user if frappe.session.user != "Administrator" else None,
+		"title": title,
+		"description": description,
+		"document": "Projects",
+		"docname": project_id,
+		"project": project_id,
+		"seen": "false",
+		"type": "info",
+		"event_id": "project:ceo_hold_releasable",
+		"action_url": f"projects/{project_id}",
+	})
+	note.insert(ignore_permissions=True)
+	frappe.db.commit()  # commit before realtime publish (avoids race)
+
+	frappe.publish_realtime(
+		event="project:ceo_hold_releasable",
+		message={
+			"title": title,
+			"description": description,
+			"project": project_id,
+			"sender": frappe.session.user,
+			"docname": project_id,
+			"notificationId": note.name,
+		},
+		user=user.get("name"),
+	)
 
 
 def update_projects_cashflow_hold():


### PR DESCRIPTION
…able

Distinguish who placed a CEO Hold and act on it differently:

- CEOHoldBanner: add a red System/Manual badge derived from Projects.ceo_hold_by, with tailored copy — system (cashflow) holds clear on their own once cashflow recovers; manual holds stay until the CEO releases them.
- useCEOHoldGuard: expose ceoHoldBy so pages can drive the badge.
- PODetails: pass heldBy to the banner so it renders the badge/detail.
- Add CEO_HOLD_SYSTEM_USER frontend constant, mirroring the backend.

Backend (project_cashflow_hold_update): when a manually-held project's cashflow gap recovers to within its limit (where an auto-hold would release), notify the holder that it's eligible for a manual release — in-app Nirmaan Notification + FCM, deduped on an unseen note and skipped during migrations. The hold itself is never auto-released; system-set holds are unaffected.