### PR TITLE
CSV export + selective milestone recompute on date change

### DIFF
--- a/frontend/src/pages/Manpower-and-WorkMilestones/components/ProjectScheduler.tsx
+++ b/frontend/src/pages/Manpower-and-WorkMilestones/components/ProjectScheduler.tsx
@@ -3,6 +3,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Dialog,
   DialogContent,
@@ -57,6 +59,42 @@ const startOfUtcDay = (d: Date) =>
 const daysBetweenUTC = (from: Date, to: Date) =>
   Math.floor((startOfUtcDay(to) - startOfUtcDay(from)) / (1000 * 60 * 60 * 24));
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+const addDaysLocal = (date: Date, days: number): Date => {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+};
+
+// Project the formula-derived window for a milestone against a NEW project
+// window. Mirrors useProjectScheduler.ts / project_schedule.py so the Edit
+// Project Dates dialog can preview what a recomputed milestone will become.
+const projectFormulaWindow = (
+  newStart: Date | null,
+  newEnd: Date | null,
+  firstWeekIdx: number,
+  lastWeekIdx: number,
+): { start: Date | null; end: Date | null } => {
+  if (!newStart || !newEnd || firstWeekIdx === -1) return { start: null, end: null };
+  const durationDays =
+    Math.round((newEnd.getTime() - newStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  if (durationDays <= 0) return { start: null, end: null };
+  const weekSlotDays = durationDays / NUM_WEEK_SLOTS;
+
+  let startOffset = Math.round(firstWeekIdx * weekSlotDays);
+  let endOffset = Math.round((lastWeekIdx + 1) * weekSlotDays) - 1;
+  // Mirror _compute_milestone_dates clamping: for windows shorter than 9 days
+  // week_slot_days < 1, so rounding can push offsets outside the window or land
+  // end below start. Clamp both into [0, lastOffset], then enforce end >= start.
+  const lastOffset = Math.max(0, durationDays - 1);
+  startOffset = Math.max(0, Math.min(startOffset, lastOffset));
+  endOffset = Math.max(0, Math.min(endOffset, lastOffset));
+  endOffset = Math.max(endOffset, startOffset);
+
+  const start = addDaysLocal(newStart, startOffset);
+  const end = addDaysLocal(newStart, endOffset);
+  return { start, end };
+};
 
 // Mirrors useTargetProgress: same anchor math + linear interpolation between
 // adjacent weekly anchors. Keeps Scheduler and Milestones Summary in sync.
@@ -124,6 +162,7 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
     refetchSchedule,
     updateMilestoneDates,
     resetMilestoneDates,
+    resetMilestonesToFormula,
   } = useProjectScheduler(projectId);
 
   const { role, user_id } = useUserData();
@@ -156,14 +195,30 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
   const [editOpen, setEditOpen] = useState(false);
   const [editStart, setEditStart] = useState('');
   const [editEnd, setEditEnd] = useState('');
+  // Edit Project Dates is a 2-step flow: 1 = pick dates, 2 = confirm + choose
+  // which manually-edited milestones to recompute against the new window.
+  const [editStep, setEditStep] = useState<1 | 2>(1);
+  const [recomputeRows, setRecomputeRows] = useState<Set<string>>(new Set());
   const [downloadingPdf, setDownloadingPdf] = useState(false);
 
   useEffect(() => {
     if (editOpen && projectStartDate && projectEndDate) {
       setEditStart(toInputDate(projectStartDate));
       setEditEnd(toInputDate(projectEndDate));
+      setEditStep(1);
+      setRecomputeRows(new Set());
     }
   }, [editOpen, projectStartDate, projectEndDate]);
+
+  // Manually-edited milestones (changed_by_user) — surfaced in step 2 so the
+  // user can opt-in to recomputing any of them to the new project window.
+  const manualMilestones = useMemo(
+    () =>
+      groups.flatMap((g) =>
+        g.milestones.filter((m) => m.changedByUser && m.rowName),
+      ),
+    [groups],
+  );
 
   const handleSaveDates = useCallback(async () => {
     if (!projectId || !editStart || !editEnd) return;
@@ -186,12 +241,24 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
         project_end_date: formatToLocalDateTimeString(end),
       });
       // The Projects.on_update hook recomputes Project Schedule rows for the
-      // new window — refresh both the project doc and the schedule cache so
-      // the grid reflects the recomputed dates without a page reload.
+      // new window — but leaves manually-edited (changed_by_user) rows frozen.
+      // For any manual milestone the user ticked in step 2, reset its override
+      // so it recomputes against the new window too.
+      const rowsToRecompute = manualMilestones
+        .filter((m) => recomputeRows.has(m.rowName as string))
+        .map((m) => m.rowName as string);
+      if (rowsToRecompute.length > 0) {
+        await resetMilestonesToFormula(rowsToRecompute);
+      }
+      // Refresh both the project doc and the schedule cache so the grid
+      // reflects the recomputed dates without a page reload.
       await Promise.all([mutateProject(), refetchSchedule()]);
       toast({
         title: 'Project dates updated',
-        description: `${formatDate(start)} → ${formatDate(end)}`,
+        description:
+          rowsToRecompute.length > 0
+            ? `${formatDate(start)} → ${formatDate(end)} · ${rowsToRecompute.length} manual milestone${rowsToRecompute.length > 1 ? 's' : ''} recomputed`
+            : `${formatDate(start)} → ${formatDate(end)}`,
         variant: 'success',
       });
       setEditOpen(false);
@@ -202,7 +269,7 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
         variant: 'destructive',
       });
     }
-  }, [projectId, editStart, editEnd, updateDoc, mutateProject, refetchSchedule]);
+  }, [projectId, editStart, editEnd, updateDoc, mutateProject, refetchSchedule, manualMilestones, recomputeRows, resetMilestonesToFormula]);
 
   const toggleHeader = (header: string) =>
     setExpanded((p) => ({ ...p, [header]: !(p[header] ?? true) }));
@@ -335,54 +402,61 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
     }
   }, [projectId, projectStartDate, projectEndDate, groups, projectData]);
 
-  // const handleExportCsv = useCallback(() => {
-  //   if (!projectStartDate || !projectEndDate) return;
-  //
-  //   const rows: (string | number)[][] = [];
-  //   const projectLabel =
-  //     projectData?.project_name || projectData?.name || projectId || 'Project';
-  //
-  //   // 4-column layout: titles start in column 1.
-  //   rows.push([`Project: ${projectLabel}`, '', '', '']);
-  //   rows.push(['Start Date', formatDate(projectStartDate), '', '']);
-  //   rows.push(['End Date', formatDate(projectEndDate), '', '']);
-  //   rows.push(['Duration', `${projectDurationDays} days`, '', '']);
-  //   rows.push(['', '', '', '']);
-  //
-  //   groups.forEach((group) => {
-  //     const headerRange =
-  //       group.earliestStart && group.latestEnd
-  //         ? ` (${formatDate(group.earliestStart)} - ${formatDate(group.latestEnd)})`
-  //         : '';
-  //     rows.push([`${group.header}${headerRange}`, '', '', '']);
-  //     rows.push(['Milestone', 'Start', 'End', 'Duration (Days)']);
-  //     if (group.milestones.length === 0) {
-  //       rows.push(['(No milestones)', '', '', '']);
-  //     } else {
-  //       group.milestones.forEach((m) => {
-  //         rows.push([
-  //           m.work_milestone_name,
-  //           m.startDate ? formatDate(m.startDate) : '',
-  //           m.endDate ? formatDate(m.endDate) : '',
-  //           m.firstWeekIdx !== -1 ? m.durationDays : '',
-  //         ]);
-  //       });
-  //     }
-  //     rows.push(['', '', '', '']);
-  //   });
-  //
-  //   const csv = unparse(rows);
-  //   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  //   const url = URL.createObjectURL(blob);
-  //   const link = document.createElement('a');
-  //   const safeName = String(projectLabel).replace(/[^a-z0-9]+/gi, '_');
-  //   link.href = url;
-  //   link.setAttribute('download', `${safeName}_scheduler.csv`);
-  //   document.body.appendChild(link);
-  //   link.click();
-  //   document.body.removeChild(link);
-  //   URL.revokeObjectURL(url);
-  // }, [projectData, projectId, projectStartDate, projectEndDate, projectDurationDays, groups]);
+  const handleExportCsv = useCallback(() => {
+    if (!projectStartDate || !projectEndDate) return;
+
+    const rows: (string | number)[][] = [];
+    const projectLabel =
+      projectData?.project_name || projectData?.name || projectId || 'Project';
+
+    // 4-column layout: titles start in column 1.
+    rows.push([`Project: ${projectLabel}`, '', '', '']);
+    rows.push(['Start Date', formatDate(projectStartDate), '', '']);
+    rows.push(['End Date', formatDate(projectEndDate), '', '']);
+    rows.push(['Duration', `${projectDurationDays} days`, '', '']);
+    rows.push(['', '', '', '']);
+
+    // Mirror the PDF: drop milestones marked Disabled in the latest completed
+    // Project Progress Report, and skip groups left with no milestones.
+    groups
+      .map((g) => ({ ...g, milestones: g.milestones.filter((m) => !m.disabledByReport) }))
+      .filter((g) => g.milestones.length > 0)
+      .forEach((group) => {
+        const headerRange =
+          group.earliestStart && group.latestEnd
+            ? ` (${formatDate(group.earliestStart)} - ${formatDate(group.latestEnd)})`
+            : '';
+        rows.push([`${group.header}${headerRange}`, '', '', '']);
+        rows.push(['Milestone', 'Start', 'End', 'Duration (Days)']);
+        group.milestones.forEach((m) => {
+          rows.push([
+            m.work_milestone_name,
+            m.startDate ? formatDate(m.startDate) : '',
+            m.endDate ? formatDate(m.endDate) : '',
+            m.firstWeekIdx !== -1 ? m.durationDays : '',
+          ]);
+        });
+        rows.push(['', '', '', '']);
+      });
+
+    const csv = unparse(rows);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const safeName = String(projectLabel).replace(/[^a-z0-9]+/gi, '_');
+    link.href = url;
+    link.setAttribute('download', `${safeName}_DPR_Project_Target.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    toast({
+      title: 'Download Complete',
+      description: 'DPR Project Target CSV saved.',
+      variant: 'success',
+    });
+  }, [projectData, projectId, projectStartDate, projectEndDate, projectDurationDays, groups]);
 
   const completionStats = useMemo(() => {
     if (!selectedDateObj || !projectStartDate || projectDurationDays <= 0) return null;
@@ -467,18 +541,19 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
                 {visibleGroups.length} headers · {totalMilestones} milestones
               </Badge>
               {/* EDIT DATES button moved into the date cards as a small pencil icon */}
-              {/* EXPORT CSV — hidden for now
               <Button
                 variant="outline"
                 size="sm"
                 onClick={handleExportCsv}
                 disabled={groups.length === 0}
+                title="Download CSV"
+                aria-label="Download CSV"
                 className="h-8"
               >
-                <Download className="w-3.5 h-3.5 sm:mr-1.5" />
-                <span className="hidden sm:inline">Export CSV</span>
+                <Download className="w-3.5 h-3.5 mr-1 sm:mr-1.5" />
+                <span className="sm:hidden">CSV</span>
+                <span className="hidden sm:inline">Download CSV</span>
               </Button>
-              */}
               <Button
                 size="sm"
                 onClick={handleDownloadPdf}
@@ -630,45 +705,198 @@ export const ProjectScheduler: React.FC<ProjectSchedulerProps> = ({ projectId, c
       </Card>
 
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Edit Project Dates</DialogTitle>
-            <DialogDescription className="text-xs">
-              Updates the project's Start Date and End Date. All milestone timeline
-              calculations will recompute against the new range.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid grid-cols-2 gap-3 py-2">
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-gray-700">Start Date</label>
-              <Input
-                type="date"
-                value={editStart}
-                max={editEnd || undefined}
-                onChange={(e) => setEditStart(e.target.value)}
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs font-medium text-gray-700">End Date</label>
-              <Input
-                type="date"
-                value={editEnd}
-                min={editStart || undefined}
-                onChange={(e) => setEditEnd(e.target.value)}
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setEditOpen(false)} disabled={savingDates}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSaveDates}
-              disabled={savingDates || !editStart || !editEnd}
-            >
-              {savingDates ? 'Saving…' : 'Save'}
-            </Button>
-          </DialogFooter>
+        <DialogContent
+          className={cn(
+            'flex flex-col max-h-[85vh]',
+            // Step 2 holds the milestone list — give it more room; step 1 stays compact.
+            editStep === 2 ? 'sm:max-w-xl' : 'sm:max-w-md',
+          )}
+        >
+          {editStep === 1 ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Edit Project Dates</DialogTitle>
+                <DialogDescription className="text-xs">
+                  Updates the project's Start Date and End Date. All milestone timeline
+                  calculations recompute against the new range — except milestones you
+                  manually edited, which stay frozen unless you choose otherwise next.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid grid-cols-2 gap-3 py-2">
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-gray-700">Start Date</label>
+                  <Input
+                    type="date"
+                    value={editStart}
+                    max={editEnd || undefined}
+                    onChange={(e) => setEditStart(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-gray-700">End Date</label>
+                  <Input
+                    type="date"
+                    value={editEnd}
+                    min={editStart || undefined}
+                    onChange={(e) => setEditEnd(e.target.value)}
+                  />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setEditOpen(false)} disabled={savingDates}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => setEditStep(2)}
+                  disabled={
+                    !editStart ||
+                    !editEnd ||
+                    new Date(editEnd) < new Date(editStart)
+                  }
+                >
+                  Next
+                </Button>
+              </DialogFooter>
+            </>
+          ) : (
+            <>
+              <DialogHeader>
+                <DialogTitle>Confirm Project Date Change</DialogTitle>
+                <DialogDescription className="text-xs">
+                  New range:{' '}
+                  <span className="font-medium text-gray-700">
+                    {formatDate(new Date(editStart))} → {formatDate(new Date(editEnd))}
+                  </span>
+                  . Formula-derived milestone dates recompute automatically.
+                </DialogDescription>
+              </DialogHeader>
+
+              {manualMilestones.length > 0 ? (
+                <div className="flex flex-col min-h-0 flex-1 py-2 space-y-2">
+                  <p className="text-xs text-gray-600">
+                    These milestones were manually edited and will <strong>keep their
+                    custom dates</strong>. Tick any you want to recompute to the new range:
+                  </p>
+                  <div className="flex items-center justify-between gap-2 border-b pb-2">
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="recompute-all"
+                        checked={
+                          recomputeRows.size === manualMilestones.length &&
+                          manualMilestones.length > 0
+                        }
+                        onCheckedChange={(checked) =>
+                          setRecomputeRows(
+                            checked
+                              ? new Set(manualMilestones.map((m) => m.rowName as string))
+                              : new Set(),
+                          )
+                        }
+                      />
+                      <label htmlFor="recompute-all" className="text-xs font-medium text-gray-700">
+                        Select all ({manualMilestones.length})
+                      </label>
+                    </div>
+                    <Badge
+                      variant={recomputeRows.size > 0 ? 'default' : 'secondary'}
+                      className="font-normal"
+                    >
+                      {recomputeRows.size} selected
+                    </Badge>
+                  </div>
+                  <ScrollArea
+                    type="always"
+                    className="h-[45vh] pr-1 [&_[data-orientation=vertical]]:w-1.5 [&_[data-orientation=vertical]>div]:bg-primary"
+                  >
+                    <div className="space-y-2 pr-3">
+                      {manualMilestones.map((m) => {
+                        const rn = m.rowName as string;
+                        const checked = recomputeRows.has(rn);
+                        const proj = projectFormulaWindow(
+                          editStart ? new Date(editStart) : null,
+                          editEnd ? new Date(editEnd) : null,
+                          m.firstWeekIdx,
+                          m.lastWeekIdx,
+                        );
+                        return (
+                          <label
+                            key={rn}
+                            htmlFor={`recompute-${rn}`}
+                            className="flex items-start gap-2 rounded-md border p-2 cursor-pointer hover:bg-gray-50"
+                          >
+                            <Checkbox
+                              id={`recompute-${rn}`}
+                              checked={checked}
+                              onCheckedChange={(c) =>
+                                setRecomputeRows((prev) => {
+                                  const next = new Set(prev);
+                                  if (c) next.add(rn);
+                                  else next.delete(rn);
+                                  return next;
+                                })
+                              }
+                              className="mt-0.5"
+                            />
+                            <div className="min-w-0 flex-1">
+                              <div className="text-xs font-medium text-gray-800 truncate">
+                                {m.work_milestone_name}
+                              </div>
+                              {/* Current (custom) dates — struck through once the user
+                                  opts to recompute, so it reads as "old → new". */}
+                              <div
+                                className={cn(
+                                  'text-[11px]',
+                                  checked ? 'text-gray-400 line-through' : 'text-gray-500',
+                                )}
+                              >
+                                {m.startDate ? formatDate(m.startDate) : '—'} →{' '}
+                                {m.endDate ? formatDate(m.endDate) : '—'}
+                                {m.editedByUser ? ` · by ${m.editedByUser}` : ''}
+                              </div>
+                              {checked && (
+                                <div className="text-[11px] font-medium text-green-700">
+                                  ⇒ {proj.start ? formatDate(proj.start) : '—'} →{' '}
+                                  {proj.end ? formatDate(proj.end) : '—'}{' '}
+                                  <span className="font-normal text-gray-500">(new)</span>
+                                </div>
+                              )}
+                            </div>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </ScrollArea>
+                  <p className="text-[11px] text-gray-500">
+                    {recomputeRows.size === 0
+                      ? 'No manual milestones selected — all custom dates will be kept.'
+                      : `${recomputeRows.size} of ${manualMilestones.length} will be recomputed to the new range.`}
+                  </p>
+                </div>
+              ) : (
+                <p className="py-3 text-xs text-gray-600">
+                  No manually-edited milestones. All milestone dates will recompute against
+                  the new range.
+                </p>
+              )}
+
+              <DialogFooter className="gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setEditStep(1)}
+                  disabled={savingDates}
+                  className="mr-auto"
+                >
+                  Back
+                </Button>
+                <Button variant="outline" onClick={() => setEditOpen(false)} disabled={savingDates}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSaveDates} disabled={savingDates}>
+                  {savingDates ? 'Saving…' : 'Confirm & Save'}
+                </Button>
+              </DialogFooter>
+            </>
+          )}
         </DialogContent>
       </Dialog>
 

--- a/frontend/src/pages/Manpower-and-WorkMilestones/hooks/useProjectScheduler.ts
+++ b/frontend/src/pages/Manpower-and-WorkMilestones/hooks/useProjectScheduler.ts
@@ -53,6 +53,7 @@ interface UseProjectSchedulerResult {
   refetchSchedule: () => Promise<void>;
   updateMilestoneDates: (rowName: string, startISO: string | null, endISO: string | null) => Promise<void>;
   resetMilestoneDates: (rowName: string) => Promise<void>;
+  resetMilestonesToFormula: (rowNames: string[]) => Promise<void>;
   scheduleDoc: ProjectSchedule | null;
 }
 
@@ -121,6 +122,9 @@ export const useProjectScheduler = (projectId: string | null | undefined): UsePr
   );
   const { call: resetMilestoneDatesCall } = useFrappePostCall(
     'nirmaan_stack.api.milestone.project_schedule.reset_milestone_dates'
+  );
+  const { call: resetMilestonesToFormulaCall } = useFrappePostCall(
+    'nirmaan_stack.api.milestone.project_schedule.reset_milestones_to_formula'
   );
 
   const [scheduleDoc, setScheduleDoc] = useState<ProjectSchedule | null>(null);
@@ -196,6 +200,18 @@ export const useProjectScheduler = (projectId: string | null | undefined): UsePr
       await refetchSchedule();
     },
     [projectId, resetMilestoneDatesCall, refetchSchedule]
+  );
+
+  const resetMilestonesToFormula = useCallback(
+    async (rowNames: string[]) => {
+      if (!projectId || rowNames.length === 0) return;
+      await resetMilestonesToFormulaCall({
+        project_id: projectId,
+        milestone_row_names: JSON.stringify(rowNames),
+      });
+      await refetchSchedule();
+    },
+    [projectId, resetMilestonesToFormulaCall, refetchSchedule]
   );
 
   const projectStartDate = useMemo(() => parseDate(projectData?.project_start_date), [projectData]);
@@ -334,6 +350,7 @@ export const useProjectScheduler = (projectId: string | null | undefined): UsePr
     refetchSchedule,
     updateMilestoneDates,
     resetMilestoneDates,
+    resetMilestonesToFormula,
     scheduleDoc,
   };
 };

--- a/nirmaan_stack/api/milestone/project_schedule.py
+++ b/nirmaan_stack/api/milestone/project_schedule.py
@@ -292,18 +292,9 @@ def update_milestone_dates(project_id: str, milestone_row_name: str,
 	return sched.as_dict()
 
 
-@frappe.whitelist(methods=["POST"])
-def reset_milestone_dates(project_id: str, milestone_row_name: str):
-	"""Revert a row's dates back to the formula-derived values and clear the
-	manual-override flags so future window-change recomputes will keep it in
-	sync."""
-	if not project_id or not milestone_row_name:
-		frappe.throw("project_id and milestone_row_name are required")
-
-	sched = frappe.get_doc("Project Schedule", project_id)
-	row = _find_row(sched, milestone_row_name)
-
-	project_doc = frappe.get_doc("Projects", project_id)
+def _reset_row_to_formula(row, project_doc):
+	"""Revert a single milestone row to its formula-derived dates and clear the
+	manual-override flags. Mutates `row` in place; caller owns the save/commit."""
 	master = frappe.get_all(
 		"Work Milestones",
 		filters={
@@ -323,6 +314,49 @@ def reset_milestone_dates(project_id: str, milestone_row_name: str):
 		row.end_date = None
 	row.changed_by_user = 0
 	row.edited_by_user = None
+
+
+@frappe.whitelist(methods=["POST"])
+def reset_milestone_dates(project_id: str, milestone_row_name: str):
+	"""Revert a row's dates back to the formula-derived values and clear the
+	manual-override flags so future window-change recomputes will keep it in
+	sync."""
+	if not project_id or not milestone_row_name:
+		frappe.throw("project_id and milestone_row_name are required")
+
+	sched = frappe.get_doc("Project Schedule", project_id)
+	row = _find_row(sched, milestone_row_name)
+
+	project_doc = frappe.get_doc("Projects", project_id)
+	_reset_row_to_formula(row, project_doc)
+	sched.save(ignore_permissions=False)
+	frappe.db.commit()
+	return sched.as_dict()
+
+
+@frappe.whitelist(methods=["POST"])
+def reset_milestones_to_formula(project_id: str, milestone_row_names):
+	"""Bulk-reset several manually-overridden milestone rows back to their
+	formula-derived dates in a single save. Used by the Edit Project Dates
+	dialog when the user opts to recompute selected manual overrides against the
+	new project window. Unlisted rows are left untouched.
+
+	`milestone_row_names` may be a JSON-encoded list (when posted over the wire)
+	or an already-decoded list."""
+	if not project_id:
+		frappe.throw("project_id is required")
+
+	if isinstance(milestone_row_names, str):
+		milestone_row_names = frappe.parse_json(milestone_row_names) or []
+	row_names = {n for n in (milestone_row_names or []) if n}
+	if not row_names:
+		return frappe.get_doc("Project Schedule", project_id).as_dict()
+
+	sched = frappe.get_doc("Project Schedule", project_id)
+	project_doc = frappe.get_doc("Projects", project_id)
+	for row in sched.milestones:
+		if row.name in row_names:
+			_reset_row_to_formula(row, project_doc)
 	sched.save(ignore_permissions=False)
 	frappe.db.commit()
 	return sched.as_dict()

--- a/nirmaan_stack/api/milestone/test_project_schedule.py
+++ b/nirmaan_stack/api/milestone/test_project_schedule.py
@@ -1,0 +1,338 @@
+# Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+"""Tests for the Project Schedule milestone-date logic.
+
+Two layers:
+
+1. TestComputeMilestoneDates / TestFormulaParity — PURE functions, no Frappe
+   site needed. They lock down `_compute_milestone_dates` (the formula the
+   backend SAVES) and prove it stays in lock-step with the frontend preview
+   (`projectFormulaWindow` in ProjectScheduler.tsx), including the short-window
+   clamping. Run inside the bench venv:
+       python -m unittest nirmaan_stack.api.milestone.test_project_schedule
+
+2. TestSelectiveRecompute — DB-backed FrappeTestCase for the new
+   `reset_milestones_to_formula` endpoint and the freeze/recompute contract.
+   Run with:
+       bench --site localhost run-tests --module \
+         nirmaan_stack.api.milestone.test_project_schedule
+"""
+
+import unittest
+from datetime import date, timedelta
+
+from nirmaan_stack.api.milestone.project_schedule import _compute_milestone_dates
+
+
+# ── Test helpers ────────────────────────────────────────────────────────────
+
+def _master(weeks):
+	"""Build a Work-Milestones-shaped dict from a 9-length list of week %s."""
+	assert len(weeks) == 9
+	return {f"week_{i + 1}": weeks[i] for i in range(9)}
+
+
+def _round_half_up(x):
+	"""JavaScript Math.round semantics: ties round toward +Infinity.
+	(Python's built-in round() is banker's rounding — half-to-even.)"""
+	import math
+	return math.floor(x + 0.5)
+
+
+def _clamped_formula(round_fn, project_start, project_end, weeks):
+	"""Faithful re-implementation of the milestone-date formula, parameterised
+	by the rounding function. With round_fn=round this mirrors the backend
+	`_compute_milestone_dates`; with round_fn=_round_half_up it mirrors the
+	frontend `projectFormulaWindow` (JS Math.round). Used by the parity tests."""
+	duration_days = (project_end - project_start).days + 1
+	if duration_days <= 0:
+		return None, None
+	week_slot_days = duration_days / 9
+
+	first_week_idx = -1
+	last_non_zero_idx = -1
+	completion_week_idx = -1
+	for i in range(9):
+		if weeks[i] > 0:
+			if first_week_idx == -1:
+				first_week_idx = i
+			last_non_zero_idx = i
+		if completion_week_idx == -1 and weeks[i] >= 100:
+			completion_week_idx = i
+	last_week_idx = completion_week_idx if completion_week_idx != -1 else last_non_zero_idx
+	if first_week_idx == -1:
+		return None, None
+
+	start_offset = round_fn(first_week_idx * week_slot_days)
+	end_offset = round_fn((last_week_idx + 1) * week_slot_days) - 1
+	last_offset = max(0, duration_days - 1)
+	start_offset = max(0, min(start_offset, last_offset))
+	end_offset = max(0, min(end_offset, last_offset))
+	end_offset = max(end_offset, start_offset)
+	return (
+		project_start + timedelta(days=start_offset),
+		project_start + timedelta(days=end_offset),
+	)
+
+
+# A spread of week-distribution patterns covering the interesting shapes.
+# week_1..week_9 are CUMULATIVE planned %, so each pattern is monotonically
+# non-decreasing (real data never drops back — once a week is 30, later weeks
+# are >= 30) and, once it hits 100, stays at 100.
+WEEK_PATTERNS = [
+	[0, 0, 0, 0, 0, 0, 0, 0, 0],              # nothing scheduled
+	[100, 100, 100, 100, 100, 100, 100, 100, 100],  # done in week 1, stays 100
+	[50, 100, 100, 100, 100, 100, 100, 100, 100],   # completes week 2
+	[0, 0, 0, 0, 20, 40, 60, 80, 100],        # starts week 5, finishes week 9
+	[0, 0, 0, 0, 0, 0, 0, 0, 100],            # starts and completes only in week 9
+	[10, 20, 30, 40, 50, 60, 70, 80, 100],    # ramps across the full span
+	[0, 0, 0, 30, 60, 90, 100, 100, 100],     # starts week 4, completes week 7
+	[0, 0, 30, 60, 80, 90, 95, 98, 99],       # starts week 3, never reaches 100
+	                                          # (defensive last-non-zero branch)
+]
+
+
+# ── 1. Pure formula tests ────────────────────────────────────────────────────
+
+class TestComputeMilestoneDates(unittest.TestCase):
+	def test_standard_window_first_two_weeks(self):
+		start = date(2026, 1, 1)
+		end = date(2026, 3, 4)  # 63 days → week_slot_days = 7
+		# cumulative: 50% by wk1, 100% by wk2, stays 100 thereafter
+		s, e = _compute_milestone_dates(start, end, _master([50, 100, 100, 100, 100, 100, 100, 100, 100]))
+		self.assertEqual(s, date(2026, 1, 1))   # offset 0
+		self.assertEqual(e, date(2026, 1, 14))  # round(2*7)-1 = 13 (completes wk2)
+
+	def test_first_week_only(self):
+		start = date(2026, 1, 1)
+		end = date(2026, 3, 4)
+		# completes in week 1, cumulative stays at 100
+		s, e = _compute_milestone_dates(start, end, _master([100, 100, 100, 100, 100, 100, 100, 100, 100]))
+		self.assertEqual(s, date(2026, 1, 1))
+		self.assertEqual(e, date(2026, 1, 7))   # round(1*7)-1 = 6
+
+	def test_mid_span_week4_to_week7(self):
+		start = date(2026, 1, 1)
+		end = date(2026, 3, 4)  # 63 days → week_slot_days = 7
+		# cumulative: starts week 4 (>0), hits 100 in week 7 → end is week 7
+		s, e = _compute_milestone_dates(start, end, _master([0, 0, 0, 30, 60, 90, 100, 100, 100]))
+		self.assertEqual(s, date(2026, 1, 22))  # round(3*7) = 21 → Jan 22
+		self.assertEqual(e, date(2026, 2, 18))  # round(7*7) - 1 = 48 → Feb 18
+
+	def test_no_scheduled_weeks_returns_none(self):
+		s, e = _compute_milestone_dates(date(2026, 1, 1), date(2026, 3, 4),
+		                                _master([0] * 9))
+		self.assertIsNone(s)
+		self.assertIsNone(e)
+
+	def test_invalid_window_returns_none(self):
+		# end before start → non-positive duration
+		s, e = _compute_milestone_dates(date(2026, 3, 4), date(2026, 1, 1),
+		                                _master([100, 0, 0, 0, 0, 0, 0, 0, 0]))
+		self.assertIsNone(s)
+		self.assertIsNone(e)
+
+	def test_missing_dates_return_none(self):
+		self.assertEqual(
+			_compute_milestone_dates(None, date(2026, 3, 4), _master([100] + [0] * 8)),
+			(None, None),
+		)
+		self.assertEqual(
+			_compute_milestone_dates(date(2026, 1, 1), None, _master([100] + [0] * 8)),
+			(None, None),
+		)
+
+	def test_short_window_clamps_into_range(self):
+		# 5-day project: week_slot_days = 0.555…; a week-9 milestone must still
+		# land *inside* the window, not past the end.
+		start = date(2026, 1, 1)
+		end = date(2026, 1, 5)  # 5 days, last valid offset = 4
+		s, e = _compute_milestone_dates(start, end, _master([0] * 8 + [100]))
+		self.assertGreaterEqual(s, start)
+		self.assertLessEqual(e, end)
+		self.assertGreaterEqual(e, s)  # never inverted
+
+	def test_short_window_never_inverts(self):
+		# 3-day project where the raw offsets would put end (0) before start (1);
+		# clamping must collapse it to a single day, not invert.
+		start = date(2026, 1, 1)
+		end = date(2026, 1, 3)  # 3 days
+		# starts and completes in week 3, cumulative stays 100 after
+		s, e = _compute_milestone_dates(start, end, _master([0, 0, 100, 100, 100, 100, 100, 100, 100]))
+		self.assertIsNotNone(s)
+		self.assertGreaterEqual(e, s)
+		self.assertLessEqual(e, end)
+
+
+# ── 2. Frontend ↔ backend parity tests ───────────────────────────────────────
+
+class TestFormulaParity(unittest.TestCase):
+	"""Guards the claim: the Step-2 preview (`projectFormulaWindow`) equals the
+	saved value (`_compute_milestone_dates`)."""
+
+	def test_backend_matches_reference_formula_exactly(self):
+		# The backend uses Python round(); _clamped_formula(round, ...) is the
+		# same algorithm. Any divergence means the backend code drifted.
+		start = date(2026, 1, 1)
+		for span in range(1, 200):                      # 1-day … ~28-week windows
+			end = start + timedelta(days=span - 1)
+			for weeks in WEEK_PATTERNS:
+				expected = _clamped_formula(round, start, end, weeks)
+				actual = _compute_milestone_dates(start, end, _master(weeks))
+				self.assertEqual(actual, expected, msg=f"span={span} weeks={weeks}")
+
+	def test_js_preview_matches_backend_on_integer_slots(self):
+		# When week_slot_days is a whole number (duration multiple of 9) there is
+		# no rounding at all, so the JS preview (half-up) and the backend MUST be
+		# byte-for-byte identical — including the previously-broken short windows.
+		start = date(2026, 1, 1)
+		for span in (9, 18, 27, 45, 63, 90, 126):
+			end = start + timedelta(days=span - 1)
+			for weeks in WEEK_PATTERNS:
+				js = _clamped_formula(_round_half_up, start, end, weeks)
+				backend = _compute_milestone_dates(start, end, _master(weeks))
+				self.assertEqual(js, backend, msg=f"span={span} weeks={weeks}")
+
+	def test_js_preview_within_one_day_everywhere(self):
+		# For arbitrary windows the only residual gap between JS (half-up) and
+		# backend (banker's) rounding is a tie at exactly .5 → at most 1 day, and
+		# the clamping keeps both in-window and non-inverted.
+		start = date(2026, 1, 1)
+		for span in range(1, 200):
+			end = start + timedelta(days=span - 1)
+			for weeks in WEEK_PATTERNS:
+				js = _clamped_formula(_round_half_up, start, end, weeks)
+				backend = _compute_milestone_dates(start, end, _master(weeks))
+				if backend == (None, None):
+					self.assertEqual(js, (None, None))
+					continue
+				self.assertLessEqual(abs((js[0] - backend[0]).days), 1)
+				self.assertLessEqual(abs((js[1] - backend[1]).days), 1)
+				self.assertGreaterEqual(js[1], js[0])  # preview never inverts
+
+
+# ── 3. DB-backed endpoint / contract tests ───────────────────────────────────
+
+try:
+	from frappe.tests.utils import FrappeTestCase
+	import frappe
+	_HAS_FRAPPE_SITE = True
+except Exception:  # pragma: no cover - import guard for venv-only runs
+	_HAS_FRAPPE_SITE = False
+
+
+if _HAS_FRAPPE_SITE:
+
+	class TestSelectiveRecompute(FrappeTestCase):
+		"""Exercises the freeze/recompute contract through the real doctypes.
+
+		Seeds a throwaway Work Header + two Work Milestones + a Project, lets the
+		Projects hook build the schedule, then drives update / bulk-reset and
+		asserts which rows move and which stay frozen."""
+
+		HEADER = "ZZ Test Schedule Header"
+		MS_A = "ZZ Test Milestone A"
+		MS_B = "ZZ Test Milestone B"
+
+		@classmethod
+		def setUpClass(cls):
+			super().setUpClass()
+			from nirmaan_stack.api.milestone.project_schedule import ensure_project_schedule
+
+			if not frappe.db.exists("Work Headers", cls.HEADER):
+				frappe.get_doc({
+					"doctype": "Work Headers",
+					"work_header_name": cls.HEADER,
+				}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+			for ms, order in ((cls.MS_A, 1), (cls.MS_B, 2)):
+				if not frappe.db.exists("Work Milestones", {"work_milestone_name": ms}):
+					frappe.get_doc({
+						"doctype": "Work Milestones",
+						"work_milestone_name": ms,
+						"work_header": cls.HEADER,
+						"work_milestone_order": order,
+						"weightage": 50,
+						# MS_A finishes week 1, MS_B finishes week 9
+						"week_1": 100 if ms == cls.MS_A else 0,
+						"week_9": 100 if ms == cls.MS_B else 0,
+					}).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+			proj = frappe.get_doc({
+				"doctype": "Projects",
+				"project_name": "ZZ Test Schedule Project",
+				"project_start_date": "2026-01-01 00:00:00",
+				"project_end_date": "2026-03-04 00:00:00",  # 63-day window
+				# generate_pwm (after_insert hook) reads project_scopes["scopes"];
+				# an empty list keeps the hook a no-op for this fixture.
+				"project_scopes": {"scopes": []},
+				"project_work_header_entries": [
+					{"project_work_header_name": cls.HEADER, "enabled": 1},
+				],
+			})
+			proj.flags.ignore_mandatory = True
+			proj.insert(ignore_permissions=True)
+			cls.project_id = proj.name
+			ensure_project_schedule(cls.project_id)
+			frappe.db.commit()
+
+		def _row(self, milestone_name):
+			sched = frappe.get_doc("Project Schedule", self.project_id)
+			return next(r for r in sched.milestones if r.work_milestone == milestone_name)
+
+		def test_manual_override_freezes_then_bulk_reset_recomputes(self):
+			from nirmaan_stack.api.milestone.project_schedule import (
+				update_milestone_dates,
+				reset_milestones_to_formula,
+			)
+
+			# 1) Manually override MS_A — it should be flagged frozen.
+			row_a = self._row(self.MS_A)
+			update_milestone_dates(self.project_id, row_a.name, "2026-02-10", "2026-02-20")
+			row_a = self._row(self.MS_A)
+			self.assertTrue(row_a.changed_by_user)
+			self.assertEqual(str(row_a.start_date), "2026-02-10")
+
+			# 2) Bulk-reset MS_A back to the formula — flags cleared, dates back.
+			reset_milestones_to_formula(self.project_id, [row_a.name])
+			row_a = self._row(self.MS_A)
+			self.assertFalse(row_a.changed_by_user)
+			self.assertIsNone(row_a.edited_by_user)
+			# Formula for week-1 milestone on a 63-day window = Jan 1 → Jan 7.
+			self.assertEqual(str(row_a.start_date), "2026-01-01")
+			self.assertEqual(str(row_a.end_date), "2026-01-07")
+
+		def test_bulk_reset_leaves_unlisted_manual_rows_frozen(self):
+			from nirmaan_stack.api.milestone.project_schedule import (
+				update_milestone_dates,
+				reset_milestones_to_formula,
+			)
+
+			# Freeze BOTH milestones.
+			row_a = self._row(self.MS_A)
+			row_b = self._row(self.MS_B)
+			update_milestone_dates(self.project_id, row_a.name, "2026-02-01", "2026-02-05")
+			update_milestone_dates(self.project_id, row_b.name, "2026-02-06", "2026-02-10")
+
+			# Reset only MS_A; MS_B must keep its custom dates + frozen flag.
+			reset_milestones_to_formula(self.project_id, [row_a.name])
+			row_b = self._row(self.MS_B)
+			self.assertTrue(row_b.changed_by_user)
+			self.assertEqual(str(row_b.start_date), "2026-02-06")
+			self.assertEqual(str(row_b.end_date), "2026-02-10")
+
+		def test_bulk_reset_empty_list_is_noop(self):
+			from nirmaan_stack.api.milestone.project_schedule import (
+				update_milestone_dates,
+				reset_milestones_to_formula,
+			)
+			row_a = self._row(self.MS_A)
+			update_milestone_dates(self.project_id, row_a.name, "2026-02-01", "2026-02-05")
+			reset_milestones_to_formula(self.project_id, [])
+			row_a = self._row(self.MS_A)
+			self.assertTrue(row_a.changed_by_user)  # untouched
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Adds two features to the Project Schedule tab:

1. CSV export — "Download CSV" button next to the PDF export. Matches the PDF (drops report-disabled milestones and empty groups), generated in-browser via papaparse.

2. Selective milestone recompute — "Edit Project Dates" is now a two-step dialog. Step 2 lets you tick which manually-edited milestones should snap to the new project window; unticked rows keep their custom dates. A green "⇒ new" preview shows projected dates before saving.

Backend: new reset_milestones_to_formula endpoint; project dates save first, then only ticked manual rows are reset. Includes 14 tests (test_project_schedule.py) covering the formula, short-window clamping, and JS/Python parity.
