### PR TITLE
Surface billing status across PO & DC/MIR screens;…

### DIFF
--- a/frontend/src/components/helpers/CriticalPOCell.tsx
+++ b/frontend/src/components/helpers/CriticalPOCell.tsx
@@ -9,7 +9,7 @@ export const criticalPOLabel = (t: { item_name: string; sub_category?: string })
 
 export const CriticalPOCell = ({ tasks }: { tasks: CriticalPOTask[] }) => {
     if (!tasks || tasks.length === 0) {
-        return <span className="text-gray-300 text-xs">—</span>;
+        return <span className="text-gray-300 text-xs pl-5">—</span>;
     }
 
     return (

--- a/frontend/src/pages/DeliveryChallansAndMirs/components/UploadDCMIRDialog.tsx
+++ b/frontend/src/pages/DeliveryChallansAndMirs/components/UploadDCMIRDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
@@ -28,7 +29,7 @@ import { Label } from "@/components/ui/label";
 import { CustomAttachment } from "@/components/helpers/CustomAttachment";
 import { useToast } from "@/components/ui/use-toast";
 import { TailSpin } from "react-loader-spinner";
-import { FileText } from "lucide-react";
+import { FileText, Info } from "lucide-react";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radiogroup";
 import SITEURL from "@/constants/siteURL";
 
@@ -358,13 +359,23 @@ export const UploadDCMIRDialog = ({
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* Section 1: Document */}
             {mode === "create" && (
-              <CustomAttachment
-                selectedFile={selectedFile}
-                onFileSelect={setSelectedFile}
-                label={`Select ${typeLabel} File`}
-                maxFileSize={20 * 1024 * 1024}
-                acceptedTypes={["application/pdf", "image/*"]}
-              />
+              <div className="space-y-1.5">
+                <Label>
+                  {typeLabel} File <span className="text-red-500">*</span>
+                </Label>
+                <CustomAttachment
+                  selectedFile={selectedFile}
+                  onFileSelect={setSelectedFile}
+                  label={`Select ${typeLabel} File`}
+                  maxFileSize={20 * 1024 * 1024}
+                  acceptedTypes={["application/pdf", "image/*"]}
+                />
+                {!selectedFile && (
+                  <p className="text-xs text-muted-foreground">
+                    A {typeLabel} file attachment is required to upload.
+                  </p>
+                )}
+              </div>
             )}
 
             {mode === "edit" && existingDoc?.attachment_url && (
@@ -512,11 +523,22 @@ export const UploadDCMIRDialog = ({
             {/* Section 2: Items */}
             {(dcType === "Delivery Challan" || mirQuantityMode !== undefined) && (
               <div>
-                <p className="text-sm text-muted-foreground mb-2">
-                  {mirQuantityMode === "no"
-                    ? "Select items included in this MIR"
-                    : "Select items and enter delivered/inspected quantities"}
-                </p>
+                <div className="flex items-center justify-between gap-3 mb-2">
+                  <p className="text-sm text-muted-foreground">
+                    {mirQuantityMode === "no"
+                      ? "Select items included in this MIR"
+                      : "Select items and enter delivered/inspected quantities"}
+                  </p>
+                  {!isITM && (
+                    <Badge
+                      variant="outline"
+                      className="shrink-0 gap-1 border-primary/30 bg-primary/5 text-primary text-xs font-medium"
+                    >
+                      <Info className="h-3 w-3" aria-hidden="true" />
+                      Billable items only
+                    </Badge>
+                  )}
+                </div>
                 <DCMIRItemSelector
                   form={form}
                   showQuantity={dcType === "Delivery Challan" || mirQuantityMode === "yes"}

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
@@ -16,6 +16,7 @@ import { useUsersList } from "@/pages/ProcurementRequests/ApproveNewPR/hooks/use
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 // Types
 import {
@@ -142,6 +143,10 @@ export const DocumentAttachments = <T extends DocumentType>({
       unit: item.unit,
       category: item.category,
       make: item.make,
+      // Required: UploadDCMIRDialog filters PO items to billing_status === "Billable".
+      // Omitting this made every item fail the filter, so DCs uploaded from the PO
+      // detail page were saved with zero items (the hub mapping already includes it).
+      billing_status: item.billing_status,
     }));
   }, [docType, documentData]);
 
@@ -406,6 +411,11 @@ export const DocumentAttachments = <T extends DocumentType>({
     documentStatus &&
     ["Delivered", "Partially Delivered"].includes(documentStatus);
 
+  // A DC/MIR cannot be filed against a Non-Billable PO (backend rejects it),
+  // so the upload buttons are disabled with an explanatory tooltip.
+  const isPONonBillable =
+    isPO && (documentData as ProcurementOrder)?.billing_status === "Non-Billable";
+
   const handleInvoiceDialogInputChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -623,28 +633,50 @@ export const DocumentAttachments = <T extends DocumentType>({
                   </Badge>
                 </div>
                 {isPO && showDcTable && !isEstimatesExecutive && (
-                  <div className="flex gap-2 items-center">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleOpenPDDUpload("DC")}
-                      className="text-primary border-primary hover:bg-primary/5"
-                      aria-label="Upload Delivery Challan"
-                    >
-                      <CirclePlus className="h-4 w-4 mr-1" aria-hidden="true" />
-                      Upload DC
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => handleOpenPDDUpload("MIR")}
-                      className="text-primary border-primary hover:bg-primary/5"
-                      aria-label="Upload Material Inspection Report"
-                    >
-                      <Upload className="h-4 w-4 mr-1" aria-hidden="true" />
-                      Upload MIR
-                    </Button>
-                  </div>
+                  <TooltipProvider>
+                    <div className="flex gap-2 items-center">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span tabIndex={0}>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleOpenPDDUpload("DC")}
+                              className="text-primary border-primary hover:bg-primary/5"
+                              aria-label="Upload Delivery Challan"
+                              disabled={isPONonBillable}
+                            >
+                              <CirclePlus className="h-4 w-4 mr-1" aria-hidden="true" />
+                              Upload DC
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        {isPONonBillable && (
+                          <TooltipContent>This PO is Non-Billable</TooltipContent>
+                        )}
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span tabIndex={0}>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleOpenPDDUpload("MIR")}
+                              className="text-primary border-primary hover:bg-primary/5"
+                              aria-label="Upload Material Inspection Report"
+                              disabled={isPONonBillable}
+                            >
+                              <Upload className="h-4 w-4 mr-1" aria-hidden="true" />
+                              Upload MIR
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        {isPONonBillable && (
+                          <TooltipContent>This PO is Non-Billable</TooltipContent>
+                        )}
+                      </Tooltip>
+                    </div>
+                  </TooltipProvider>
                 )}
               </CardTitle>
             </CardHeader>

--- a/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
@@ -1205,6 +1205,7 @@ export const PurchaseOrder = ({
                     <th className="text-left pl-2 py-3">Item Name</th>
                     <th className="text-center py-3">Unit</th>
                     <th className="text-center py-3">Qty</th>
+                    <th className="text-center py-3">Billing</th>
                     {["Partially Delivered", "Delivered"].includes(PO?.status) && (
                       <th className="text-center py-3">Delivered Qty</th>
                     )}
@@ -1232,6 +1233,13 @@ export const PurchaseOrder = ({
                       </td>
                       <td className="text-center py-3 align-top">{item.unit}</td>
                       <td className="text-center py-3 align-top">{item.quantity}</td>
+                      <td className="text-center py-3 align-top">
+                        {item?.billing_status === "Non-Billable" ? (
+                          <Badge variant="outline" className="bg-gray-100 text-gray-600 border-gray-300">Non-Billable</Badge>
+                        ) : (
+                          <Badge variant="outline" className="bg-green-100 text-green-700 border-green-300">Billable</Badge>
+                        )}
+                      </td>
                       {["Partially Delivered", "Delivered"].includes(PO?.status) && (
                         <td className={`text-center py-3 align-top ${item?.received_quantity === item?.quantity ? "text-green-600" : "text-red-700"
                           }`}>
@@ -1274,6 +1282,11 @@ export const PurchaseOrder = ({
                       </div>
                     )}
                   </div>
+                  {item?.billing_status === "Non-Billable" ? (
+                    <Badge variant="outline" className="shrink-0 bg-gray-100 text-gray-600 border-gray-300">Non-Billable</Badge>
+                  ) : (
+                    <Badge variant="outline" className="shrink-0 bg-green-100 text-green-700 border-green-300">Billable</Badge>
+                  )}
                 </div>
 
                 {/* Item Details Grid */}

--- a/frontend/src/pages/ProcurementOrders/purchase-order/components/PODetails.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/components/PODetails.tsx
@@ -208,6 +208,10 @@ export const PODetails: React.FC<PODetailsProps> = ({
     dcType: "Delivery Challan" | "Material Inspection Report";
   }>({ open: false, mode: "create", dcType: "Delivery Challan" });
 
+  // A DC/MIR cannot be filed against a Non-Billable PO (backend rejects it),
+  // so the upload buttons are disabled with an explanatory tooltip.
+  const isPONonBillable = po?.billing_status === "Non-Billable";
+
   const handleOpenPDDUpload = useCallback((type: "DC" | "MIR") => {
     setPddUploadState({
       open: true,
@@ -234,6 +238,9 @@ export const PODetails: React.FC<PODetailsProps> = ({
       unit: item.unit,
       category: item.category,
       make: item.make,
+      // Required: UploadDCMIRDialog filters PO items to billing_status === "Billable".
+      // Without it every item fails the filter and the DC/MIR is saved with zero items.
+      billing_status: item.billing_status,
     }));
   }, [po?.items]);
 
@@ -660,6 +667,13 @@ export const PODetails: React.FC<PODetailsProps> = ({
                   {po?.status}
                 </Badge>
               </div>
+
+              <Separator orientation="vertical" className="h-5 hidden sm:block" />
+
+              {/* Billing */}
+              <Badge variant={po?.billing_status === "Non-Billable" ? "red" : "green"}>
+                {po?.billing_status === "Non-Billable" ? "Non-Billable" : "Billable"}
+              </Badge>
             </div>
 
             {/* Row 2: Critical PO Tag - below vendor info */}
@@ -864,17 +878,22 @@ export const PODetails: React.FC<PODetailsProps> = ({
                     ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Project Manager Profile", "Nirmaan Project Lead Profile", "Nirmaan Procurement Executive Profile"].includes(role) && (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-8 px-2.5 border-primary text-primary shrink-0"
-                            onClick={() => handleOpenPDDUpload("DC")}
-                          >
-                            <CirclePlus className="h-3.5 w-3.5 sm:mr-1.5" />
-                            <span className="hidden sm:inline text-xs">Upload DC</span>
-                          </Button>
+                          <span tabIndex={0} className="shrink-0">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-8 px-2.5 border-primary text-primary shrink-0"
+                              onClick={() => handleOpenPDDUpload("DC")}
+                              disabled={isPONonBillable}
+                            >
+                              <CirclePlus className="h-3.5 w-3.5 sm:mr-1.5" />
+                              <span className="hidden sm:inline text-xs">Upload DC</span>
+                            </Button>
+                          </span>
                         </TooltipTrigger>
-                        <TooltipContent className="sm:hidden">Upload DC</TooltipContent>
+                        <TooltipContent className={isPONonBillable ? "" : "sm:hidden"}>
+                          {isPONonBillable ? "This PO is Non-Billable" : "Upload DC"}
+                        </TooltipContent>
                       </Tooltip>
                     )}
 
@@ -883,17 +902,22 @@ export const PODetails: React.FC<PODetailsProps> = ({
                     ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Project Manager Profile", "Nirmaan Project Lead Profile", "Nirmaan Procurement Executive Profile"].includes(role) && (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-8 px-2.5 border-primary text-primary shrink-0"
-                            onClick={() => handleOpenPDDUpload("MIR")}
-                          >
-                            <Upload className="h-3.5 w-3.5 sm:mr-1.5" />
-                            <span className="hidden sm:inline text-xs">Upload MIR</span>
-                          </Button>
+                          <span tabIndex={0} className="shrink-0">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="h-8 px-2.5 border-primary text-primary shrink-0"
+                              onClick={() => handleOpenPDDUpload("MIR")}
+                              disabled={isPONonBillable}
+                            >
+                              <Upload className="h-3.5 w-3.5 sm:mr-1.5" />
+                              <span className="hidden sm:inline text-xs">Upload MIR</span>
+                            </Button>
+                          </span>
                         </TooltipTrigger>
-                        <TooltipContent className="sm:hidden">Upload MIR</TooltipContent>
+                        <TooltipContent className={isPONonBillable ? "" : "sm:hidden"}>
+                          {isPONonBillable ? "This PO is Non-Billable" : "Upload MIR"}
+                        </TooltipContent>
                       </Tooltip>
                     )}
 

--- a/frontend/src/pages/projects/components/ProjectPOSummaryTable.tsx
+++ b/frontend/src/pages/projects/components/ProjectPOSummaryTable.tsx
@@ -81,6 +81,7 @@ export const PO_SUMMARY_LIST_FIELDS_TO_FETCH: (
   "vendor_name",
   "procurement_request",
   "status",
+  "billing_status",
   "po_amount_delivered",
   // --- NEW FIELD ---
   "payment_type",
@@ -452,7 +453,7 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
       {
         accessorKey: "creation",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="PO Creation Date" />
+          <DataTableColumnHeader column={column} title="PO Creation Date" className="whitespace-nowrap" />
         ),
         cell: ({ row }) => (
           <div className="font-medium whitespace-nowrap">
@@ -467,7 +468,7 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
       {
         id: "critical_po",
         header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Critical PO" />
+          <DataTableColumnHeader column={column} title="Critical PO" className="whitespace-nowrap pl-5" />
         ),
         cell: ({ row }) => {
           const tasks = criticalTasksByPO.get(row.original.name) || [];
@@ -525,6 +526,26 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
           exportValue: (row: ProcurementOrder) => {
             return row.status;
           },
+        },
+      },
+      {
+        accessorKey: "billing_status",
+        header: ({ column }) => (
+          <DataTableColumnHeader column={column} title="Billing" />
+        ),
+        cell: ({ row }) => (
+          <Badge
+            variant={row.original.billing_status === "Non-Billable" ? "red" : "green"}
+          >
+            {row.original.billing_status === "Non-Billable" ? "Non-Billable" : "Billable"}
+          </Badge>
+        ),
+        enableColumnFilter: true,
+        size: 130,
+        meta: {
+          exportHeaderName: "Billing",
+          exportValue: (row: ProcurementOrder) =>
+            row.billing_status === "Non-Billable" ? "Non-Billable" : "Billable",
         },
       },
       {
@@ -802,6 +823,19 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
     enabled: true,
   });
 
+  const {
+    facetOptions: billingFacetOptions,
+    isLoading: isBillingFacetLoading,
+  } = useFacetValues({
+    doctype: DOCTYPE,
+    field: "billing_status",
+    currentFilters: columnFilters,
+    searchTerm,
+    selectedSearchField,
+    additionalFilters: dynamicFilters,
+    enabled: true,
+  });
+
   const facetFilterOptions = useMemo(
     () => ({
       vendor: {
@@ -824,6 +858,11 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
         options: paymentTypeFacetOptions,
         isLoading: isPaymentTypeFacetLoading,
       },
+      billing_status: {
+        title: "Billing",
+        options: billingFacetOptions,
+        isLoading: isBillingFacetLoading,
+      },
     }),
     [
       statusFacetOptions,
@@ -834,6 +873,8 @@ export const ProjectPOSummaryTable: React.FC<ProjectPOSummaryTableProps> = ({
       isOwnerFacetLoading,
       paymentTypeFacetOptions,
       isPaymentTypeFacetLoading,
+      billingFacetOptions,
+      isBillingFacetLoading,
     ]
   );
 

--- a/frontend/src/pages/reports/components/DNDCQuantityReport.tsx
+++ b/frontend/src/pages/reports/components/DNDCQuantityReport.tsx
@@ -134,6 +134,59 @@ function getStatusLabel(status: ReconcileStatus): string {
   }
 }
 
+// A blank billing_status renders as Billable (matches the rest of the app).
+function getBillingLabel(billingStatus: string): "Billable" | "Non-Billable" {
+  return billingStatus === "Non-Billable" ? "Non-Billable" : "Billable";
+}
+
+function getBillingBadge(billingStatus: string) {
+  return billingStatus === "Non-Billable" ? (
+    <Badge className="bg-red-100 text-red-700 border-red-300" variant="outline">
+      Non-Billable
+    </Badge>
+  ) : (
+    <Badge className="bg-green-100 text-green-700 border-green-300" variant="outline">
+      Billable
+    </Badge>
+  );
+}
+
+// Small billing badge for the per-item rows (the parent PO row keeps the regular
+// getBillingBadge). Billable = ACTIVE (clear green); Non-Billable = DISABLED
+// (muted grey, faded) so the two states are unmistakably different.
+function getItemBillingBadge(billingStatus: string) {
+  const base = "text-[10px] leading-none px-1.5 py-0.5 font-normal";
+  return billingStatus === "Non-Billable" ? (
+    <Badge
+      variant="outline"
+      className={`${base} bg-gray-100 text-gray-400 border-gray-200 opacity-60 cursor-not-allowed`}
+    >
+      Non-Billable
+    </Badge>
+  ) : (
+    <Badge
+      variant="outline"
+      className={`${base} bg-green-100 text-green-700 border-green-300`}
+    >
+      Billable
+    </Badge>
+  );
+}
+
+// Non-Billable POs are out of scope for DN/DC reconciliation (DC/MIR can't be
+// filed against them), so their Status cell shows a disabled neutral badge
+// instead of a misleading reconcile status.
+function getNonBillableStatusBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="bg-gray-100 text-gray-400 border-gray-300 opacity-70 cursor-not-allowed"
+    >
+      Non-Billable
+    </Badge>
+  );
+}
+
 // =================================================================================
 // 2. PROJECT TEAM STRIP
 // =================================================================================
@@ -334,6 +387,9 @@ function DNDCQuantityReportContent({
 
   // --- Faceted filters ---
   const [vendorFilter, setVendorFilter] = useState<Set<string>>(new Set());
+  const [billingFilter, setBillingFilter] = useState<Set<string>>(
+    new Set(["Billable"])
+  );
   const [statusFilter, setStatusFilter] = useState<Set<string>>(
     new Set(["mismatch", "no_dc_update", "pending_dn"])
   );
@@ -376,6 +432,14 @@ function DNDCQuantityReportContent({
       .map((s) => ({ label: getStatusLabel(s), value: s }));
   }, [poRows]);
 
+  const billingOptions = useMemo(() => {
+    if (!poRows) return [];
+    const unique = new Set(poRows.map((po) => getBillingLabel(po.billingStatus)));
+    return Array.from(unique)
+      .sort()
+      .map((b) => ({ label: b, value: b }));
+  }, [poRows]);
+
   // --- Search, Filter & Sort Pipeline ---
   const filteredPOs = useMemo(() => {
     if (!poRows) return [];
@@ -396,6 +460,13 @@ function DNDCQuantityReportContent({
       result = result.filter((po) => vendorFilter.has(po.vendorName));
     }
 
+    // Billing status faceted filter
+    if (billingFilter.size > 0) {
+      result = result.filter((po) =>
+        billingFilter.has(getBillingLabel(po.billingStatus))
+      );
+    }
+
     // Status faceted filter
     if (statusFilter.size > 0) {
       result = result.filter((po) =>
@@ -412,7 +483,7 @@ function DNDCQuantityReportContent({
     }
 
     return result;
-  }, [poRows, searchTerm, vendorFilter, statusFilter, sortKey, sortDirection]);
+  }, [poRows, searchTerm, vendorFilter, billingFilter, statusFilter, sortKey, sortDirection]);
 
   // --- Flat rows for virtualization ---
   const flatRows = useMemo(() => {
@@ -467,6 +538,7 @@ function DNDCQuantityReportContent({
     const headers = [
       "PO Number",
       "Vendor",
+      "PO Billing Status",
       "Category",
       "Item Name",
       "Unit",
@@ -483,6 +555,7 @@ function DNDCQuantityReportContent({
         rows.push({
           "PO Number": po.poNumber,
           Vendor: po.vendorName,
+          "PO Billing Status": getBillingLabel(po.billingStatus),
           Category: item.category,
           "Item Name": item.itemName || "N/A",
           Unit: item.unit || "-",
@@ -618,6 +691,17 @@ function DNDCQuantityReportContent({
                   <span>Vendor</span>
                 </div>
               </TableHead>
+              <TableHead className="min-w-[130px]">
+                <div className="flex items-center gap-1">
+                  <SimpleFacetedFilter
+                    title="Billing"
+                    options={billingOptions}
+                    selectedValues={billingFilter}
+                    onSelectedValuesChange={setBillingFilter}
+                  />
+                  <span>Billing</span>
+                </div>
+              </TableHead>
               <TableHead className="min-w-[120px]">Category</TableHead>
               <TableHead className="text-center min-w-[100px]">
                 Items
@@ -662,14 +746,14 @@ function DNDCQuantityReportContent({
           <TableBody>
             {paddingTop > 0 && (
               <TableRow>
-                <td colSpan={10} style={{ height: `${paddingTop}px` }} />
+                <td colSpan={11} style={{ height: `${paddingTop}px` }} />
               </TableRow>
             )}
 
             {virtualRows.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={10}
+                  colSpan={11}
                   className="h-24 text-center text-muted-foreground"
                 >
                   {poRows && poRows.length === 0
@@ -688,7 +772,11 @@ function DNDCQuantityReportContent({
                 return (
                   <TableRow
                     key={`po-${po.poNumber}`}
-                    className={`cursor-pointer hover:opacity-80 ${getReconcileRowClasses(po.reconcileStatus)}`}
+                    className={`cursor-pointer hover:opacity-80 ${
+                      po.billingStatus === "Non-Billable"
+                        ? "bg-gray-100 border-l-4 border-l-gray-400 text-muted-foreground"
+                        : getReconcileRowClasses(po.reconcileStatus)
+                    }`}
                     onClick={() => toggleExpand(po.poNumber)}
                   >
                     <TableCell className="py-2 px-2">
@@ -709,6 +797,9 @@ function DNDCQuantityReportContent({
                     </TableCell>
                     <TableCell className="py-2 px-3 text-sm text-muted-foreground">
                       {po.vendorName}
+                    </TableCell>
+                    <TableCell className="py-2 px-3">
+                      {getBillingBadge(po.billingStatus)}
                     </TableCell>
                     <TableCell className="py-2 px-3"></TableCell>
                     <TableCell className="text-center py-2 px-3 text-sm">
@@ -742,7 +833,9 @@ function DNDCQuantityReportContent({
                       )}
                     </TableCell>
                     <TableCell className="text-center py-2 px-3">
-                      {getStatusBadge(po.reconcileStatus)}
+                      {po.billingStatus === "Non-Billable"
+                        ? getNonBillableStatusBadge()
+                        : getStatusBadge(po.reconcileStatus)}
                     </TableCell>
                   </TableRow>
                 );
@@ -754,11 +847,19 @@ function DNDCQuantityReportContent({
               return (
                 <TableRow
                   key={`item-${po.poNumber}-${row.itemIndex}`}
-                  className={getItemRowClasses(item.status)}
+                  className={
+                    po.billingStatus === "Non-Billable" ||
+                    item.billingStatus === "Non-Billable"
+                      ? "bg-gray-50 text-muted-foreground"
+                      : getItemRowClasses(item.status)
+                  }
                 >
                   <TableCell className="py-1.5 px-2"></TableCell>
                   <TableCell className="py-1.5 px-3"></TableCell>
                   <TableCell className="py-1.5 px-3"></TableCell>
+                  <TableCell className="py-1.5 px-3">
+                    {getItemBillingBadge(item.billingStatus)}
+                  </TableCell>
                   <TableCell className="py-1.5 px-3 text-xs text-muted-foreground">
                     {item.category}
                   </TableCell>
@@ -796,7 +897,10 @@ function DNDCQuantityReportContent({
                     )}
                   </TableCell>
                   <TableCell className="text-center py-1.5 px-3">
-                    {getStatusBadge(item.status)}
+                    {po.billingStatus === "Non-Billable" ||
+                    item.billingStatus === "Non-Billable"
+                      ? getNonBillableStatusBadge()
+                      : getStatusBadge(item.status)}
                   </TableCell>
                 </TableRow>
               );
@@ -804,7 +908,7 @@ function DNDCQuantityReportContent({
 
             {paddingBottom > 0 && (
               <TableRow>
-                <td colSpan={10} style={{ height: `${paddingBottom}px` }} />
+                <td colSpan={11} style={{ height: `${paddingBottom}px` }} />
               </TableRow>
             )}
           </TableBody>

--- a/frontend/src/pages/reports/hooks/useDNDCQuantityData.ts
+++ b/frontend/src/pages/reports/hooks/useDNDCQuantityData.ts
@@ -14,6 +14,7 @@ export interface DNDCItemRow {
   itemName: string;
   category: string;
   unit: string;
+  billingStatus: "Billable" | "Non-Billable" | "";
   orderedQty: number;
   dnQty: number; // from received_quantity
   dcQty: number; // sum of DC item quantities for this PO+item
@@ -24,6 +25,7 @@ export interface DNDCItemRow {
 export interface DNDCPORow {
   poNumber: string;
   vendorName: string;
+  billingStatus: "Billable" | "Non-Billable" | "";
   totalOrderedQty: number;
   totalDNQty: number;
   totalDCQty: number;
@@ -84,7 +86,7 @@ export function useDNDCQuantityData(projectId: string | null) {
   } = useFrappeGetDocList(
     "Procurement Orders",
     {
-      fields: ["name", "status"],
+      fields: ["name", "status", "billing_status"],
       filters: [
         ["project", "=", projectId],
         ["status", "in", ["Dispatched", "Partially Dispatched", "Delivered", "Partially Delivered"]],
@@ -122,6 +124,9 @@ export function useDNDCQuantityData(projectId: string | null) {
     // 2. Build valid PO set and status map
     const validPOSet = new Set<string>(poList.map((po) => po.name));
     const poStatusMap = new Map<string, string>(poList.map((po) => [po.name, po.status]));
+    const poBillingMap = new Map<string, "Billable" | "Non-Billable" | "">(
+      poList.map((po) => [po.name, (po.billing_status as "Billable" | "Non-Billable" | "") || ""])
+    );
 
     // 3. Merge po_items + custom_items
     const allItems = [
@@ -150,6 +155,7 @@ export function useDNDCQuantityData(projectId: string | null) {
             itemName: string;
             category: string;
             unit: string;
+            billingStatus: "Billable" | "Non-Billable" | "";
           }
         >;
       }
@@ -175,6 +181,7 @@ export function useDNDCQuantityData(projectId: string | null) {
           itemName: item.item_name,
           category: item.category,
           unit: item.unit,
+          billingStatus: (item.billing_status as "Billable" | "Non-Billable" | "") || "",
         });
       }
     }
@@ -259,6 +266,7 @@ export function useDNDCQuantityData(projectId: string | null) {
           itemName: itemData.itemName,
           category,
           unit: itemData.unit,
+          billingStatus: itemData.billingStatus,
           orderedQty: itemData.orderedQty,
           dnQty,
           dcQty,
@@ -279,6 +287,7 @@ export function useDNDCQuantityData(projectId: string | null) {
             itemName: dcData.itemName,
             category: dcData.category,
             unit: dcData.unit,
+            billingStatus: "Billable",
             orderedQty: 0,
             dnQty: 0,
             dcQty: dcData.qty,
@@ -318,6 +327,7 @@ export function useDNDCQuantityData(projectId: string | null) {
       resultRows.push({
         poNumber,
         vendorName: poEntry.vendorName,
+        billingStatus: poBillingMap.get(poNumber) ?? "",
         totalOrderedQty: activeItems.reduce((sum, i) => sum + i.orderedQty, 0),
         totalDNQty,
         totalDCQty,
@@ -362,6 +372,7 @@ export function useDNDCQuantityData(projectId: string | null) {
       resultRows.push({
         poNumber,
         vendorName: dcDoc?.vendor ?? "",
+        billingStatus: poBillingMap.get(poNumber) ?? "",
         totalOrderedQty: 0,
         totalDNQty: 0,
         totalDCQty: activeItems.reduce((sum, i) => sum + i.dcQty, 0),
@@ -373,16 +384,20 @@ export function useDNDCQuantityData(projectId: string | null) {
       });
     }
 
-    // 11. Summary
-    const matchedPOs = resultRows.filter((r) => r.reconcileStatus === "matched").length;
-    const mismatchPOs = resultRows.filter((r) => r.reconcileStatus === "mismatch").length;
-    const noDCUpdatePOs = resultRows.filter((r) => r.reconcileStatus === "no_dc_update").length;
-    const pendingDNPOs = resultRows.filter((r) => r.reconcileStatus === "pending_dn").length;
+    // 11. Summary — Billable POs only. A DC/MIR cannot be filed against a
+    // Non-Billable PO, so including them would inflate "No DC Update" with rows
+    // that can never be reconciled. The cards therefore count the actionable
+    // (Billable) universe, matching the table's default Billing filter.
+    const billableRows = resultRows.filter((r) => r.billingStatus !== "Non-Billable");
+    const matchedPOs = billableRows.filter((r) => r.reconcileStatus === "matched").length;
+    const mismatchPOs = billableRows.filter((r) => r.reconcileStatus === "mismatch").length;
+    const noDCUpdatePOs = billableRows.filter((r) => r.reconcileStatus === "no_dc_update").length;
+    const pendingDNPOs = billableRows.filter((r) => r.reconcileStatus === "pending_dn").length;
 
     return {
       poRows: resultRows,
       summary: {
-        totalPOs: resultRows.length,
+        totalPOs: billableRows.length,
         matchedPOs,
         mismatchPOs,
         noDCUpdatePOs,


### PR DESCRIPTION
… block DC/MIR for Non-Billable POs

Make Billable/Non-Billable status visible everywhere POs and their deliveries are managed, and stop Delivery Challans / MIRs being filed against Non-Billable POs (which the backend already rejects).

Root fix — DC/MIR saved with ZERO items: the item list passed to the upload dialog omitted `billing_status`, so the dialog's "Billable items only" filter dropped every item. The DC/MIR hub passed it; the PO detail pages did not — which is why items showed on the hub but not on PO details.

Changes:
- DocumentAttachments / PODetails: include `billing_status` in the items fed to UploadDCMIRDialog (fixes the zero-item save); disable Upload DC/MIR when the PO is Non-Billable, with an explanatory tooltip.
- UploadDCMIRDialog: mark the file attachment as required (label + hint) and flag the item picker as "billable items only".
- PODetails: show a Billable/Non-Billable badge in the PO header.
- PurchaseOrder: add a per-item Billing badge column to the PO items table.
- PO Summary table: add a sortable, faceted Billing column; fix the PO Creation Date / Critical PO header overlap (nowrap + cell alignment).
- DN > DC report: per-item Billing badges; neutralise Non-Billable rows (grey row + disabled "Non-Billable" status instead of a false "No DC Update"); add a Billing facet defaulting to Billable; and count only Billable POs in the summary cards so "No DC Update" is no longer inflated by non-reconcilable POs.