### PR TITLE
Sales user / Customer Po  / Design tracker Zone missing while Adding category

### DIFF
--- a/frontend/src/components/helpers/renderRightActionButton.tsx
+++ b/frontend/src/components/helpers/renderRightActionButton.tsx
@@ -48,6 +48,7 @@ export const RenderRightActionButton = ({
 
   const navigate = useNavigate();
   const { role, user_id } = useUserData()
+  const isSales = role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile";
   const { selectedProject } = useContext(UserContext);
   const { toggleNewInflowDialog, toggleNewItemDialog, toggleNewProjectInvoiceDialog, toggleNewNonProjectExpenseDialog, toggleNewProjectExpenseDialog, toggleNewWODialog } = useDialogStore()
 
@@ -130,6 +131,8 @@ export const RenderRightActionButton = ({
       </Button>
     );
   } else if (locationPath === "/in-flow-payments") {
+    // Sales users (Executive / Lead) are view-only here — no create button.
+    if (isSales) return null;
     return (
       <Button onClick={toggleNewInflowDialog} className="sm:mr-4 mr-2">
         <CirclePlus className="w-5 h-5 pr-1" />
@@ -137,6 +140,8 @@ export const RenderRightActionButton = ({
       </Button>
     );
   } else if (locationPath === "/project-invoices") {
+    // Sales users (Executive / Lead) are view-only here — no create button.
+    if (isSales) return null;
     return (
       <Button onClick={toggleNewProjectInvoiceDialog} className="sm:mr-4 mr-2">
         <CirclePlus className="w-5 h-5 pr-1" />

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -193,6 +193,25 @@ export function NewSidebar() {
 
   const items = useMemo(() => [
     { key: "/", icon: LayoutGrid, label: "Dashboard" },
+    ...(["Nirmaan Sales Executive Profile", "Nirmaan Sales Lead Profile"].includes(role as string)
+      ? [
+        {
+          key: "/projects",
+          icon: BlendIcon,
+          label: "Projects",
+        },
+        {
+          key: "/project-invoices",
+          icon: FileUp,
+          label: "Project Invoices",
+        },
+        {
+          key: "/in-flow-payments",
+          icon: HandCoins,
+          label: "Project Inflows",
+        },
+      ]
+      : []),
     ...(user_id == "Administrator" || ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile"].includes(role as string)
       ? [
         {
@@ -827,6 +846,7 @@ export function NewSidebar() {
                     "Projects",
                     "Work Orders",
                     "In-Flow Payments",
+                    "Project Inflows",
                     "Vendor Invoice Recon",
                     "Reports",
                     "Design Tracker",

--- a/frontend/src/components/layout/dashboards/dashboard-sales.tsx
+++ b/frontend/src/components/layout/dashboards/dashboard-sales.tsx
@@ -1,0 +1,108 @@
+import { ArrowUpRight, BlendIcon, FileUp, HandCoins, type LucideIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+import { useUserData } from "@/hooks/useUserData";
+
+interface QuickLink {
+  to: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+const QUICK_LINKS: QuickLink[] = [
+  {
+    to: "/projects",
+    label: "Projects",
+    description: "Browse and review your projects",
+    icon: BlendIcon,
+  },
+  {
+    to: "/project-invoices",
+    label: "Project Invoices",
+    description: "View project invoices",
+    icon: FileUp,
+  },
+  {
+    to: "/in-flow-payments",
+    label: "Project Inflows",
+    description: "Track incoming project payments",
+    icon: HandCoins,
+  },
+];
+
+const QuickLinkCard: React.FC<{ link: QuickLink }> = ({ link }) => {
+  const Icon = link.icon;
+  return (
+    <Link to={link.to} className="group relative block">
+      <div
+        className="
+          relative h-[140px] overflow-hidden rounded-xl border border-rose-100
+          bg-white p-5 transition-all duration-300 ease-out
+          hover:border-rose-200 hover:shadow-[0_8px_30px_rgb(208,59,69,0.08)]
+          dark:border-rose-900/30 dark:bg-gray-900 dark:hover:border-rose-800/50
+        "
+      >
+        {/* Watermark icon */}
+        <div
+          className="
+            pointer-events-none absolute -bottom-6 -right-6 opacity-[0.06]
+            transition-all duration-500 ease-out
+            group-hover:-bottom-4 group-hover:-right-4 group-hover:opacity-[0.12]
+          "
+        >
+          <Icon className="h-32 w-32 text-rose-700 dark:text-rose-300" strokeWidth={1} />
+        </div>
+
+        {/* Content */}
+        <div className="relative z-10 flex h-full flex-col justify-between">
+          <div className="flex items-start justify-between">
+            <span
+              className="
+                text-base font-semibold tracking-tight text-gray-900
+                transition-colors duration-200 group-hover:text-rose-700
+                dark:text-gray-100 dark:group-hover:text-rose-400
+              "
+            >
+              {link.label}
+            </span>
+            <ArrowUpRight
+              className="
+                h-4 w-4 -translate-x-1 translate-y-1 text-gray-300 opacity-0
+                transition-all duration-300 group-hover:translate-x-0
+                group-hover:translate-y-0 group-hover:text-rose-600 group-hover:opacity-100
+              "
+            />
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{link.description}</p>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export const SalesDashboard = () => {
+  const { full_name } = useUserData();
+
+  return (
+    <div className="flex-1 space-y-8">
+      {/* Header */}
+      <div className="space-y-1">
+        <h2 className="text-2xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">
+          Welcome{full_name ? `, ${full_name}` : ""}
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Quick access to your projects and payments
+        </p>
+      </div>
+
+      {/* Quick links */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {QUICK_LINKS.map((link) => (
+          <QuickLinkCard key={link.to} link={link} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SalesDashboard;

--- a/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
+++ b/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
@@ -367,16 +367,21 @@ interface AddCategoryModalProps {
     availableCategories: CategoryItem[];
     onAdd: (newTasks: Partial<DesignTrackerTask>[]) => Promise<void>;
     hasHandover: boolean;
+    // The zones the tracker actually displays (uniqueZones). Resolved from the
+    // zone child table OR, when that's empty, from the zones on existing tasks.
+    existingZones: string[];
+    // Tracker start_date, used as the base for deadline_offset. Passed from the
+    // parent (which resolves the tracker id from prop OR url) so this modal does
+    // not depend on useParams — that is undefined when the tracker is opened from
+    // the Project page (param is `projectId`, not `id`).
+    startDate?: string;
 }
 
 const AddCategoryModal: React.FC<AddCategoryModalProps> = ({
-    isOpen, onOpenChange, availableCategories, onAdd, hasHandover
+    isOpen, onOpenChange, availableCategories, onAdd, hasHandover, existingZones, startDate
 }) => {
     const [selectedCategories, setSelectedCategories] = useState<CategoryItem[]>([]);
     const [isSaving, setIsSaving] = useState(false);
-
-    const { id: trackerId } = useParams<{ id: string }>();
-    const { trackerDoc } = useDesignTrackerLogic({ trackerId: trackerId! });
 
     React.useEffect(() => {
         if (!isOpen) {
@@ -401,17 +406,19 @@ const AddCategoryModal: React.FC<AddCategoryModalProps> = ({
         setIsSaving(true);
 
         const tasksToGenerate: Partial<DesignTrackerTask>[] = [];
-        const existingZones = trackerDoc?.zone && trackerDoc.zone.length > 0
-            ? trackerDoc.zone.map(z => z.tracker_zone)
-            : [undefined];
+        // Apply the new category to the SAME zones the UI shows (passed in as
+        // existingZones / uniqueZones). Only fall back to [undefined] when the
+        // tracker genuinely has no zones at all — otherwise zone-less tasks get
+        // created and vanish under every zone tab (the production bug this fixes).
+        const zonesToApply: (string | undefined)[] = existingZones.length > 0 ? existingZones : [undefined];
 
         selectedCategories.forEach(cat => {
             const taskItems = cat.tasks;
-            existingZones.forEach(zoneName => {
+            zonesToApply.forEach(zoneName => {
                 taskItems.forEach(taskDef => {
                     let calculatedDeadline: string | undefined = undefined;
                     if (taskDef.deadline_offset !== undefined && taskDef.deadline_offset !== null) {
-                        const baseDate = trackerDoc?.start_date ? new Date(trackerDoc.start_date) : new Date();
+                        const baseDate = startDate ? new Date(startDate) : new Date();
                         const d = new Date(baseDate);
                         d.setDate(baseDate.getDate() + Number(taskDef.deadline_offset));
                         calculatedDeadline = d.toISOString().split('T')[0];
@@ -455,7 +462,7 @@ const AddCategoryModal: React.FC<AddCategoryModalProps> = ({
     };
 
     // Calculate total tasks that will be created
-    const existingZonesCount = trackerDoc?.zone?.length || 1;
+    const existingZonesCount = existingZones.length || 1;
     const phaseMultiplier = hasHandover ? 2 : 1;
     const totalTasksToCreate = selectedCategories.reduce(
         (sum, cat) => sum + (cat.tasks?.length || 0), 0
@@ -1938,6 +1945,8 @@ export const ProjectDesignTrackerDetailV2: React.FC<ProjectDesignTrackerDetailPr
                 availableCategories={availableNewCategories}
                 onAdd={handleAddCategories}
                 hasHandover={hasHandover}
+                existingZones={uniqueZones}
+                startDate={trackerDoc?.start_date}
             />
 
             <AddZoneModal

--- a/frontend/src/pages/ProjectInvoices/ProjectInvoices.tsx
+++ b/frontend/src/pages/ProjectInvoices/ProjectInvoices.tsx
@@ -5,6 +5,7 @@ import { toast } from "@/components/ui/use-toast";
 import { TableSkeleton } from "@/components/ui/skeleton";
 // SITEURL is used by ProjectInvoiceTable now, no need to pass as prop if it imports directly
 import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
+import { useUserData } from "@/hooks/useUserData";
 import { useDialogStore } from "@/zustand/useDialogStore";
 import { useFrappeGetDocList, useFrappeDeleteDoc } from "frappe-react-sdk";
 import { CirclePlus, Edit2, Trash2 } from "lucide-react"; // Added icons for clarity, though table handles its own
@@ -29,6 +30,9 @@ export const ProjectInvoices: React.FC<{ projectId?: string; customerId?: string
     toggleNewProjectInvoiceDialog,
     setEditProjectInvoiceDialog // Get setter for edit dialog
   } = useDialogStore();
+
+  const { role } = useUserData();
+  const isSales = role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile";
 
   const { data, isLoading, error, mutate } = useFrappeGetDocList<ProjectInvoice>(DOCTYPE, {
     fields: ITEM_LIST_FIELDS_TO_FETCH, // No need to cast as string[] if type is correct
@@ -87,14 +91,17 @@ export const ProjectInvoices: React.FC<{ projectId?: string; customerId?: string
           <CardTitle className="flex justify-between items-center">
             <p className="text-xl max-sm:text-lg text-primary">Invoices</p> {/* Using primary color */}
             <div className='flex gap-2 items-center'>
-              <Button
-                variant="outline"
-                size="sm"
-                className="text-primary border-primary hover:bg-primary/5"
-                onClick={toggleNewProjectInvoiceDialog}
-              >
-                <CirclePlus className="h-4 w-4 mr-2" /> Add Invoice
-              </Button>
+              {/* Sales users (Executive / Lead) are view-only — no create button. */}
+              {!isSales && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-primary border-primary hover:bg-primary/5"
+                  onClick={toggleNewProjectInvoiceDialog}
+                >
+                  <CirclePlus className="h-4 w-4 mr-2" /> Add Invoice
+                </Button>
+              )}
             </div>
           </CardTitle>
         </CardHeader>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -8,6 +8,7 @@ import { ProjectManager } from "@/components/layout/dashboards/dashboard-pm";
 import { EstimatesExecutive } from "@/components/layout/dashboards/estimates-executive-dashboard";
 import ProcurementDashboard from "@/components/layout/dashboards/procurement-dashboard";
 import { DesignDashboard } from "@/components/layout/dashboards/design-dashboard";
+import { SalesDashboard } from "@/components/layout/dashboards/dashboard-sales";
 import {
     Alert,
     AlertDescription,
@@ -54,7 +55,7 @@ export default function Dashboard() {
         <>
 
             {(role === 'Nirmaan Admin Profile' || role === 'Nirmaan PMO Executive Profile') && <DefaultDashboard />}
-            {(has_project === "false" && !["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Estimates Executive Profile", "Nirmaan Design Lead Profile", "Nirmaan Design Executive Profile", "Nirmaan HR Executive Profile", "Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile"].includes(role)) ?
+            {(has_project === "false" && !["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Estimates Executive Profile", "Nirmaan Design Lead Profile", "Nirmaan Design Executive Profile", "Nirmaan HR Executive Profile", "Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Sales Executive Profile", "Nirmaan Sales Lead Profile"].includes(role)) ?
                 <Alert className="flex flex-col max-md:w-[80%] max-lg:w-[60%] w-[50%] mx-auto justify-center max-md:mt-[40%] mt-[20%]">
                     <div className="flex gap-2 items-center">
                         <RocketIcon className="h-4 w-4" />
@@ -74,6 +75,7 @@ export default function Dashboard() {
                     {(role === 'Nirmaan Accountant Profile' || role === 'Nirmaan Accountant Lead Profile') && <Accountant />}
                     {(role === "Nirmaan Design Lead Profile" || role === "Nirmaan Design Executive Profile") && <DesignDashboard />}
                     {role === "Nirmaan HR Executive Profile" && <HRDashboard />}
+                    {(role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile") && <SalesDashboard />}
                 </>
             }
         </>

--- a/frontend/src/pages/projects/ProjectFinancialsTab.tsx
+++ b/frontend/src/pages/projects/ProjectFinancialsTab.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import SITEURL from "@/constants/siteURL"
 import { getUrlStringParam } from "@/hooks/useServerDataTable"
+import { useUserData } from "@/hooks/useUserData"
 import { Customers } from "@/types/NirmaanStack/Customers"
 import { ProjectInflows } from "@/types/NirmaanStack/ProjectInflows"
 import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice"
@@ -49,10 +50,21 @@ interface ProjectFinancialsTabProps {
   advanceAgainstPO: number
 
 }
+// Sales users (Executive / Lead) only see these financial sub-tabs.
+const SALES_ALLOWED_TABS = ["Project Invoices", "Inflow", "Client PO"];
+
 export const ProjectFinancialsTab: React.FC<ProjectFinancialsTabProps> = ({ projectData, projectCustomer, getTotalAmountPaid, totalPOAmountWithGST, getAllSRsTotalWithGST, getAllPODeliveredAmount, poPaymentAgainstDelivery, advanceAgainstPO }) => {
 
+  const { role } = useUserData();
+  const isSales = role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile";
+
   const initialTab = useMemo(() => {
-    return getUrlStringParam("fTab", "All Payments");
+    const urlTab = getUrlStringParam("fTab", "All Payments");
+    // Sales users default to (and are confined to) their allowed sub-tabs.
+    if (isSales && !SALES_ALLOWED_TABS.includes(urlTab)) {
+      return "Project Invoices";
+    }
+    return urlTab;
   }, []); // Calculate once
 
   const [tab, setTab] = useState<string>(initialTab)
@@ -224,32 +236,36 @@ export const ProjectFinancialsTab: React.FC<ProjectFinancialsTabProps> = ({ proj
   ], [totalInflowAmount, totalProjectInvoiceAmount, getTotalAmountPaid, totalPOAmountWithGST, getAllSRsTotalWithGST, projectData?.project_value, relatedTotalBalanceCredit, relatedTotalCreditPaid, getAllPODeliveredAmount, poPaymentAgainstDelivery, advanceAgainstPO])
 
 
-  const tabs = useMemo(() => [
-    {
-      label: "All Payments",
-      value: "All Payments"
-    },
-    // {
-    //   label: "All Orders",
-    //   value: "All Orders"
-    // },
-    {
-      label: "All PO Invoices",
-      value: "All PO Invoices"
-    },
-    {
-      label: "Project Invoices",
-      value: "Project Invoices"
-    },
-    {
-      label: "Inflow",
-      value: "Inflow"
-    },
-    {
-      label: "Client PO",
-      value: "Client PO"
-    },
-  ], [])
+  const tabs = useMemo(() => {
+    const allTabs = [
+      {
+        label: "All Payments",
+        value: "All Payments"
+      },
+      // {
+      //   label: "All Orders",
+      //   value: "All Orders"
+      // },
+      {
+        label: "All PO Invoices",
+        value: "All PO Invoices"
+      },
+      {
+        label: "Project Invoices",
+        value: "Project Invoices"
+      },
+      {
+        label: "Inflow",
+        value: "Inflow"
+      },
+      {
+        label: "Client PO",
+        value: "Client PO"
+      },
+    ];
+    // Sales users only see Project Invoices, Inflow, and Client PO.
+    return isSales ? allTabs.filter((t) => SALES_ALLOWED_TABS.includes(t.value)) : allTabs;
+  }, [isSales])
 
   const onClick = useCallback(
     (value: string) => {
@@ -259,6 +275,14 @@ export const ProjectFinancialsTab: React.FC<ProjectFinancialsTabProps> = ({ proj
       }
     }
     , [tab]);
+
+  // Keep Sales users confined to their allowed sub-tabs even if `tab` ends up
+  // on a restricted value (e.g. a stale fTab URL param).
+  useEffect(() => {
+    if (isSales && !SALES_ALLOWED_TABS.includes(tab)) {
+      setTab("Project Invoices");
+    }
+  }, [isSales, tab]);
 
   return (
     <div className="flex-1 space-y-4">

--- a/frontend/src/pages/projects/ProjectOverviewTab.tsx
+++ b/frontend/src/pages/projects/ProjectOverviewTab.tsx
@@ -55,6 +55,7 @@ interface ProjectOverviewTabProps {
 export const ProjectOverviewTab: React.FC<ProjectOverviewTabProps> = ({ projectData, projectCustomer, getAllSRsTotalWithGST, totalPOAmountWithGST, getTotalAmountPaid }) => {
 
   const { role, user_id } = useUserData();
+  const isSales = role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile";
   const navigate = useNavigate();
   const {
     createUserPermission,
@@ -534,10 +535,15 @@ export const ProjectOverviewTab: React.FC<ProjectOverviewTabProps> = ({ projectD
       <Card>
         <CustomerPODetailsCard projectId={projectData.name} />
       </Card>
-      <Card>
-        <ProjectDriveLink projectId={projectData.name} role={role} />
-      </Card>
-      <SevenDayPlanningTab isOverview={true} projectName={projectData?.project_name} />
+      {/* Sales users (Executive / Lead) don't see Project Drive Links or Planning. */}
+      {!isSales && (
+        <Card>
+          <ProjectDriveLink projectId={projectData.name} role={role} />
+        </Card>
+      )}
+      {!isSales && (
+        <SevenDayPlanningTab isOverview={true} projectName={projectData?.project_name} />
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/projects/components/AddCustomerPODialog.tsx
+++ b/frontend/src/pages/projects/components/AddCustomerPODialog.tsx
@@ -501,9 +501,8 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
     }, []);
     
     const isFormValid = useMemo(() => {
-        // Enforce: PO Number, Incl. Tax value, AND valid Link/Attachment
+        // PO Number is OPTIONAL. Enforce: Incl. Tax value, PO Date, AND valid Link/Attachment
         return (
-            formData.customer_po_number.trim() !== '' &&
             formData.customer_po_value_inctax > 0 &&
             formData.customer_po_creation_date.trim() !== '' &&
             isLinkAttachmentValid
@@ -515,7 +514,7 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
         e.preventDefault();
         
         if (!isFormValid) {
-            let message = "Please fill all required fields: PO Number, PO Date, Value (Incl. Tax).";
+            let message = "Please fill all required fields: PO Date, Value (Incl. Tax).";
             toast({ title: "Validation Failed", description: message, variant: "destructive" });
             return;
         }
@@ -604,12 +603,11 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
                     {/* Basic Fields */}
                     <div className="grid grid-cols-1 gap-4">
                         <div className="space-y-2">
-                            <Label htmlFor="customer_po_number">PO Number <span className="text-red-500">*</span></Label>
+                            <Label htmlFor="customer_po_number">PO Number <span className="text-muted-foreground text-xs">(optional)</span></Label>
                             <Input
                                 id="customer_po_number"
                                 value={formData.customer_po_number}
                                 onChange={handleInputChange}
-                                required
                             />
                         </div>
                     </div>

--- a/frontend/src/pages/projects/components/CustomerPODeatilsCard.tsx
+++ b/frontend/src/pages/projects/components/CustomerPODeatilsCard.tsx
@@ -607,7 +607,13 @@ const getCustomerPOColumns = (
   handleDeleteClick?: (po: CustomerPOTableRow) => void,// PASSED
   role?: string
 ): ColumnDef<CustomerPOTableRow>[] => {
-    
+
+    // Sales roles are view-only for deletion — hide the Delete action for them
+    // (they can still edit). Both Sales Executive and Sales Lead.
+    const hideDelete =
+        role === "Nirmaan Sales Executive Profile" ||
+        role === "Nirmaan Sales Lead Profile";
+
     const columns: ColumnDef<CustomerPOTableRow>[] = [
              {
                accessorKey: "customer_po_creation_date",
@@ -824,7 +830,8 @@ const getCustomerPOColumns = (
                             </Tooltip>
                         </TooltipProvider>
 
-                        {/* Delete Icon */}
+                        {/* Delete Icon — hidden for Sales roles (view-only; cannot delete) */}
+                        {!hideDelete && (
                         <TooltipProvider delayDuration={100}>
                             <Tooltip>
                                 <TooltipTrigger asChild>
@@ -841,6 +848,7 @@ const getCustomerPOColumns = (
                                 <TooltipContent>Delete this Customer PO</TooltipContent>
                             </Tooltip>
                         </TooltipProvider>
+                        )}
                     </div>
                 );
             },

--- a/frontend/src/pages/projects/components/EditCustomerPODialog.tsx
+++ b/frontend/src/pages/projects/components/EditCustomerPODialog.tsx
@@ -132,7 +132,7 @@ export const EditCustomerPODialog: React.FC<EditCustomerPODialogProps> = ({
 
   const isFormValid = useMemo(() => {
     return (
-      formData.customer_po_number.trim() !== "" &&
+      // PO Number is optional
       formData.customer_po_value_inctax > 0 &&
       formData.customer_po_creation_date.trim() !== "" &&
       isLinkAttachmentValid
@@ -219,12 +219,11 @@ export const EditCustomerPODialog: React.FC<EditCustomerPODialogProps> = ({
 
         <form onSubmit={handleSubmit} className="grid gap-6 py-4">
           <div className="space-y-2">
-            <Label htmlFor="customer_po_number">PO Number <span className="text-red-500">*</span></Label>
+            <Label htmlFor="customer_po_number">PO Number</Label>
             <Input
               id="customer_po_number"
               value={formData.customer_po_number}
               onChange={handleInputChange}
-              required
             />
           </div>
 

--- a/frontend/src/pages/projects/project.tsx
+++ b/frontend/src/pages/projects/project.tsx
@@ -400,6 +400,7 @@ const ProjectView = ({ projectId, data, project_mutate, projectCustomer, po_item
   const isProcurementExecutive = role === "Nirmaan Procurement Executive Profile";
   const isEstimatesExecutive = role === "Nirmaan Estimates Executive Profile";
   const isProjectManager = role === "Nirmaan Project Manager Profile";
+  const isSales = role === "Nirmaan Sales Executive Profile" || role === "Nirmaan Sales Lead Profile";
 
   // Allowed tabs for non-privileged users (all roles except Admin, PMO, Accountant)
   const nonPrivilegedAllowedTabs = useMemo<Set<ProjectPageTabValue>>(() => new Set([
@@ -455,7 +456,12 @@ const ProjectView = ({ projectId, data, project_mutate, projectCustomer, po_item
 
   // Redirect users to allowed tab if on restricted tab
   useEffect(() => {
-    if (isProcurementExecutive && !procurementExecutiveAllowedTabs.has(activePage)) {
+    if (isSales) {
+      // Sales users can only see the Overview and Financials tabs.
+      if (activePage !== PROJECT_PAGE_TABS.OVERVIEW && activePage !== PROJECT_PAGE_TABS.FINANCIALS) {
+        setActivePage(PROJECT_PAGE_TABS.OVERVIEW);
+      }
+    } else if (isProcurementExecutive && !procurementExecutiveAllowedTabs.has(activePage)) {
       setActivePage(PROJECT_PAGE_TABS.CRITICAL_POS);
     } else if (isEstimatesExecutive && !estimatesExecutiveAllowedTabs.has(activePage)) {
       setActivePage(PROJECT_PAGE_TABS.WORK_REPORT);
@@ -463,9 +469,23 @@ const ProjectView = ({ projectId, data, project_mutate, projectCustomer, po_item
       // Redirect non-privileged users (except Procurement Executive and Estimates Executive who have their own rules)
       setActivePage(PROJECT_PAGE_TABS.WORK_REPORT);
     }
-  }, [isProcurementExecutive, isEstimatesExecutive, isPrivilegedUser, activePage, procurementExecutiveAllowedTabs, estimatesExecutiveAllowedTabs, nonPrivilegedAllowedTabs]);
+  }, [isSales, isProcurementExecutive, isEstimatesExecutive, isPrivilegedUser, activePage, procurementExecutiveAllowedTabs, estimatesExecutiveAllowedTabs, nonPrivilegedAllowedTabs]);
 
   const items: MenuItem[] = useMemo(() => {
+    // Sales users (Executive / Lead) can only see the Overview and Financials tabs.
+    if (isSales) {
+      return [
+        {
+          label: "Overview",
+          key: PROJECT_PAGE_TABS.OVERVIEW,
+        },
+        {
+          label: "Financials",
+          key: PROJECT_PAGE_TABS.FINANCIALS,
+        },
+      ];
+    }
+
     // For non-privileged users (not Admin, PMO, Accountant, Procurement Executive, Estimates Executive), show only limited tabs
     if (!isPrivilegedUser && !isProcurementExecutive && !isEstimatesExecutive) {
       return [
@@ -740,7 +760,7 @@ const ProjectView = ({ projectId, data, project_mutate, projectCustomer, po_item
         key: PROJECT_PAGE_TABS.COMMISSION_REPORT,
       }] : []),
     ];
-  }, [role, isAccountant, isProcurementExecutive, isEstimatesExecutive, isPrivilegedUser, isProjectManager]);
+  }, [role, isAccountant, isProcurementExecutive, isEstimatesExecutive, isPrivilegedUser, isProjectManager, isSales]);
 
   // Define tabs available based on role or other logic
   // const availableTabs = useMemo(() => {

--- a/frontend/src/utils/auth/ProtectedRoute.tsx
+++ b/frontend/src/utils/auth/ProtectedRoute.tsx
@@ -123,6 +123,8 @@ export const InflowPaymentsRoute = () => {
         role === "Nirmaan Accountant Profile" ||
         role === "Nirmaan Accountant Lead Profile" ||
         role === "Nirmaan Project Lead Profile" ||
+        role === "Nirmaan Sales Executive Profile" ||
+        role === "Nirmaan Sales Lead Profile" ||
         user_id === "Administrator"
 
     if (canAccessInflowPayments) {

--- a/nirmaan_stack/api/projects/add_customer_po.py
+++ b/nirmaan_stack/api/projects/add_customer_po.py
@@ -24,27 +24,26 @@ def add_customer_po_with_validation(project_name, new_po_detail):
         frappe.throw(f"Project with name {project_name} not found.", title="Validation Error")
         
     po_number = new_po_detail.get('customer_po_number')
-    
-    if not po_number:
-        frappe.throw("Customer PO Number is mandatory.", title="Validation Error")
 
-    # 2. GLOBAL Validation: Check for duplicate PO Number across ALL child table records
-    
-    try:
-        # Use frappe.get_all with limit=1 to efficiently check for existence
-        # We only need the 'name' field, which is the smallest to fetch.
-        duplicate_pos = frappe.get_all(
-            CHILD_DOCTYPE_NAME, 
-            filters={"customer_po_number": po_number},
-            fields=["name"], # Fetch only the name field
-            limit=1         # Stop after finding the first one
-        )
-    except Exception as e:
-        frappe.log_error(title="PO Detail Doctype Error", message=f"Could not query Doctype '{CHILD_DOCTYPE_NAME}'. Check if the name is correct. Error: {str(e)}")
-        frappe.throw(f"Database error during PO number check. (Check server logs)", title="System Error")
+    # 2. GLOBAL Validation: PO Number is OPTIONAL. Only enforce duplicate-checking
+    # when a PO number is actually provided (a blank value may repeat freely).
+    if po_number:
+        duplicate_pos = []
+        try:
+            # Use frappe.get_all with limit=1 to efficiently check for existence
+            # We only need the 'name' field, which is the smallest to fetch.
+            duplicate_pos = frappe.get_all(
+                CHILD_DOCTYPE_NAME,
+                filters={"customer_po_number": po_number},
+                fields=["name"], # Fetch only the name field
+                limit=1         # Stop after finding the first one
+            )
+        except Exception as e:
+            frappe.log_error(title="PO Detail Doctype Error", message=f"Could not query Doctype '{CHILD_DOCTYPE_NAME}'. Check if the name is correct. Error: {str(e)}")
+            frappe.throw(f"Database error during PO number check. (Check server logs)", title="System Error")
 
-    if len(duplicate_pos) > 0:
-        return {"status":"Duplicate"}
+        if len(duplicate_pos) > 0:
+            return {"status":"Duplicate"}
 
     # 3. Add the new PO detail to the child table
     # The new_po_detail is a dictionary matching the child doctype fields.

--- a/nirmaan_stack/api/projects/add_customer_po.py
+++ b/nirmaan_stack/api/projects/add_customer_po.py
@@ -85,8 +85,7 @@ def update_customer_po_with_validation(project_name, updated_po_detail):
     po_incl_tax = flt(updated_po_detail.get('customer_po_value_inctax', 0))
     po_creation_date = updated_po_detail.get('customer_po_creation_date')
 
-    if not po_number or not str(po_number).strip():
-        frappe.throw(_("PO Number is a required field."))
+    # PO Number is optional — do not enforce it here (mirrors the add path).
     if not po_creation_date:
         frappe.throw(_("PO Date is a required field."))
     if po_incl_tax <= 0:
@@ -99,11 +98,13 @@ def update_customer_po_with_validation(project_name, updated_po_detail):
         project = frappe.get_doc("Projects", project_name)
         
         # 2. PERFORM UNIQUENESS CHECK WITHOUT SQL
-        # Check if the updated PO Number already exists in the list (excluding the current row)
-        for row in project.customer_po_details:
-            # We check for a match AND ensure the row found is NOT the one we are currently updating
-            if row.customer_po_number == po_number and row.name != current_row_name:
-                 return {"status": "Duplicate"} 
+        # Only check for duplicates when a PO number is actually provided
+        # (blank PO numbers are optional and may repeat freely).
+        if po_number:
+            for row in project.customer_po_details:
+                # match AND ensure the row found is NOT the one we are currently updating
+                if row.customer_po_number == po_number and row.name != current_row_name:
+                    return {"status": "Duplicate"}
         
         
         # 3. Get the specific child row document using the correct list comprehension (FIX for AttributeError)

--- a/nirmaan_stack/nirmaan_stack/doctype/projects/projects.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/projects/projects.json
@@ -317,7 +317,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-12 19:05:23.290902",
+ "modified": "2026-06-18 19:11:17.413340",
  "modified_by": "Administrator",
  "module": "Nirmaan Stack",
  "name": "Projects",
@@ -429,13 +429,15 @@
    "share": 1
   },
   {
+   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,
    "read": 1,
    "report": 1,
    "role": "Nirmaan Sales Executive",
-   "share": 1
+   "share": 1,
+   "write": 1
   },
   {
    "email": 1,


### PR DESCRIPTION
1. Sales roles can add/edit Customer POs (Sales Exec given write/create), delete action hidden for both Sales roles, and PO Number made optional in the edit form + update API.
2.  Fixed Design Tracker "Add Category" creating hidden zone-less tasks when opened from the Project page (made the modal prop-driven for zones + start date).
3. Wired the Nirmaan Sales Exec + Lead roles into the frontend (view-only): sidebar, minimal dashboard, project Overview/Financials tabs, and optional PO Number on Add Customer PO.