### PR TITLE
PO revision comments + design-tracker / PO table / PO-PDF fixes

### DIFF
--- a/frontend/src/pages/PORevision/components/Step1/Step1ReviseItems.tsx
+++ b/frontend/src/pages/PORevision/components/Step1/Step1ReviseItems.tsx
@@ -152,6 +152,7 @@ export const Step1ReviseItems: React.FC<Step1ReviseItemsProps> = ({
 
                     {/* Item Name */}
                     <TableCell>
+                      <div className="space-y-1.5">
                       {item.category === "Additional Charges" ? (
                         <div className="flex items-center h-9 px-3 text-xs font-medium text-gray-700 bg-gray-50 border rounded-md cursor-not-allowed w-full">
                           {item.item_name}
@@ -218,6 +219,15 @@ export const Step1ReviseItems: React.FC<Step1ReviseItemsProps> = ({
                           {item.item_name}
                         </div>
                       )}
+                        {!isDeleted && (
+                          <Input
+                            value={item.comment || ""}
+                            onChange={(e) => handleUpdateItem(idx, { comment: e.target.value })}
+                            placeholder="Add a comment (optional)..."
+                            className="text-[11px] h-7 text-gray-600 placeholder:text-gray-300 bg-white"
+                          />
+                        )}
+                      </div>
                     </TableCell>
 
                     {/* Make */}

--- a/frontend/src/pages/PORevision/components/Step3/Step3Summary.tsx
+++ b/frontend/src/pages/PORevision/components/Step3/Step3Summary.tsx
@@ -60,13 +60,19 @@ export const Step3Summary: React.FC<Step3SummaryProps> = ({
                     const totalAmount = amount + (amount * (item.tax || 0) / 100);
                     const original = item.original_row_id ? po.items?.find(i => i.name === item.original_row_id) : null;
 
-                    const details: string[] = [];
+                    // What changed, shown in priority order: Comment → Rate → Qty → Tax → Item name
+                    const details: { text: string; tone: "default" | "comment" }[] = [];
                     if (original && (item.item_type === "Revised" || item.item_type === "Replace")) {
-                      if (item.quantity !== original.quantity) details.push(`Qty: ${original.quantity} → ${item.quantity}`);
-                      if (item.quote !== original.quote) details.push(`Rate: ${formatToIndianRupee(original.quote)} → ${formatToIndianRupee(item.quote || 0)}`);
-                      if (item.tax !== original.tax) details.push(`Tax: ${original.tax}% → ${item.tax}%`);
+                      if ((item.comment || "") !== (original.comment || "")) {
+                        details.push({ text: item.comment ? `Comment: ${item.comment}` : "Comment removed", tone: "comment" });
+                      }
+                      if (item.quote !== original.quote) details.push({ text: `Rate: ${formatToIndianRupee(original.quote)} → ${formatToIndianRupee(item.quote || 0)}`, tone: "default" });
+                      if (item.quantity !== original.quantity) details.push({ text: `Qty: ${original.quantity} → ${item.quantity}`, tone: "default" });
+                      if (item.tax !== original.tax) details.push({ text: `Tax: ${original.tax}% → ${item.tax}%`, tone: "default" });
+                      if ((item.item_name || "") !== (original.item_name || "")) details.push({ text: `Item: ${original.item_name} → ${item.item_name}`, tone: "default" });
                     } else if (item.item_type === "New") {
-                      details.push(`Qty: ${item.quantity}, Rate: ${formatToIndianRupee(item.quote || 0)}`);
+                      details.push({ text: `Qty: ${item.quantity}, Rate: ${formatToIndianRupee(item.quote || 0)}`, tone: "default" });
+                      if (item.comment) details.push({ text: `Comment: ${item.comment}`, tone: "comment" });
                     }
 
                     return (
@@ -76,8 +82,12 @@ export const Step3Summary: React.FC<Step3SummaryProps> = ({
                           {details.length > 0 && (
                             <div className="flex flex-wrap gap-1 mt-1">
                               {details.map((d, i) => (
-                                <span key={i} className="text-[9px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded font-medium">
-                                  {d}
+                                <span
+                                  key={i}
+                                  title={d.text}
+                                  className={`text-[9px] px-1.5 py-0.5 rounded font-medium max-w-[240px] truncate ${d.tone === "comment" ? "bg-amber-100 text-amber-700" : "bg-gray-100 text-gray-600"}`}
+                                >
+                                  {d.text}
                                 </span>
                               ))}
                             </div>

--- a/frontend/src/pages/PORevision/components/detail/PORevisionLineItems.tsx
+++ b/frontend/src/pages/PORevision/components/detail/PORevisionLineItems.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import formatCurrency from "@/utils/FormatPrice";
 import { List } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 interface PORevisionLineItemsProps {
     items: any[];
@@ -88,6 +87,9 @@ export default function PORevisionLineItems({ items, isCustom = false }: PORevis
                                 const amountInclGst = baseAmount + (baseAmount * (tax / 100));
                                 const originalAmountInclGst = originalBaseAmount + (originalBaseAmount * (originalTax / 100));
 
+                                const comment = (isOriginal || isDeleted) ? (item.original_comment || "") : (item.revision_comment ?? item.comment ?? item.original_comment ?? "");
+                                const originalComment = item.original_comment || "";
+
                                 return (
                                     <React.Fragment key={idx}>
                                         {/* Original Row for Revised/Replaced Items */}
@@ -122,6 +124,12 @@ export default function PORevisionLineItems({ items, isCustom = false }: PORevis
                                                         <span className="font-medium">{itemName}</span>
                                                         {isChanged && item.original_item_name && item.original_item_name !== item.revision_item_name && (
                                                             <span className="text-[10px] text-slate-400 line-through">{item.original_item_name}</span>
+                                                        )}
+                                                        {comment && (
+                                                            <span className="text-[10px] text-slate-500 italic mt-0.5">💬 {comment}</span>
+                                                        )}
+                                                        {isChanged && originalComment && originalComment !== comment && (
+                                                            <span className="text-[10px] text-slate-400 line-through">{originalComment}</span>
                                                         )}
                                                     </div>
                                                 </div>

--- a/frontend/src/pages/PORevision/hooks/usePORevision.ts
+++ b/frontend/src/pages/PORevision/hooks/usePORevision.ts
@@ -153,9 +153,11 @@ export const usePORevision = ({ po, open, onClose, onSuccess }: UsePORevisionPro
           tax: item.tax,
           category: item.category,
           procurement_package: item.procurement_package,
+          comment: item.comment,
 
           // Original Details
           original_item_id: original?.item_id,
+          original_comment: original?.comment,
           original_item_name: original?.item_name,
           original_make: original?.make,
           original_qty: original?.quantity,

--- a/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
@@ -1219,14 +1219,14 @@ export const PurchaseOrder = ({
                   {PO?.items?.map((item, index) => (
                     <tr key={index} className="hover:bg-gray-50 transition-colors text-sm text-gray-600">
                       <td className="pl-4 py-3 align-top">{index + 1}</td>
-                      <td className="pl-2 py-3 align-top">
+                      <td className="pl-2 py-3 align-top max-w-[450px]">
                         <div className="flex flex-col gap-1">
                           <span>{item.item_name}</span>
                           <small className="font-medium text-red-700">{item?.make}</small>
                           {item.comment && (
-                            <div className="flex gap-1 items-start bg-gray-50 rounded p-1.5 mt-1">
+                            <div className="flex gap-1 items-start bg-gray-50 rounded p-1.5 mt-1 w-full">
                               <MessageCircleMore className="w-4 h-4 flex-shrink-0 mt-0.5 text-gray-400" />
-                              <div className="text-xs text-gray-600 leading-snug">{item.comment}</div>
+                              <div className="text-xs text-gray-600 leading-snug break-words min-w-0">{item.comment}</div>
                             </div>
                           )}
                         </div>

--- a/frontend/src/pages/ProcurementOrders/purchase-order/components/POPdf.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/components/POPdf.tsx
@@ -1,1027 +1,143 @@
-// import logo from "@/assets/logo-svg.svg";
-// import Seal from "@/assets/NIRMAAN-SEAL.jpeg";
-// import {
-//   ProcurementOrder,
-//   PurchaseOrderItem,
-//   PaymentTerm, POTotals
-// } from "@/types/NirmaanStack/ProcurementOrders";
-// import formatToIndianRupee from "@/utils/FormatPrice";
-// import { parseNumber } from "@/utils/parseNumber";
-// import { useFrappeGetDocList } from "frappe-react-sdk";
-// import { MessageCircleMore, Printer } from "lucide-react";
-// import * as pdfjsLib from "pdfjs-dist";
-// import { useEffect, useRef, useState, useMemo } from "react";
-// import { useReactToPrint } from "react-to-print";
-// import { AddressView } from "@/components/address-view";
-// import { Button } from "@/components/ui/button";
-
-// import { Sheet, SheetContent } from "@/components/ui/sheet";
-
-// interface POPdfProps {
-//   po: ProcurementOrder | null;
-//   orderData?: PurchaseOrderItem[];
-//   paymentTerms?: PaymentTerm[];
-//   includeComments: boolean
-//   POTotals?: POTotals;
-//   // advance: number
-//   // materialReadiness: number
-//   // afterDelivery: number
-//   // xDaysAfterDelivery: number
-//   // xDays: number
-//   poPdfSheet: boolean;
-//   togglePoPdfSheet: () => void;
-// }
-
-// pdfjsLib.GlobalWorkerOptions.workerSrc =
-//   "https://unpkg.com/pdfjs-dist@3.4.120/build/pdf.worker.min.js";
-
-
-// const gstAddressMap = {
-//   "29ABFCS9095N1Z9": "1st Floor, 234, 9th Main, 16th Cross, Sector 6, HSR Layout, Bengaluru - 560102, Karnataka",
-//   "06ABFCS9095N1ZH": "7th Floor, MR1, ALTF Global Business Park Cowarking Space, Mehrauli Gurugram Rd, Tower D, Sikanderpur, Gurugram - 122002, Haryana",
-//   "09ABFCS9095N1ZB": "MR1, Plot no. 21 & 21A, AltF 142 Noida, Sector 142, Noida - 201305, Uttar Pradesh"
-// }
-
-// export const POPdf: React.FC<POPdfProps> = ({
-//   po,
-//   orderData,
-//   includeComments,
-//   POTotals,
-//   paymentTerms,
-//   poPdfSheet,
-//   togglePoPdfSheet,
-// }) => {
-//   if (!po) return <div>No PO ID Provided</div>;
-//   const componentRef = useRef<HTMLDivElement>(null);
-
-//   const finalPaymentTerms = paymentTerms && paymentTerms.length > 0 ? paymentTerms : po?.payment_terms;
-
-//   const { data: attachmentsData } = useFrappeGetDocList(
-//     "Nirmaan Attachments",
-//     {
-//       fields: ["*"],
-//       filters: [
-//         ["associated_doctype", "=", "Procurement Requests"],
-//         ["associated_docname", "=", po?.procurement_request!],
-//         ["attachment_type", "=", "custom pr attachment"],
-//       ],
-//     },
-//     po?.procurement_request ? undefined : null
-//   );
-
-//   const [images, setImages] = useState([]);
-
-//   // const loadPdfAsImages = async (pdfData) => {
-//   //   try {
-
-//   //     const response = await fetch(pdfData, {
-//   //       method: 'GET',
-//   //       headers: {
-//   //         'Content-Type': 'application/pdf',
-//   //       },
-//   //     });
-
-//   //     if (!response.ok) {
-//   //       throw new Error(`Failed to fetch PDF: ${response.statusText}`);
-//   //     }
-
-//   //     const pdfArrayBuffer = await response.arrayBuffer();
-
-//   //     const loadingTask = pdfjsLib.getDocument({ data: pdfArrayBuffer });
-//   //     const pdf = await loadingTask.promise;
-
-//   //     const pages = [];
-
-//   //     for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-//   //       const page = await pdf.getPage(pageNum);
-
-//   //       const viewport = page.getViewport({ scale: 1.5 });
-//   //       const canvas = document.createElement('canvas');
-//   //       const context = canvas.getContext('2d');
-//   //       canvas.height = viewport.height;
-//   //       canvas.width = viewport.width;
-
-//   //       await page.render({ canvasContext: context, viewport }).promise;
-//   //       const imgData = canvas.toDataURL();
-//   //       pages.push(imgData);
-//   //     }
-
-//   //     setPdfImages(pages);
-//   //   } catch (error) {
-//   //     console.error('Failed to load PDF as images:', error);
-//   //   }
-//   // };
-
-//   const loadFileAsImage = async (att) => {
-//     try {
-//       const baseURL = window.location.origin;
-//       const fileUrl = `${baseURL}${att.attachment}`;
-//       const fileType = att.attachment.split(".").pop().toLowerCase();
-
-//       if (["pdf"].includes(fileType)) {
-//         // Handle PDF files
-//         const response = await fetch(fileUrl, {
-//           method: "GET",
-//           headers: {
-//             "Content-Type": "application/pdf",
-//           },
-//         });
-
-//         if (!response.ok) {
-//           throw new Error(`Failed to fetch PDF: ${response.statusText}`);
-//         }
-
-//         const pdfArrayBuffer = await response.arrayBuffer();
-
-//         const loadingTask = pdfjsLib.getDocument({ data: pdfArrayBuffer });
-//         const pdf = await loadingTask.promise;
-
-//         const pages = [];
-
-//         for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-//           const page = await pdf.getPage(pageNum);
-
-//           const viewport = page.getViewport({ scale: 1.5 });
-//           const canvas = document.createElement("canvas");
-//           const context = canvas.getContext("2d");
-//           canvas.height = viewport.height;
-//           canvas.width = viewport.width;
-
-//           await page.render({ canvasContext: context, viewport }).promise;
-//           const imgData = canvas.toDataURL();
-//           pages.push(imgData);
-//         }
-
-//         setImages((prevImages) => [...prevImages, ...pages]);
-//       } else if (["png", "jpg", "jpeg", "gif", "webp"].includes(fileType)) {
-//         // Handle image files
-//         setImages((prevImages) => [...prevImages, fileUrl]);
-//       } else {
-//         console.warn(`Unsupported file type: ${fileType}`);
-//       }
-//     } catch (error) {
-//       console.error("Failed to load file as image:", error);
-//     }
-//   };
-
-//   useEffect(() => {
-//     if (attachmentsData) {
-//       attachmentsData.forEach(loadFileAsImage);
-//     }
-//   }, [attachmentsData]);
-
-//   const handlePrint = useReactToPrint({
-//     content: () => componentRef.current || null,
-//     documentTitle: `${po?.name}_${po?.vendor_name}`,
-//   });
-
-
-//   const parsedNotes = useMemo(() => {
-//     if (!po?.note_points) {
-//       return []; // Return an empty array if there are no notes
-//     }
-//     try {
-//       const parsedObject = JSON.parse(po?.note_points);
-//       const notesList = parsedObject.list;
-//       if (Array.isArray(notesList)) {
-//         // Return a clean array of strings, filtering out any empty notes
-//         return notesList.map((item) => item.note).filter(Boolean);
-//       }
-//     } catch (error) {
-//       console.error("Could not parse po.note_points as JSON:", error);
-//     }
-//     // Return an empty array in case of errors or invalid data structure
-//     return [];
-//   }, [po.note_points]); // Dependency: this logic only re-runs if note_points changes.
-
-
-//   return (
-//     <Sheet open={poPdfSheet} onOpenChange={togglePoPdfSheet}>
-//       <SheetContent className="overflow-y-auto md:min-w-[900px]">
-//         <Button onClick={handlePrint} className="flex items-center gap-1">
-//           <Printer className="h-4 w-4" />
-//           Print
-//         </Button>
-//         <div className={`w-full border mt-6`}>
-//           <div ref={componentRef} className="w-full p-4">
-//             <div className="overflow-x-auto p-4">
-//               <table className="min-w-full divide-gray-200">
-//                 <thead className="border-b border-black">
-//                   <tr>
-//                     <th colSpan={8}>
-//                       <div className="flex justify-between border-gray-600 pb-1">
-//                         <div className="mt-2 flex justify-between">
-//                           <div>
-//                             {/* <img className="w-44" src={redlogo} alt="Nirmaan" /> */}
-//                             <img
-//                               src={logo}
-//                               alt="Nirmaan"
-//                               width="180"
-//                               height="52"
-//                             />
-//                             <div className="pt-2 text-lg text-gray-600 font-semibold">
-//                               Nirmaan(Stratos Infra Technologies Pvt. Ltd.)
-//                             </div>
-//                           </div>
-//                         </div>
-//                         <div>
-//                           <div className="pt-2 text-xl text-gray-600 font-semibold">
-//                             Purchase Order No.
-//                           </div>
-//                           <div className="text-lg font-light italic text-black">
-//                             {po?.name?.toUpperCase()}
-//                           </div>
-//                         </div>
-//                       </div>
-
-//                       <div className="items-start text-start flex justify-between border-b-2 border-gray-600 pb-1 mb-1">
-//                         <div className="text-xs text-gray-600 font-normal">
-//                           {po?.project_gst
-//                             ? po?.project_gst === "29ABFCS9095N1Z9"
-//                               ? "1st Floor, 234, 9th Main, 16th Cross, Sector 6, HSR Layout, Bengaluru - 560102, Karnataka"
-//                               : "7th Floor, MR1, ALTF Global Business Park Cowarking Space, Mehrauli Gurugram Rd, Tower D, Sikanderpur, Gurugram, Haryana - 122002"
-//                             : "Please set company GST number in order to display the Address!"}
-//                         </div>
-//                         <div className="text-xs text-gray-600 font-normal">
-//                           GST: {po?.project_gst || "N/A"}
-//                         </div>
-//                       </div>
-
-//                       <div className="flex justify-between">
-//                         <div>
-//                           <div className="text-gray-600 text-sm pb-2 text-left">
-//                             Vendor Address
-//                           </div>
-//                           <div className="text-sm font-medium text-gray-900 max-w-[280px] truncate text-left">
-//                             {po?.vendor_name}
-//                           </div>
-//                           <div className="text-sm font-medium text-gray-900 break-words max-w-[280px] text-left">
-//                             <AddressView id={po?.vendor_address || ""} />
-//                           </div>
-//                           <div className="text-sm font-medium text-gray-900 text-left">
-//                             GSTIN: {po?.vendor_gst}
-//                           </div>
-//                         </div>
-//                         <div>
-//                           <div>
-//                             <h3 className="text-gray-600 text-sm pb-2 text-left">
-//                               Delivery Location
-//                             </h3>
-//                             <div className="text-sm font-medium text-gray-900 break-words max-w-[280px] text-left">
-//                               <AddressView id={po?.project_address} />
-//                             </div>
-//                           </div>
-//                           <div className="pt-2">
-//                             <div className="text-sm font-normal text-gray-900 text-left">
-//                               <span className="text-gray-600 font-normal">
-//                                 Date:
-//                               </span>
-//                               &nbsp;&nbsp;&nbsp;
-//                               <i>{po?.creation?.split(" ")[0]}</i>
-//                             </div>
-//                             <div className="text-sm font-normal text-gray-900 text-left">
-//                               <span className="text-gray-600 font-normal">
-//                                 Project Name:
-//                               </span>
-//                               &nbsp;&nbsp;&nbsp;
-//                               <i>{po?.project_name}</i>
-//                             </div>
-//                           </div>
-//                         </div>
-//                       </div>
-//                     </th>
-//                   </tr>
-//                   <tr className="border-t border-black">
-//                     <th
-//                       scope="col"
-//                       className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       S. No.
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="py-3 text-left text-xs font-bold text-gray-800 tracking-wider pr-48"
-//                     >
-//                       Items
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="px-4 py-3 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       Unit
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="px-4 py-1 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       Qty
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="px-4 py-1 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       Rate
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="px-4 py-1 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       Tax
-//                     </th>
-//                     <th
-//                       scope="col"
-//                       className="px-4 py-1 text-left text-xs font-bold text-gray-800 tracking-wider"
-//                     >
-//                       Amount
-//                     </th>
-//                   </tr>
-//                 </thead>
-//                 <tbody className={`bg-white`}>
-//                   {orderData?.map((item, index) => {
-//                     return (
-//                       <tr
-//                         key={index}
-//                         className={`${!parseNumber(po?.loading_charges) &&
-//                           !parseNumber(po?.freight_charges) &&
-//                           index === length - 1 &&
-//                           "border-b border-black"
-//                           } page-break-inside-avoid ${index === 15 ? "page-break-before" : ""
-//                           }`}
-//                       >
-//                         <td className="py-2 px-2 text-sm whitespace-nowrap w-[7%]">
-//                           {index + 1}.
-//                         </td>
-//                         <td className="py-2 text-xs whitespace-nowrap text-wrap">
-//                           {item.item_name?.toUpperCase()}
-//                           {item.make && (
-//                             <p className="text-xs italic font-semibold text-gray-500">
-//                               -{" "}{item.make?.toUpperCase()}
-//                             </p>
-//                           )}
-//                           {item.comment && includeComments && (
-//                             <div className="flex gap-1 items-start block p-1">
-//                               <MessageCircleMore className="w-4 h-4 flex-shrink-0" />
-//                               <div className="text-xs text-gray-400">
-//                                 {item.comment}
-//                               </div>
-//                             </div>
-//                           )}
-//                         </td>
-//                         <td className="px-4 py-2 text-sm whitespace-nowrap">
-//                           {item.unit}
-//                         </td>
-//                         <td className="px-4 py-2 text-sm whitespace-nowrap">
-//                           {item.quantity}
-//                         </td>
-//                         <td className="px-4 py-2 text-sm whitespace-nowrap">
-//                           {formatToIndianRupee(item.quote)}
-//                         </td>
-//                         <td className="px-4 py-2 text-sm whitespace-nowrap">
-//                           {item.tax}%
-//                         </td>
-//                         <td className="px-4 py-2 text-sm whitespace-nowrap">
-//                           {formatToIndianRupee(item.quote * item.quantity)}
-//                         </td>
-//                       </tr>
-//                     );
-//                   })}
-
-//                   {/* <tr className="border-t border-black">
-//                     <td className="py-2 text-sm whitespace-nowrap w-[7%]"></td> 
-//                     <td className=" py-2 whitespace-nowrap font-semibold flex justify-start w-[80%]"></td>
-//                     <td className="px-4 py-2 text-sm whitespace-nowrap"></td>
-//                     <td className="px-4 py-2 text-sm whitespace-nowrap"></td>
-//                     <td className="px-4 py-2 text-sm whitespace-nowrap"></td>
-//                     <td className="px-4 py-2 text-sm whitespace-nowrap font-semibold">
-//                       Sub-Total
-//                     </td>
-//                     <td className="px-4 py-2 text-sm whitespace-nowrap font-semibold">
-//                       {formatToIndianRupee(po?.amount)}
-//                     </td>
-//                   </tr> */}
-
-//                   <tr className="border-b border-t border-black">
-//                     <td></td>
-//                     <td></td>
-//                     <td></td>
-//                     <td></td>
-//                     <td></td>
-//                     <td className="space-y-4 w-[110px] py-4 flex flex-col items-end text-sm font-bold page-break-inside-avoid">
-//                       <div>Sub-Total:</div>
-//                       <div>Total Tax(GST):</div>
-//                       <div>Round Off:</div>
-//                       <div>Total:</div>
-//                     </td>
-
-//                     <td className="space-y-4 py-4 text-sm font-bold whitespace-nowrap">
-//                       <div className="ml-4">
-//                         {formatToIndianRupee(POTotals?.totalBase)}
-//                       </div>
-//                       <div className="ml-4">
-//                         {formatToIndianRupee(POTotals?.totalTax)}
-//                       </div>
-//                       <div className="ml-4">
-//                         {" "}
-//                         {formatToIndianRupee(
-//                           (POTotals?.grandTotal -
-//                             Math.round(POTotals?.grandTotal)) *
-//                           -1
-//                         )}
-//                       </div>
-//                       <div className="ml-4">
-//                         {formatToIndianRupee(Math.round(POTotals?.grandTotal))}
-//                       </div>
-//                     </td>
-//                   </tr>
-//                   <tr className="">
-//                     <td colSpan={6}>
-//                       {finalPaymentTerms.length > 0 && (
-//                         <div className="mb-4">
-//                           <div className="text-gray-600 font-bold text-sm py-2">
-//                             Payment
-//                           </div>
-//                           <ul className="list-disc list-inside space-y-1 text-sm text-gray-900">
-//                             <li>
-//                               {finalPaymentTerms
-//                                 // 1. (Optional but Recommended) Filter out terms with no value
-//                                 .filter(
-//                                   (term) => parseFloat(term.percentage) > 0
-//                                 )
-
-//                                 // 2. Map the array of objects to an array of strings in the desired format
-//                                 .map(
-//                                   (term) =>
-//                                     `${parseFloat(term.percentage).toFixed(
-//                                       2
-//                                     )}% -- ${term.label}`
-//                                 )
-
-//                                 // 3. Join the array of strings into a single string, separated by ", "
-//                                 .join(", ")}
-//                             </li>
-//                           </ul>
-//                         </div>
-//                       )}
-//                     </td>
-//                   </tr>
-//                   <tr className="end-of-page page-break-inside-avoid">
-//                     <td colSpan={6}>
-//                       {parsedNotes.length > 0 && (
-//                         <div className="mb-4">
-//                           <div className="text-gray-600 font-bold text-sm py-2">
-//                             Note
-//                           </div>
-//                           <ol className="list-decimal list-inside space-y-1 text-sm text-gray-900">
-//                             {parsedNotes.map((note, index) => (
-//                               <li key={index}>{note}</li>
-//                             ))}
-//                           </ol>
-//                         </div>
-//                       )}
-
-//                       <img src={Seal} className="w-24 h-24" />
-//                       <div className="text-sm text-gray-900 py-6">
-//                         For, Stratos Infra Technologies Pvt. Ltd.
-//                       </div>
-//                     </td>
-//                   </tr>
-//                 </tbody>
-//               </table>
-//             </div>
-//             <div style={{ display: "block", pageBreakBefore: "always" }}></div>
-//             <div className="overflow-x-auto">
-//               <table className="min-w-full divide-gray-200">
-//                 <thead className="border-b border-black">
-//                   <tr>
-//                     <th colSpan={6}>
-//                       <div className="flex justify-between border-gray-600 pb-1">
-//                         <div className="mt-2 flex justify-between">
-//                           <div>
-//                             {/* <img className="w-44" src={redlogo} alt="Nirmaan" /> */}
-//                             <img
-//                               src={logo}
-//                               alt="Nirmaan"
-//                               width="180"
-//                               height="52"
-//                             />
-//                             <div className="pt-2 text-lg text-gray-600 font-semibold">
-//                               Nirmaan(Stratos Infra Technologies Pvt. Ltd.)
-//                             </div>
-//                           </div>
-//                         </div>
-//                         <div>
-//                           <div className="pt-2 text-xl text-gray-600 font-semibold">
-//                             Purchase Order No. :
-//                           </div>
-//                           <div className="text-lg font-light italic text-black">
-//                             {po?.name?.toUpperCase()}
-//                           </div>
-//                         </div>
-//                       </div>
-
-//                       <div className="items-start text-start flex justify-between border-b-2 border-gray-600 pb-1 mb-1">
-//                         <div className="text-xs text-gray-600 font-normal">
-//                           {gstAddressMap[po?.project_gst]}
-//                         </div>
-//                         <div className="text-xs text-gray-600 font-normal">
-//                           GST: {po?.project_gst || "N/A"}
-//                         </div>
-//                       </div>
-//                     </th>
-//                   </tr>
-//                 </thead>
-//                 <tbody>
-//                   <div className="max-w-4xl mx-auto p-6 text-gray-800">
-//                     <h1 className="text-xl font-bold mb-4">
-//                       Terms and Conditions
-//                     </h1>
-//                     <h2 className="text-lg font-semibold mt-6">
-//                       1. Invoicing:
-//                     </h2>
-//                     <ol className="list-decimal pl-6 space-y-2 text-sm">
-//                       <li className="pl-2">
-//                         All invoices shall be submitted in original and shall be
-//                         tax invoices showing the breakup of tax structure/value
-//                         payable at the prevailing rate and a clear description
-//                         of goods.
-//                       </li>
-//                       <li className="pl-2">
-//                         All invoices submitted shall have Delivery
-//                         Challan/E-waybill for supply items.
-//                       </li>
-//                       <li className="pl-2">
-//                         All Invoices shall have the tax registration numbers
-//                         mentioned thereon. The invoices shall be raised in the
-//                         name of “Stratos Infra Technologies Pvt Ltd, Bangalore”.
-//                       </li>
-//                       <li className="pl-2">
-//                         Payments shall be only entertained after receipt of the
-//                         correct invoice.
-//                       </li>
-//                       <li className="pl-2">
-//                         In case of advance request, Advance payment shall be
-//                         paid after the submission of an advance receipt (as
-//                         suggested under GST law).
-//                       </li>
-//                     </ol>
-
-//                     <h2 className="text-lg font-semibold mt-6">2. Payment:</h2>
-//                     <ol className="list-decimal pl-6 space-y-2 text-sm">
-//                       <li className="pl-2">
-//                         Payment shall be done through RTGS/NEFT.
-//                       </li>
-//                       <li className="pl-2">
-//                         A retention amount shall be deducted as per PO payment
-//                         terms and:
-//                       </li>
-//                       <ol className="list-decimal pl-6 space-y-1 text-sm">
-//                         <li className="pl-2">
-//                           In case the vendor is not completing the task assigned
-//                           by Nirmaan a suitable amount, as decided by Nirmaan,
-//                           shall be deducted from the retention amount.
-//                         </li>
-//                         <li className="pl-2">
-//                           The adjusted amount shall be paid on completion of the
-//                           defect liability period.
-//                         </li>
-//                         <li className="pl-2">
-//                           Vendors are expected to pay GST as per the prevailing
-//                           rules. In case the vendor is not making GST payments
-//                           to the tax authority, Nirmaan shall deduct the
-//                           appropriated amount from the invoice payment of the
-//                           vendor.
-//                         </li>
-//                         <li className="pl-2">
-//                           Nirmaan shall deduct the following amounts from the
-//                           final bills:
-//                         </li>
-//                         <ol className="list-decimal pl-6 space-y-1 text-sm">
-//                           <li className="pl-2">
-//                             Amount pertaining to unfinished supply.
-//                           </li>
-//                           <li className="pl-2">
-//                             Amount pertaining to Liquidated damages and other
-//                             fines, as mentioned in the documents.
-//                           </li>
-//                           <li className="pl-2">
-//                             Any agreed amount between the vendor and Nirmaan.
-//                           </li>
-//                         </ol>
-//                       </ol>
-//                     </ol>
-
-//                     <h2 className="text-lg font-semibold mt-6">
-//                       3. Technical Specifications of the Work:
-//                     </h2>
-//                     <ol className="list-decimal pl-6 space-y-2 text-sm">
-//                       <li className="pl-2">
-//                         All goods delivered shall conform to the technical
-//                         specifications mentioned in the vendor’s quote referred
-//                         to in this PO or as detailed in Annexure 1 to this PO.
-//                       </li>
-//                       <li className="pl-2">
-//                         Supply of goods or services shall be strictly as per
-//                         Annexure - 1 or the Vendor’s quote/PI in case of the
-//                         absence of Annexure - I.
-//                       </li>
-//                       <li className="pl-2">
-//                         Any change in line items or quantities shall be duly
-//                         approved by Nirmaan with rate approval prior to supply.
-//                         Any goods supplied by the agency without obtaining due
-//                         approvals shall be subject to the acceptance or
-//                         rejection from Nirmaan.
-//                       </li>
-//                       <li className="pl-2">
-//                         Any damaged/faulty material supplied needs to be
-//                         replaced with a new item free of cost, without extending
-//                         the completion dates.
-//                       </li>
-//                       <li className="pl-2">
-//                         Material supplied in excess and not required by the
-//                         project shall be taken back by the vendor at no cost to
-//                         Nirmaan.
-//                       </li>
-//                     </ol>
-//                     <br />
-//                     <br />
-//                     <br />
-//                     <br />
-//                     <br />
-
-//                     <h1 className="text-xl font-bold mb-4">
-//                       General Terms & Conditions for Purchase Order
-//                     </h1>
-//                     <ol className="list-decimal pl-6 space-y-2 text-sm">
-//                       <li className="pl-2">
-//                         <div className="font-semibold">Liquidity Damages:</div>{" "}
-//                         Liquidity damages shall be applied at 2.5% of the order
-//                         value for every day of delay.
-//                       </li>
-//                       <li className="pl-2">
-//                         <div className="font-semibold">
-//                           Termination/Cancellation:
-//                         </div>{" "}
-//                         If Nirmaan reasonably determines that it can no longer
-//                         continue business with the vendor in accordance with
-//                         applicable legal, regulatory, or professional
-//                         obligations, Nirmaan shall have the right to
-//                         terminate/cancel this PO immediately.
-//                       </li>
-//                       <li className="pl-2">
-//                         <div className="font-semibold">
-//                           Other General Conditions:
-//                         </div>
-//                       </li>
-//                       <ol className="list-decimal pl-6 space-y-1 text-sm">
-//                         <li className="pl-2">
-//                           Insurance: All required insurance including, but not
-//                           limited to, Contractors’ All Risk (CAR) Policy, FLEXA
-//                           cover, and Workmen’s Compensation (WC) policy are in
-//                           the vendor’s scope. Nirmaan in any case shall not be
-//                           made liable for providing these insurance. All
-//                           required insurances are required prior to the
-//                           commencement of the work at the site.
-//                         </li>
-//                         <li className="pl-2">
-//                           Safety: The safety and security of all men deployed
-//                           and materials placed by the Vendor or its agents for
-//                           the project shall be at the risk and responsibility of
-//                           the Vendor. Vendor shall ensure compliance with all
-//                           safety norms at the site. Nirmaan shall have no
-//                           obligation or responsibility on any safety, security &
-//                           compensation related matters for the resources &
-//                           material deployed by the Vendor or its agent.
-//                         </li>
-//                         <li className="pl-2">
-//                           Notice: Any notice or other communication required or
-//                           authorized under this PO shall be in writing and given
-//                           to the party for whom it is intended at the address
-//                           given in this PO or such other address as shall have
-//                           been notified to the other party for that purpose,
-//                           through registered post, courier, facsimile or
-//                           electronic mail.
-//                         </li>
-//                         <li className="pl-2">
-//                           Force Majeure: Neither party shall be liable for any
-//                           delay or failure to perform if such delay or failure
-//                           arises from an act of God or of the public enemy, an
-//                           act of civil disobedience, epidemic, war,
-//                           insurrection, labor action, or governmental action.
-//                         </li>
-//                         <li className="pl-2">
-//                           Name use: Vendor shall not use, or permit the use of,
-//                           the name, trade name, service marks, trademarks, or
-//                           logo of Nirmaan in any form of publicity, press
-//                           release, advertisement, or otherwise without Nirmaan's
-//                           prior written consent.
-//                         </li>
-//                         <li className="pl-2">
-//                           Arbitration: Any dispute arising out of or in
-//                           connection with the order shall be settled by
-//                           Arbitration in accordance with the Arbitration and
-//                           Conciliation Act,1996 (As amended in 2015). The
-//                           arbitration proceedings shall be conducted in English
-//                           in Bangalore by the sole arbitrator appointed by the
-//                           Purchaser.
-//                         </li>
-//                         <li className="pl-2">
-//                           The law governing: All disputes shall be governed as
-//                           per the laws of India and subject to the exclusive
-//                           jurisdiction of the court in Karnataka.
-//                         </li>
-//                       </ol>
-//                     </ol>
-//                   </div>
-//                 </tbody>
-//               </table>
-//             </div>
-//             {po?.custom === "true" && images?.length > 0 && (
-//               <div>
-//                 {images?.map((imgSrc, index) => (
-//                   <img
-//                     key={index}
-//                     src={imgSrc}
-//                     alt={`Attachment ${index + 1}`}
-//                     style={{
-//                       width: "100%",
-//                       marginBottom: "20px",
-//                       marginTop: "20px",
-//                     }}
-//                   />
-//                 ))}
-//               </div>
-//             )}
-//           </div>
-//         </div>
-//       </SheetContent>
-//     </Sheet>
-//   );
-// };
-
-// {# --- ATTACHMENT SECTION --- #}
-
-//     {% if doc.attachment %}
-//         {% set image_list = frappe.call("nirmaan_stack.api.pdf_to_image.get_attachments_for_print", file_url=doc.attachment) %}
-//         {% if image_list and image_list | length > 0 %}
-//             <div style="page-break-before: always;"></div>
-
-//             <!--<div class="section-title">ATTACHMENT</div>-->
-//             <div style="width:100%; text-align:center; margin: -10mm -12mm -15mm -12mm !important; position: relative;">
-//                 {% for img_data in image_list %}
-//                     <div class="converted-image-container">
-//                         <img src="{{ img_data }}" alt="Attachment Page {{ loop.index }}">
-//                     </div>
-//                     {% if not loop.last %}<div style="page-break-after: always;"></div>{% endif %}
-//                 {% endfor %}
-//             </div>
-//         {% endif %}
-//     {% endif %}
-
-// //-------Popdf will custom item also there make dynamically ---
-
 import logo from "@/assets/logo-svg.svg";
 import Seal from "@/assets/NIRMAAN-SEAL.jpeg";
 import {
   ProcurementOrder,
   PurchaseOrderItem,
   PaymentTerm,
-  //  POTotals
 } from "@/types/NirmaanStack/ProcurementOrders";
-import formatToIndianRupee from "@/utils/FormatPrice";
 import { parseNumber } from "@/utils/parseNumber";
-import { useFrappeGetDocList } from "frappe-react-sdk";
-import { MessageCircleMore, Printer, Download } from "lucide-react";
+import { formatDate } from "@/utils/FormatDate";
+import { Download } from "lucide-react";
 import { useUserData } from "@/hooks/useUserData";
-// REMOVED: pdfjs-dist dependency - PDF preview in browser disabled
-// PDF download still works via backend API (handleDownloadPdf)
-// import * as pdfjsLib from "pdfjs-dist";
 import { useEffect, useRef, useState, useMemo } from "react";
 import { AddressView } from "@/components/address-view";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
-
 import { useGstOptions } from "@/hooks/useGstOptions";
 
 interface POPdfProps {
   po: ProcurementOrder | null;
   orderData?: PurchaseOrderItem[];
   paymentTerms?: PaymentTerm[];
-  includeComments: boolean
-  // POTotals?: POTotals;
+  includeComments: boolean;
   poPdfSheet: boolean;
   togglePoPdfSheet: () => void;
 }
 
-// Header Component for reuse
-const POHeader: React.FC<{ po: ProcurementOrder; showVendorInfo?: boolean; resolvedAddress: string }> = ({ po, showVendorInfo = true, resolvedAddress }) => (
-  <thead className="border-b border-black">
-    <tr>
-      <th colSpan={7}>
-        <div className="flex justify-between border-gray-600 pb-1">
-          <div className="mt-2 flex justify-between">
-            <div>
-              <img
-                src={logo}
-                alt="Nirmaan"
-                width="180"
-                height="52"
-              />
-              <div className="pt-2 text-lg text-gray-600 font-semibold">
-                Nirmaan(Stratos Infra Technologies Pvt. Ltd.)
-              </div>
-            </div>
-          </div>
-          <div>
-            <div className="pt-2 text-xl text-gray-600 font-semibold">
-              Purchase Order No.
-            </div>
-            <div className="text-lg font-light italic text-black">
-              {po?.name?.toUpperCase()}
-            </div>
-          </div>
-        </div>
+/* -------------------------------------------------------------------------- */
+/*  Helpers — mirror the Frappe "PO Orders" print format primitives           */
+/* -------------------------------------------------------------------------- */
 
-        <div className="items-start text-start flex justify-between border-b-2 border-gray-600 pb-1 mb-1">
-          <div className="text-xs text-gray-600 font-normal">
-            {resolvedAddress}
-          </div>
-          <div className="text-xs text-gray-600 font-normal">
-            GST: {po?.project_gst || "N/A"}
-          </div>
-        </div>
+// Indian-grouped money WITHOUT the currency symbol — mirrors frappe.utils.fmt_money.
+// (0 renders as "0.00", not "--", to match the print format.)
+const fmtMoney = (val: number | string | undefined, precision = 2) =>
+  parseNumber(val).toLocaleString("en-IN", {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
 
-        {showVendorInfo && (
-          <div className="flex justify-between">
-            <div>
-              <div className="text-gray-600 text-sm pb-2 text-left">
-                Vendor Address
-              </div>
-              <div className="text-sm font-medium text-gray-900 max-w-[280px] truncate text-left">
-                {po?.vendor_name}
-              </div>
-              <div className="text-sm font-medium text-gray-900 break-words max-w-[280px] text-left">
-                <AddressView id={po?.vendor_address || ""} />
-              </div>
-              <div className="text-sm font-medium text-gray-900 text-left">
-                GSTIN: {po?.vendor_gst}
-              </div>
-            </div>
-            <div>
-              <div>
-                <h3 className="text-gray-600 text-sm pb-2 text-left">
-                  Delivery Location
-                </h3>
-                <div className="text-sm font-medium text-gray-900 break-words max-w-[280px] text-left">
-                  <AddressView id={po?.project_address} />
-                </div>
-              </div>
-              <div className="pt-2">
-                <div className="text-sm font-normal text-gray-900 text-left">
-                  <span className="text-gray-600 font-normal">
-                    Date:
-                  </span>
-                  &nbsp;&nbsp;&nbsp;
-                  <i>{po?.creation?.split(" ")[0]}</i>
-                </div>
-                <div className="text-sm font-normal text-gray-900 text-left">
-                  <span className="text-gray-600 font-normal">
-                    Project Name:
-                  </span>
-                  &nbsp;&nbsp;&nbsp;
-                  <i>{po?.project_name}</i>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-      </th>
-    </tr>
-    <tr className="border-t border-black">
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[8%]"
-      >
-        S. No.
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[35%]"
-      >
-        Items
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[10%]"
-      >
-        Unit
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[10%]"
-      >
-        Qty
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[12%]"
-      >
-        Rate
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[10%]"
-      >
-        Tax
-      </th>
-      <th
-        scope="col"
-        className="py-3 px-2 text-left text-xs font-bold text-gray-800 tracking-wider w-[15%]"
-      >
-        Amount
-      </th>
-    </tr>
-  </thead>
-);
+// Amount in words (Indian numbering system) — mirrors frappe.utils.money_in_words.
+const A_ONES = [
+  "", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine",
+  "Ten", "Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen",
+  "Seventeen", "Eighteen", "Nineteen",
+];
+const A_TENS = ["", "", "Twenty", "Thirty", "Forty", "Fifty", "Sixty", "Seventy", "Eighty", "Ninety"];
 
-// Function to estimate item height based on content
-const estimateItemHeight = (item: PurchaseOrderItem, includeComments: boolean) => {
-  const baseHeight = 40; // Base height for a simple item
-  let estimatedHeight = baseHeight;
-
-  // Estimate height based on item name length (assume ~35 characters per line)
-  const itemNameLines = Math.ceil((item.item_name?.length || 0) / 35);
-  if (itemNameLines > 1) {
-    estimatedHeight += (itemNameLines - 1) * 16; // 16px per additional line
-  }
-
-  // Add height for make if present
-  if (item.make) {
-    const makeLines = Math.ceil(item.make.length / 35);
-    estimatedHeight += makeLines * 16;
-  }
-
-  // Add height for comments if present and included
-  if (item.comment && includeComments) {
-    const commentLines = Math.ceil(item.comment.length / 30); // Comments are usually smaller text
-    estimatedHeight += commentLines * 14 + 20; // Extra padding for comment box
-  }
-
-  return estimatedHeight;
+const twoDigitWords = (n: number): string => {
+  if (n < 20) return A_ONES[n];
+  const t = A_TENS[Math.floor(n / 10)];
+  const o = n % 10;
+  return o ? `${t} ${A_ONES[o]}` : t;
 };
 
-// Item Row Component
-const ItemRow: React.FC<{
-  item: PurchaseOrderItem;
-  index: number;
-  includeComments: boolean;
-}> = ({ item, index, includeComments }) => (
-  <tr className="page-break-inside-avoid border-b border-gray-200">
-    <td className="py-2 px-2 text-sm align-top w-[8%]">
-      {index + 1}.
-    </td>
-    <td className="py-2 px-2 text-xs align-top w-[35%]">
-      <div className="break-words">
-        <div className="font-medium leading-tight">
-          {item.item_name?.toUpperCase()}
-        </div>
-        {item.make && (
-          <div className="text-xs italic font-semibold text-gray-500 mt-1 leading-tight">
-            - {item.make?.toUpperCase()}
-          </div>
-        )}
-        {item.comment && includeComments && (
-          <div className="flex gap-1 items-start mt-2 p-2 bg-gray-50 rounded">
-            <MessageCircleMore className="w-3 h-3 flex-shrink-0 mt-0.5" />
-            <div className="text-xs text-gray-600 break-words leading-tight">
-              {item.comment}
-            </div>
-          </div>
-        )}
-      </div>
-    </td>
-    <td className="py-2 px-2 text-sm align-top w-[10%]">
-      {item.unit}
-    </td>
-    <td className="py-2 px-2 text-sm align-top w-[10%]">
-      {item.quantity}
-    </td>
-    <td className="py-2 px-2 text-sm align-top w-[12%]">
-      {formatToIndianRupee(item.quote)}
-    </td>
-    <td className="py-2 px-2 text-sm align-top w-[10%]">
-      {item.tax}%
-    </td>
-    <td className="py-2 px-2 text-sm align-top w-[15%]">
-      {formatToIndianRupee(item.quote * item.quantity)}
-    </td>
-  </tr>
-);
+const threeDigitWords = (n: number): string => {
+  let str = "";
+  if (n > 99) {
+    str += `${A_ONES[Math.floor(n / 100)]} Hundred`;
+    n %= 100;
+    if (n) str += " ";
+  }
+  if (n) str += twoDigitWords(n);
+  return str;
+};
+
+const amountInWords = (value: number): string => {
+  let num = Math.round(parseNumber(value));
+  if (num === 0) return "INR Zero Only";
+  let words = "";
+  const crore = Math.floor(num / 10000000);
+  num %= 10000000;
+  const lakh = Math.floor(num / 100000);
+  num %= 100000;
+  const thousand = Math.floor(num / 1000);
+  num %= 1000;
+  if (crore) words += `${threeDigitWords(crore)} Crore `;
+  if (lakh) words += `${twoDigitWords(lakh)} Lakh `;
+  if (thousand) words += `${twoDigitWords(thousand)} Thousand `;
+  if (num) words += threeDigitWords(num);
+  return `INR ${words.trim().replace(/\s+/g, " ")} Only`;
+};
+
+// Scoped styles — adapted 1:1 from the "PO Orders" print format CSS, namespaced
+// under .po-print-preview so nothing leaks into the rest of the app.
+const POPDF_STYLES = `
+.po-print-preview { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; font-size: 11px; color: #333; background: #fff; }
+.po-print-preview p { margin: 2px 0; line-height: 1.4; }
+
+.po-print-preview .pf-header { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 4px solid #000; padding-bottom: 8px; margin-bottom: 15px; }
+.po-print-preview .pf-header .logo { max-width: 140px; max-height: 40px; }
+.po-print-preview .pf-header .company { text-align: right; font-size: 11px; }
+.po-print-preview .pf-header .company .name { font-weight: bold; }
+
+.po-print-preview .po-title-row { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 2px solid #333; padding-bottom: 10px; margin-bottom: 15px; }
+.po-print-preview .po-title { font-size: 22px; font-weight: bold; color: #1a1a1a; text-transform: uppercase; padding-top: 5px; }
+.po-print-preview .po-meta { text-align: right; font-size: 11px; }
+
+.po-print-preview .address-block { display: flex; justify-content: space-between; margin-bottom: 15px; }
+.po-print-preview .address-block .addr-col { width: 48%; font-size: 11px; }
+.po-print-preview .address-block h4 { font-size: 11px; font-weight: bold; text-transform: uppercase; color: #555; margin: 0 0 6px 0; }
+
+.po-print-preview .items-table { width: 100%; border-collapse: collapse; margin-bottom: 15px; }
+.po-print-preview .items-table th, .po-print-preview .items-table td { border: 1px solid #ddd; padding: 5px 7px; text-align: left; font-size: 11px; vertical-align: top; }
+.po-print-preview .items-table th { background: #f0f0f0; font-weight: bold; text-transform: uppercase; }
+.po-print-preview .items-table .note { margin-top: 3px; color: #666; font-size: 10px; font-style: italic; }
+.po-print-preview .text-right { text-align: right; }
+.po-print-preview .text-center { text-align: center; }
+
+.po-print-preview .totals-section { display: flex; justify-content: space-between; margin-top: 15px; }
+.po-print-preview .totals-section .notes-terms { width: 58%; font-size: 11px; }
+.po-print-preview .totals-section .summary { width: 40%; }
+.po-print-preview .totals-section .summary table { width: 100%; font-size: 11px; }
+.po-print-preview .totals-section .summary td { padding: 3px 0; }
+.po-print-preview .totals-section .summary .grand-total td { font-weight: bold; font-size: 12px; border-top: 1px solid #333; border-bottom: 1px solid #333; padding-top: 6px; padding-bottom: 6px; }
+.po-print-preview .notes-terms .notes-head { font-size: 11px; font-weight: bold; margin: 10px 0 3px; }
+.po-print-preview .notes-terms .notes-body { font-size: 10px; }
+.po-print-preview .notes-terms ol { padding-left: 18px; margin: 0; }
+
+.po-print-preview .payment-row { margin-top: 20px; font-size: 11px; border-top: 1px dashed #ccc; padding-top: 8px; }
+.po-print-preview .payment-row .payment-label { font-weight: bold; color: #555; }
+
+.po-print-preview .signature-area { margin-top: 40px; text-align: right; }
+.po-print-preview .signature-area .seal { max-width: 90px; max-height: 90px; display: block; margin-left: auto; margin-bottom: 5px; }
+.po-print-preview .signature-area .sign-line { width: 180px; border-top: 1px solid #333; margin-left: auto; margin-bottom: 5px; }
+.po-print-preview .signature-area p { font-size: 11px; margin: 0; }
+
+.po-print-preview .tc-container { margin-top: 30px; border-top: 2px dashed #bbb; padding-top: 20px; }
+.po-print-preview .tc-content h1 { font-size: 16px; font-weight: bold; text-transform: uppercase; margin: 20px 0 15px; text-align: center; text-decoration: underline; }
+.po-print-preview .tc-content h2 { font-size: 12px; font-weight: bold; margin: 20px 0 10px; color: #222; text-transform: uppercase; }
+.po-print-preview .tc-content ol { padding-left: 25px; margin: 0; }
+.po-print-preview .tc-content li { font-size: 11.5px; line-height: 1.6; margin-bottom: 8px; text-align: justify; }
+
+.po-print-preview .footer-notes { margin-top: 25px; font-size: 9px; color: #777; border-top: 1px dashed #ccc; padding-top: 8px; text-align: center; }
+
+.po-print-preview .attachments img { width: 100%; margin: 20px 0; }
+`;
 
 export const POPdf: React.FC<POPdfProps> = ({
   po,
   orderData,
   includeComments,
-  // POTotals,
   paymentTerms,
   poPdfSheet,
   togglePoPdfSheet,
@@ -1033,36 +149,21 @@ export const POPdf: React.FC<POPdfProps> = ({
 
   const resolvedAddress = useMemo(() => {
     // 1. Try to find by PO's project_gst
-    const match = gstOptions.find(opt => opt.gst === po?.project_gst);
+    const match = gstOptions.find((opt) => opt.gst === po?.project_gst);
     if (match?.address) return match.address;
 
     // 2. Fallback to Bengaluru
-    const bengaluru = gstOptions.find(opt => opt.location === "Bengaluru");
-    return bengaluru?.address || "1st Floor, 234, 9th Main, 16th Cross, Sector 6, HSR Layout, Bengaluru - 560102, Karnataka";
+    const bengaluru = gstOptions.find((opt) => opt.location === "Bengaluru");
+    return (
+      bengaluru?.address ||
+      "1st Floor, 234, 9th Main, 16th Cross, Sector 6, HSR Layout, Bengaluru - 560102, Karnataka"
+    );
   }, [gstOptions, po?.project_gst]);
 
-  // Dynamic page height calculation (approximate print page height in pixels)
-  const PAGE_HEIGHT = 1000; // Adjust based on your print settings
-  const HEADER_HEIGHT = 200; // Approximate header height
-  const AVAILABLE_HEIGHT = PAGE_HEIGHT - HEADER_HEIGHT;
-
-  const finalPaymentTerms = paymentTerms && paymentTerms.length > 0 ? paymentTerms : po?.payment_terms;
-
-  // const { data: attachmentsData } = useFrappeGetDocList(
-  //   "Nirmaan Attachments",
-  //   {
-  //     fields: ["*"],
-  //     filters: [
-  //       ["associated_doctype", "=", "Procurement Requests"],
-  //       ["associated_docname", "=", po?.procurement_request!],
-  //       ["attachment_type", "=", "custom pr attachment"],
-  //     ],
-  //   },
-  //   po?.procurement_request ? undefined : null
-  // );
+  const finalPaymentTerms =
+    paymentTerms && paymentTerms.length > 0 ? paymentTerms : po?.payment_terms;
 
   const [images, setImages] = useState([]);
-  const [isPrinting, setIsPrinting] = useState(false);
   const [downloadingFormat, setDownloadingFormat] = useState<string | null>(null);
 
   // Helper to process a single attachment and return list of image URLs (or data URLs for PDF pages)
@@ -1099,37 +200,6 @@ export const POPdf: React.FC<POPdfProps> = ({
         // which merges PDFs server-side and provides a single download
         console.log("PDF preview disabled - use Download button for PDF with attachments");
         return [];
-
-        /* REMOVED: pdfjs-based PDF rendering
-        console.log("Fetching PDF...");
-        const response = await fetch(fileUrl, { method: "GET" });
-
-        if (!response.ok) {
-           const errText = await response.text();
-           throw new Error(`Failed to fetch PDF: ${response.status} ${response.statusText} - ${errText}`);
-        }
-
-        const pdfArrayBuffer = await response.arrayBuffer();
-        console.log("PDF fetched, size:", pdfArrayBuffer.byteLength);
-
-        const loadingTask = pdfjsLib.getDocument({ data: pdfArrayBuffer });
-        const pdf = await loadingTask.promise;
-
-        const pages = [];
-        for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
-          const page = await pdf.getPage(pageNum);
-          const viewport = page.getViewport({ scale: 1.5 });
-          const canvas = document.createElement("canvas");
-          const context = canvas.getContext("2d");
-          canvas.height = viewport.height;
-          canvas.width = viewport.width;
-
-          await page.render({ canvasContext: context, viewport }).promise;
-          const imgData = canvas.toDataURL();
-          pages.push(imgData);
-        }
-        return pages;
-        */
       } else if (["png", "jpg", "jpeg", "gif", "webp"].includes(fileType)) {
         return [fileUrl];
       } else {
@@ -1160,7 +230,7 @@ export const POPdf: React.FC<POPdfProps> = ({
       }
 
       // Process concurrently
-      const results = await Promise.all(allAttachments.map(att => getImagesFromAttachment(att)));
+      const results = await Promise.all(allAttachments.map((att) => getImagesFromAttachment(att)));
 
       // Flatten results
       const flattenedImages = results.flat();
@@ -1176,9 +246,6 @@ export const POPdf: React.FC<POPdfProps> = ({
       isActive = false;
     };
   }, [po?.attachment]);
-
-
-
 
   const handleDownloadPdf = async (formatName: string) => {
     if (!po?.name) return;
@@ -1200,7 +267,7 @@ export const POPdf: React.FC<POPdfProps> = ({
       const downloadUrl = window.URL.createObjectURL(blob);
 
       // Create temporary link to trigger download with custom filename
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.href = downloadUrl;
       // Custom Filename: [PO Number]_[Project Name]_[Format].pdf
       const safeName = po.name.replace(/\//g, "_");
@@ -1218,7 +285,7 @@ export const POPdf: React.FC<POPdfProps> = ({
       console.error("Download failed:", error);
       // Fallback -> Standard Print
       const url = `/api/method/frappe.utils.print_format.download_pdf?doctype=Procurement Orders&name=${po?.name}&format=${formatName}&no_letterhead=0`;
-      window.open(url, '_blank');
+      window.open(url, "_blank");
     } finally {
       setDownloadingFormat(null);
     }
@@ -1240,40 +307,45 @@ export const POPdf: React.FC<POPdfProps> = ({
     return [];
   }, [po.note_points]);
 
-  // Smart pagination function that considers item height
-  const smartPagination = (items: PurchaseOrderItem[]) => {
-    if (!items || items.length === 0) return [];
+  /* ---- Totals computed from items (mirrors the print format math) ---- */
+  const items = orderData || [];
+  const subTotal = items.reduce(
+    (acc, it) => acc + parseNumber(it.quote) * parseNumber(it.quantity),
+    0
+  );
+  const totalTax = items.reduce(
+    (acc, it) =>
+      acc + (parseNumber(it.quote) * parseNumber(it.quantity) * parseNumber(it.tax)) / 100,
+    0
+  );
+  const freight = parseNumber(po?.freight_charges);
+  const loading = parseNumber(po?.loading_charges);
+  const exactGrandTotal = subTotal + totalTax + freight + loading;
+  const roundedGrandTotal = Math.round(exactGrandTotal);
+  const roundOff = roundedGrandTotal - exactGrandTotal;
+  const totalQty = items.reduce((acc, it) => acc + parseNumber(it.quantity), 0);
 
-    const pages = [];
-    let currentPage = [];
-    let currentPageHeight = 0;
+  // Project Managers may not see rates — render the rate-hidden preview for them
+  // (mirrors the "PO Orders Without Rate" print format / Download Without Rate).
+  const withoutRate = role === "Nirmaan Project Manager Profile";
 
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      const itemHeight = estimateItemHeight(item, includeComments);
+  const companyName = "Nirmaan (Stratos Infra Technologies Pvt. Ltd.)";
 
-      // Check if adding this item would exceed page height
-      if (currentPageHeight + itemHeight > AVAILABLE_HEIGHT && currentPage.length > 0) {
-        // Start a new page
-        pages.push(currentPage);
-        currentPage = [item];
-        currentPageHeight = itemHeight;
-      } else {
-        // Add item to current page
-        currentPage.push(item);
-        currentPageHeight += itemHeight;
-      }
-    }
-
-    // Add the last page if it has items
-    if (currentPage.length > 0) {
-      pages.push(currentPage);
-    }
-
-    return pages;
-  };
-
-  const itemPages = smartPagination(orderData || []);
+  // Reused on both the PO page and the Terms & Conditions page.
+  const headerBlock = (
+    <div className="pf-header">
+      <img src={logo} alt="Nirmaan" className="logo" />
+      <div className="company">
+        <div className="name">{companyName}</div>
+        <div>{resolvedAddress}</div>
+        {po?.project_gst && (
+          <div>
+            <strong>GSTIN:</strong> {po.project_gst}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 
   return (
     <Sheet open={poPdfSheet} onOpenChange={togglePoPdfSheet}>
@@ -1287,7 +359,9 @@ export const POPdf: React.FC<POPdfProps> = ({
                 disabled={!!downloadingFormat}
                 className="flex items-center gap-1 bg-green-600 hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <Download className={`h-4 w-4 ${downloadingFormat === "PO Invoice" ? "animate-bounce" : ""}`} />
+                <Download
+                  className={`h-4 w-4 ${downloadingFormat === "PO Invoice" ? "animate-bounce" : ""}`}
+                />
                 {downloadingFormat === "PO Invoice" ? "Downloading..." : "Download"}
               </Button>
             </>
@@ -1297,481 +371,389 @@ export const POPdf: React.FC<POPdfProps> = ({
             disabled={!!downloadingFormat}
             className="flex items-center gap-1 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <Download className={`h-4 w-4 ${downloadingFormat === "PO Orders Without Rate" ? "animate-bounce" : ""}`} />
+            <Download
+              className={`h-4 w-4 ${
+                downloadingFormat === "PO Orders Without Rate" ? "animate-bounce" : ""
+              }`}
+            />
             {downloadingFormat === "PO Orders Without Rate" ? "Downloading..." : "Download Without Rate"}
           </Button>
         </div>
-        {/* Hide PO render/preview for Project Manager - they can only download without rate */}
-        {role !== "Nirmaan Project Manager Profile" && (
-          <div className={`w-full border mt-6`}>
-            <div ref={componentRef} className="w-full p-4">
 
-              {/* Render all item pages with smart pagination */}
-              {itemPages.map((pageItems, pageIndex) => (
-                <div key={pageIndex} className={pageIndex > 0 ? "page-break" : ""}>
-                  <div className="overflow-x-auto p-4">
-                    <table className="min-w-full table-fixed divide-gray-200">
-                      <POHeader po={po} showVendorInfo={pageIndex === 0} resolvedAddress={resolvedAddress} />
-                      <tbody className="bg-white divide-y divide-gray-200">
-                        {pageItems.map((item, itemIndex) => {
-                          // Calculate global index across all pages
-                          const globalIndex = itemPages.slice(0, pageIndex).reduce((acc, page) => acc + page.length, 0) + itemIndex + 1;
-                          return (
-                            <ItemRow
-                              key={globalIndex}
-                              item={item}
-                              index={globalIndex - 1}
-                              includeComments={includeComments}
-                            />
-                          );
-                        })}
-                        {pageIndex === itemPages.length - 1 && (
-                          <>
-                            <tr className="border-b border-t border-black page-break-inside-avoid">
-                              <td className="py-4 w-[8%]"></td>
-                              <td className="py-4 w-[35%]"></td>
-                              <td className="py-4 w-[10%]"></td>
-                              <td className="py-4 w-[10%]"></td>
-                              <td className="py-4 w-[10%]"></td>
-                              <td className="py-4 text-sm font-bold text-right pr-2 page-break-inside-avoid w-[30%]">
-                                <div className="space-y-2">
-                                  <div>Sub-Total:</div>
-                                  <div>Total Tax(GST):</div>
-                                  <div>Round Off:</div>
-                                  <div>Total:</div>
-                                </div>
-                              </td>
-                              <td className="py-4 text-sm font-bold text-right pr-4 w-[15%]">
-                                <div className="space-y-2">
-                                  <div>
-                                    {formatToIndianRupee(po?.amount)}
-                                  </div>
-                                  <div>
-                                    {formatToIndianRupee(po?.tax_amount)}
-                                  </div>
-                                  <div>
-                                    {formatToIndianRupee(
-                                      (po?.total_amount -
-                                        Math.round(po?.total_amount)) *
-                                      -1
-                                    )}
-                                  </div>
-                                  <div>
-                                    {formatToIndianRupee(Math.round(po?.total_amount))}
-                                  </div>
-                                </div>
-                              </td>
-                            </tr>
+        {/* PO render/preview — full for most roles, rate-hidden for Project Manager */}
+        {(
+          <div className="w-full border mt-6">
+            <style>{POPDF_STYLES}</style>
+            <div ref={componentRef} className="po-print-preview w-full p-6">
+              {/* ============================ PAGE 1 ============================ */}
+              {headerBlock}
 
-
-                            <tr>
-                              <td colSpan={7}>
-                                {finalPaymentTerms && finalPaymentTerms.length > 0 && (
-                                  <div className="mb-4">
-                                    <div className="text-gray-600 font-bold text-sm py-2">
-                                      Payment
-                                    </div>
-                                    <ul className="list-disc list-inside space-y-1 text-sm text-gray-900">
-                                      <li>
-                                        {finalPaymentTerms
-                                          .filter(
-                                            (term) => parseFloat(term.percentage) > 0
-                                          )
-                                          .map(
-                                            (term) =>
-                                              `${parseFloat(term.percentage).toFixed(
-                                                2
-                                              )}% -- ${term.label}`
-                                          )
-                                          .join(", ")}
-                                      </li>
-                                    </ul>
-                                  </div>
-                                )}
-                              </td>
-                            </tr>
-
-                            {/* Notes and signature */}
-                            <tr className="page-break-inside-avoid">
-                              <td colSpan={7}>
-                                {parsedNotes.length > 0 && (
-                                  <div className="mb-4">
-                                    <div className="text-gray-600 font-bold text-sm py-2">
-                                      Note
-                                    </div>
-                                    <ol className="list-decimal list-inside space-y-1 text-sm text-gray-900">
-                                      {parsedNotes.map((note, index) => (
-                                        <li key={index}>{note}</li>
-                                      ))}
-                                    </ol>
-                                  </div>
-                                )}
-                                <img src={Seal} className="w-24 h-24" />
-                                <div className="text-sm text-gray-900 py-6">
-                                  For, Stratos Infra Technologies Pvt. Ltd.
-                                </div>
-                              </td>
-                            </tr>
-                          </>
-                        )}
-                      </tbody>
-                    </table>
-                  </div>
-                  {/* RENDER THE SUMMARY AND TOTALS SECTION ONLY ON THE LAST PAGE */}
-
-                </div>
-              ))}
-
-              {/* Summary and totals section
-            <div className="overflow-x-auto p-4 page-break-inside-avoid">
-              <table className="min-w-full table-fixed divide-gray-200">
-                <POHeader po={po} showVendorInfo={false} />
-                <tbody>
-                  <tr className="border-b border-t border-black page-break-inside-avoid">
-                    <td className="py-4 w-[8%]"></td>
-                    <td className="py-4 w-[35%]"></td>
-                    <td className="py-4 w-[10%]"></td>
-                    <td className="py-4 w-[10%]"></td>
-                   
-                    <td className="py-4 text-sm font-bold text-right pr-2 page-break-inside-avoid w-[30%]">
-                      <div className="space-y-2">
-                        <div>Sub-Total:</div>
-                        <div>Total Tax(GST):</div>
-                        <div>Round Off:</div>
-                        <div>Total:</div>
-                      </div>
-                    </td>
-                    <td className="py-4 text-sm font-bold text-right pr-4 w-[15%]">
-                      <div className="space-y-2">
-                        <div>
-                          {formatToIndianRupee(POTotals?.totalBase)}
-                        </div>
-                        <div>
-                          {formatToIndianRupee(POTotals?.totalTax)}
-                        </div>
-                        <div>
-                          {formatToIndianRupee(
-                            (POTotals?.grandTotal -
-                              Math.round(POTotals?.grandTotal)) *
-                            -1
-                          )}
-                        </div>
-                        <div>
-                          {formatToIndianRupee(Math.round(POTotals?.grandTotal))}
-                        </div>
-                      </div>
-                    </td>
-                  </tr>
-                  
-                 
-                  <tr>
-                    <td colSpan={7}>
-                      {finalPaymentTerms && finalPaymentTerms.length > 0 && (
-                        <div className="mb-4">
-                          <div className="text-gray-600 font-bold text-sm py-2">
-                            Payment
-                          </div>
-                          <ul className="list-disc list-inside space-y-1 text-sm text-gray-900">
-                            <li>
-                              {finalPaymentTerms
-                                .filter(
-                                  (term) => parseFloat(term.percentage) > 0
-                                )
-                                .map(
-                                  (term) =>
-                                    `${parseFloat(term.percentage).toFixed(
-                                      2
-                                    )}% -- ${term.label}`
-                                )
-                                .join(", ")}
-                            </li>
-                          </ul>
-                        </div>
-                      )}
-                    </td>
-                  </tr>
-                  
-         
-                  <tr className="page-break-inside-avoid">
-                    <td colSpan={7}>
-                      {parsedNotes.length > 0 && (
-                        <div className="mb-4">
-                          <div className="text-gray-600 font-bold text-sm py-2">
-                            Note
-                          </div>
-                          <ol className="list-decimal list-inside space-y-1 text-sm text-gray-900">
-                            {parsedNotes.map((note, index) => (
-                              <li key={index}>{note}</li>
-                            ))}
-                          </ol>
-                        </div>
-                      )}
-                      <img src={Seal} className="w-24 h-24" />
-                      <div className="text-sm text-gray-900 py-6">
-                        For, Stratos Infra Technologies Pvt. Ltd.
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div> */}
-
-              {/* Terms and Conditions Page */}
-              <div className="page-break ">
-                <div className="overflow-x-auto px-4">
-                  <table className="min-w-full divide-gray-200">
-                    <thead className="border-b border-black mt-2">
-                      <tr>
-                        <th colSpan={6}>
-                          <div className="flex justify-between border-gray-600 pb-1 pt-2 mt-4">
-                            <div className=" flex justify-between">
-                              <div>
-                                <img
-                                  src={logo}
-                                  alt="Nirmaan"
-                                  width="180"
-                                  height="52"
-                                />
-                                <div className="pt-2 text-lg text-gray-600 font-semibold">
-                                  Nirmaan(Stratos Infra Technologies Pvt. Ltd.)
-                                </div>
-                              </div>
-                            </div>
-                            <div>
-                              <div className="pt-2 text-xl text-gray-600 font-semibold">
-                                Purchase Order No. :
-                              </div>
-                              <div className="text-lg font-light italic text-black">
-                                {po?.name?.toUpperCase()}
-                              </div>
-                            </div>
-                          </div>
-
-                          <div className="items-start text-start flex justify-between border-b-2 border-gray-600 pb-1 mb-1">
-                            <div className="text-xs text-gray-600 font-normal">
-                              {resolvedAddress}
-                            </div>
-                            <div className="text-xs text-gray-600 font-normal">
-                              GST: {po?.project_gst || "N/A"}
-                            </div>
-                          </div>
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td colSpan={6}>
-                          <div className="max-w-4xl mx-auto p-6 text-gray-800">
-                            <h1 className="text-xl font-bold mb-4">
-                              Terms and Conditions
-                            </h1>
-                            <h2 className="text-lg font-semibold mt-6">
-                              1. Invoicing:
-                            </h2>
-                            <ol className="list-decimal pl-6 space-y-2 text-sm">
-                              <li className="pl-2">
-                                All invoices shall be submitted in original and shall be
-                                tax invoices showing the breakup of tax structure/value
-                                payable at the prevailing rate and a clear description
-                                of goods.
-                              </li>
-                              <li className="pl-2">
-                                All invoices submitted shall have Delivery
-                                Challan/E-waybill for supply items.
-                              </li>
-                              <li className="pl-2">
-                                All Invoices shall have the tax registration numbers
-                                mentioned thereon. The invoices shall be raised in the
-                                name of "Stratos Infra Technologies Pvt Ltd, Bangalore".
-                              </li>
-                              <li className="pl-2">
-                                Payments shall be only entertained after receipt of the
-                                correct invoice.
-                              </li>
-                              <li className="pl-2">
-                                In case of advance request, Advance payment shall be
-                                paid after the submission of an advance receipt (as
-                                suggested under GST law).
-                              </li>
-                            </ol>
-
-                            <h2 className="text-lg font-semibold mt-6">2. Payment:</h2>
-                            <ol className="list-decimal pl-6 space-y-2 text-sm">
-                              <li className="pl-2">
-                                Payment shall be done through RTGS/NEFT.
-                              </li>
-                              <li className="pl-2">
-                                A retention amount shall be deducted as per PO payment
-                                terms and:
-                              </li>
-                              <li className="pl-2">
-                                In case the vendor is not completing the task assigned
-                                by Nirmaan a suitable amount, as decided by Nirmaan,
-                                shall be deducted from the retention amount.
-                              </li>
-                              <li className="pl-2">
-                                The adjusted amount shall be paid on completion of the
-                                defect liability period.
-                              </li>
-                              <li className="pl-2">
-                                Vendors are expected to pay GST as per the prevailing
-                                rules. In case the vendor is not making GST payments
-                                to the tax authority, Nirmaan shall deduct the
-                                appropriated amount from the invoice payment of the
-                                vendor.
-                              </li>
-                              <li className="pl-2">
-                                Nirmaan shall deduct the following amounts from the
-                                final bills:
-                              </li>
-                              <li className="pl-2">
-                                Amount pertaining to unfinished supply.
-                              </li>
-                              <li className="pl-2">
-                                Amount pertaining to Liquidated damages and other
-                                fines, as mentioned in the documents.
-                              </li>
-                              <li className="pl-2">
-                                Any agreed amount between the vendor and Nirmaan.
-                              </li>
-                            </ol>
-
-                            <h2 className="text-lg font-semibold mt-6">
-                              3. Technical Specifications of the Work:
-                            </h2>
-                            <ol className="list-decimal pl-6 space-y-2 text-sm">
-                              <li className="pl-2">
-                                All goods delivered shall conform to the technical
-                                specifications mentioned in the vendor's quote referred
-                                to in this PO or as detailed in Annexure 1 to this PO.
-                              </li>
-                              <li className="pl-2">
-                                Supply of goods or services shall be strictly as per
-                                Annexure - 1 or the Vendor's quote/PI in case of the
-                                absence of Annexure - I.
-                              </li>
-                              <li className="pl-2">
-                                Any change in line items or quantities shall be duly
-                                approved by Nirmaan with rate approval prior to supply.
-                                Any goods supplied by the agency without obtaining due
-                                approvals shall be subject to the acceptance or
-                                rejection from Nirmaan.
-                              </li>
-                              <li className="pl-2">
-                                Any damaged/faulty material supplied needs to be
-                                replaced with a new item free of cost, without extending
-                                the completion dates.
-                              </li>
-                              <li className="pl-2">
-                                Material supplied in excess and not required by the
-                                project shall be taken back by the vendor at no cost to
-                                Nirmaan.
-                              </li>
-                            </ol>
-
-                            <h1 className="text-xl font-bold mb-4 mt-8">
-                              General Terms & Conditions for Purchase Order
-                            </h1>
-                            <ol className="list-decimal pl-6 space-y-2 text-sm">
-                              <li className="pl-2">
-                                <div className="font-semibold">Liquidity Damages:</div>{" "}
-                                Liquidity damages shall be applied at 2.5% of the order
-                                value for every day of delay.
-                              </li>
-                              <li className="pl-2">
-                                <div className="font-semibold">
-                                  Termination/Cancellation:
-                                </div>{" "}
-                                If Nirmaan reasonably determines that it can no longer
-                                continue business with the vendor in accordance with
-                                applicable legal, regulatory, or professional
-                                obligations, Nirmaan shall have the right to
-                                terminate/cancel this PO immediately.
-                              </li>
-                              <li className="pl-2">
-                                <div className="font-semibold">
-                                  Other General Conditions:
-                                </div>
-                              </li>
-                              <li className="pl-2">
-                                Insurance: All required insurance including, but not
-                                limited to, Contractors' All Risk (CAR) Policy, FLEXA
-                                cover, and Workmen's Compensation (WC) policy are in
-                                the vendor's scope. Nirmaan in any case shall not be
-                                made liable for providing these insurance. All
-                                required insurances are required prior to the
-                                commencement of the work at the site.
-                              </li>
-                              <li className="pl-2">
-                                Safety: The safety and security of all men deployed
-                                and materials placed by the Vendor or its agents for
-                                the project shall be at the risk and responsibility of
-                                the Vendor. Vendor shall ensure compliance with all
-                                safety norms at the site. Nirmaan shall have no
-                                obligation or responsibility on any safety, security &
-                                compensation related matters for the resources &
-                                material deployed by the Vendor or its agent.
-                              </li>
-                              <li className="pl-2">
-                                Notice: Any notice or other communication required or
-                                authorized under this PO shall be in writing and given
-                                to the party for whom it is intended at the address
-                                given in this PO or such other address as shall have
-                                been notified to the other party for that purpose,
-                                through registered post, courier, facsimile or
-                                electronic mail.
-                              </li>
-                              <li className="pl-2">
-                                Force Majeure: Neither party shall be liable for any
-                                delay or failure to perform if such delay or failure
-                                arises from an act of God or of the public enemy, an
-                                act of civil disobedience, epidemic, war,
-                                insurrection, labor action, or governmental action.
-                              </li>
-                              <li className="pl-2">
-                                Name use: Vendor shall not use, or permit the use of,
-                                the name, trade name, service marks, trademarks, or
-                                logo of Nirmaan in any form of publicity, press
-                                release, advertisement, or otherwise without Nirmaan's
-                                prior written consent.
-                              </li>
-                              <li className="pl-2">
-                                Arbitration: Any dispute arising out of or in
-                                connection with the order shall be settled by
-                                Arbitration in accordance with the Arbitration and
-                                Conciliation Act,1996 (As amended in 2015). The
-                                arbitration proceedings shall be conducted in English
-                                in Bangalore by the sole arbitrator appointed by the
-                                Purchaser.
-                              </li>
-                              <li className="pl-2">
-                                The law governing: All disputes shall be governed as
-                                per the laws of India and subject to the exclusive
-                                jurisdiction of the court in Karnataka.
-                              </li>
-                            </ol>
-                          </div>
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+              {/* Title + PO meta */}
+              <div className="po-title-row">
+                <div className="po-title">Purchase Order</div>
+                <div className="po-meta">
+                  <p>
+                    <strong>PO Number:</strong> {po?.name}
+                  </p>
+                  <p>
+                    <strong>PO Date:</strong> {po?.creation ? formatDate(po.creation) : "N/A"}
+                  </p>
                 </div>
               </div>
 
+              {/* Vendor / Ship-to */}
+              <div className="address-block">
+                <div className="addr-col">
+                  <h4>Vendor Details</h4>
+                  <p>
+                    <strong>{po?.vendor_name}</strong>
+                  </p>
+                  <div>
+                    <AddressView id={po?.vendor_address || ""} />
+                  </div>
+                  {po?.vendor_gst && (
+                    <p>
+                      <strong>GSTIN:</strong> {po.vendor_gst}
+                    </p>
+                  )}
+                </div>
+                <div className="addr-col">
+                  <h4>Ship-To / Project Details</h4>
+                  <p>
+                    <strong>{po?.project_name}</strong>
+                  </p>
+                  <div>
+                    <AddressView id={po?.project_address || ""} />
+                  </div>
+                  {po?.delivery_contact && (
+                    <p>
+                      <strong>Site Contact:</strong> {po.delivery_contact}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* Items */}
+              <table className="items-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: "5%" }}>Sr.</th>
+                    <th style={{ width: withoutRate ? "55%" : "33%" }}>Item Description</th>
+                    <th style={{ width: withoutRate ? "20%" : "10%" }} className="text-center">
+                      Make
+                    </th>
+                    <th style={{ width: withoutRate ? "10%" : "8%" }} className="text-center">
+                      Qty
+                    </th>
+                    <th style={{ width: withoutRate ? "10%" : "8%" }} className="text-center">
+                      Unit
+                    </th>
+                    {!withoutRate && (
+                      <>
+                        <th style={{ width: "12%" }} className="text-right">
+                          Rate
+                        </th>
+                        <th style={{ width: "10%" }} className="text-right">
+                          Tax %
+                        </th>
+                        <th style={{ width: "14%" }} className="text-right">
+                          Amount
+                        </th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.length > 0 ? (
+                    items.map((item, index) => (
+                      <tr key={index}>
+                        <td className="text-center">{index + 1}</td>
+                        <td>
+                          {item.item_name}
+                          {item.comment && (
+                            <div className="note">Note: {item.comment}</div>
+                          )}
+                        </td>
+                        <td className="text-center">{item.make || "-"}</td>
+                        <td className="text-center">{parseNumber(item.quantity)}</td>
+                        <td className="text-center">{item.unit || "N/A"}</td>
+                        {!withoutRate && (
+                          <>
+                            <td className="text-right">{fmtMoney(item.quote)}</td>
+                            <td className="text-right">{parseNumber(item.tax)}%</td>
+                            <td className="text-right">
+                              {fmtMoney(parseNumber(item.quote) * parseNumber(item.quantity))}
+                            </td>
+                          </>
+                        )}
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={withoutRate ? 5 : 8} style={{ textAlign: "center", padding: "20px" }}>
+                        No items found.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+
+              {/* Totals — full financials hidden in the rate-less view */}
+              {withoutRate ? (
+                parsedNotes.length > 0 && (
+                  <div className="notes-terms" style={{ width: "100%", marginTop: 15 }}>
+                    <div className="notes-head">Notes &amp; Terms:</div>
+                    <ol className="notes-body">
+                      {parsedNotes.map((note, idx) => (
+                        <li key={idx}>{note}</li>
+                      ))}
+                    </ol>
+                  </div>
+                )
+              ) : (
+                <div className="totals-section">
+                  <div className="notes-terms">
+                    <p>
+                      <strong>Total Quantity:</strong> {totalQty}
+                    </p>
+                    <br />
+                    <p>
+                      <strong>Amount in Words:</strong>
+                      <br />
+                      {amountInWords(roundedGrandTotal)}
+                    </p>
+                    {parsedNotes.length > 0 && (
+                      <div>
+                        <div className="notes-head">Notes &amp; Terms:</div>
+                        <ol className="notes-body">
+                          {parsedNotes.map((note, idx) => (
+                            <li key={idx}>{note}</li>
+                          ))}
+                        </ol>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="summary">
+                    <table>
+                      <tbody>
+                        <tr>
+                          <td>Sub-Total:</td>
+                          <td className="text-right">₹ {fmtMoney(subTotal)}</td>
+                        </tr>
+                        <tr>
+                          <td>Total Tax(GST):</td>
+                          <td className="text-right">₹ {fmtMoney(totalTax)}</td>
+                        </tr>
+                        <tr>
+                          <td>Round Off:</td>
+                          <td className="text-right">₹ {fmtMoney(roundOff)}</td>
+                        </tr>
+                        <tr className="grand-total">
+                          <td>Grand Total:</td>
+                          <td className="text-right">₹ {fmtMoney(roundedGrandTotal, 0)}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* Payment — hidden in the rate-less view */}
+              {!withoutRate && finalPaymentTerms && finalPaymentTerms.length > 0 && (
+                <div className="payment-row">
+                  <span className="payment-label">PAYMENT:</span>
+                  <div style={{ marginTop: 3 }}>
+                    {finalPaymentTerms
+                      .filter((term) => parseFloat(String(term.percentage)) > 0)
+                      .map(
+                        (term) =>
+                          `${parseFloat(String(term.percentage)).toFixed(2)}% -- ${term.label}`
+                      )
+                      .join(", ")}
+                  </div>
+                </div>
+              )}
+
+              {/* Signature */}
+              <div className="signature-area">
+                <img src={Seal} className="seal" alt="Seal" />
+                <div className="sign-line" />
+                <p>
+                  For <strong>{companyName}</strong>
+                </p>
+                <p>(Authorized Signatory)</p>
+              </div>
+
+              {/* ============= TERMS & CONDITIONS (hidden in rate-less view) ============= */}
+              {!withoutRate && (
+              <div className="tc-container">
+                {headerBlock}
+                <div className="tc-content">
+                  <h1>Terms and Conditions</h1>
+
+                  <h2>1. Invoicing:</h2>
+                  <ol>
+                    <li>
+                      All invoices shall be submitted in original and shall be tax invoices showing
+                      the breakup of tax structure/value payable at the prevailing rate and a clear
+                      description of goods.
+                    </li>
+                    <li>
+                      All invoices submitted shall have Delivery Challan/E-waybill for supply items.
+                    </li>
+                    <li>
+                      All Invoices shall have the tax registration numbers mentioned thereon. The
+                      invoices shall be raised in the name of "Stratos Infra Technologies Pvt Ltd,
+                      Bangalore".
+                    </li>
+                    <li>Payments shall be only entertained after receipt of the correct invoice.</li>
+                    <li>
+                      In case of advance request, Advance payment shall be paid after the submission
+                      of an advance receipt (as suggested under GST law).
+                    </li>
+                  </ol>
+
+                  <h2>2. Payment:</h2>
+                  <ol>
+                    <li>Payment shall be done through RTGS/NEFT.</li>
+                    <li>
+                      A retention amount shall be deducted as per PO payment terms and:
+                      <ol type="a" style={{ marginTop: 2 }}>
+                        <li>
+                          In case the vendor is not completing the task assigned by Nirmaan a
+                          suitable amount, as decided by Nirmaan, shall be deducted from the retention
+                          amount.
+                        </li>
+                        <li>
+                          The adjusted amount shall be paid on completion of the defect liability
+                          period.
+                        </li>
+                        <li>
+                          Vendors are expected to pay GST as per the prevailing rules. In case the
+                          vendor is not making GST payments to the tax authority, Nirmaan shall deduct
+                          the appropriated amount from the invoice payment of the vendor.
+                        </li>
+                        <li>
+                          Nirmaan shall deduct the following amounts from the final bills:
+                          <ol type="i">
+                            <li>Amount pertaining to unfinished supply.</li>
+                            <li>
+                              Amount pertaining to Liquidated damages and other fines, as mentioned in
+                              the documents.
+                            </li>
+                            <li>Any agreed amount between the vendor and Nirmaan.</li>
+                          </ol>
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+
+                  <h2>3. Technical Specifications of the Work:</h2>
+                  <ol>
+                    <li>
+                      All goods delivered shall conform to the technical specifications mentioned in
+                      the vendor's quote referred to in this PO or as detailed in Annexure 1 to this
+                      PO.
+                    </li>
+                    <li>
+                      Supply of goods or services shall be strictly as per Annexure - 1 or the
+                      Vendor's quote/PI in case of the absence of Annexure - I.
+                    </li>
+                    <li>
+                      Any change in line items or quantities shall be duly approved by Nirmaan with
+                      rate approval prior to supply. Any goods supplied by the agency without
+                      obtaining due approvals shall be subject to the acceptance or rejection from
+                      Nirmaan.
+                    </li>
+                    <li>
+                      Any damaged/faulty material supplied needs to be replaced with a new item free
+                      of cost, without extending the completion dates.
+                    </li>
+                    <li>
+                      Material supplied in excess and not required by the project shall be taken back
+                      by the vendor at no cost to Nirmaan.
+                    </li>
+                  </ol>
+
+                  <h1 style={{ marginTop: 20 }}>General Terms &amp; Conditions for Purchase Order</h1>
+                  <ol>
+                    <li>
+                      <div style={{ fontWeight: "bold", marginBottom: 2 }}>Liquidity Damages:</div>
+                      Liquidity damages shall be applied at 2.5% of the order value for every day of
+                      delay.
+                    </li>
+                    <li>
+                      <div style={{ fontWeight: "bold", marginBottom: 2 }}>
+                        Termination/Cancellation:
+                      </div>
+                      If Nirmaan reasonably determines that it can no longer continue business with
+                      the vendor in accordance with applicable legal, regulatory, or professional
+                      obligations, Nirmaan shall have the right to terminate/cancel this PO
+                      immediately.
+                    </li>
+                    <li>
+                      <div style={{ fontWeight: "bold", marginBottom: 2 }}>
+                        Other General Conditions:
+                      </div>
+                      <ol type="a">
+                        <li>
+                          Insurance: All required insurance including, but not limited to,
+                          Contractors' All Risk (CAR) Policy, FLEXA cover, and Workmen's Compensation
+                          (WC) policy are in the vendor's scope. Nirmaan in any case shall not be made
+                          liable for providing these insurance. All required insurances are required
+                          prior to the commencement of the work at the site.
+                        </li>
+                        <li>
+                          Safety: The safety and security of all men deployed and materials placed by
+                          the Vendor or its agents for the project shall be at the risk and
+                          responsibility of the Vendor. Vendor shall ensure compliance with all safety
+                          norms at the site. Nirmaan shall have no obligation or responsibility on any
+                          safety, security &amp; compensation related matters for the resources &amp;
+                          material deployed by the Vendor or its agent.
+                        </li>
+                        <li>
+                          Notice: Any notice or other communication required or authorized under this
+                          PO shall be in writing and given to the party for whom it is intended at the
+                          address given in this PO or such other address as shall have been notified to
+                          the other party for that purpose, through registered post, courier,
+                          facsimile or electronic mail.
+                        </li>
+                        <li>
+                          Force Majeure: Neither party shall be liable for any delay or failure to
+                          perform if such delay or failure arises from an act of God or of the public
+                          enemy, an act of civil disobedience, epidemic, war, insurrection, labor
+                          action, or governmental action.
+                        </li>
+                        <li>
+                          Name use: Vendor shall not use, or permit the use of, the name, trade name,
+                          service marks, trademarks, or logo of Nirmaan in any form of publicity, press
+                          release, advertisement, or otherwise without Nirmaan's prior written consent.
+                        </li>
+                        <li>
+                          Arbitration: Any dispute arising out of or in connection with the order shall
+                          be settled by Arbitration in accordance with the Arbitration and Conciliation
+                          Act,1996 (As amended in 2015). The arbitration proceedings shall be conducted
+                          in English in Bangalore by the sole arbitrator appointed by the Purchaser.
+                        </li>
+                        <li>
+                          The law governing: All disputes shall be governed as per the laws of India
+                          and subject to the exclusive jurisdiction of the court in Karnataka.
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </div>
+              </div>
+              )}
+
+              <div className="footer-notes">This is a computer-generated Purchase Order.</div>
+
               {/* Attachments */}
               {po?.custom === "true" && images?.length > 0 && (
-                <div>
+                <div className="attachments">
                   {images?.map((imgSrc, index) => (
-                    <img
-                      key={index}
-                      src={imgSrc}
-                      alt={`Attachment ${index + 1}`}
-                      style={{
-                        width: "100%",
-                        marginBottom: "20px",
-                        marginTop: "20px",
-                      }}
-                    />
+                    <img key={index} src={imgSrc} alt={`Attachment ${index + 1}`} />
                   ))}
                 </div>
               )}

--- a/frontend/src/pages/ProcurementOrders/purchase-order/components/PORevisionsAndAdjustments.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/components/PORevisionsAndAdjustments.tsx
@@ -432,6 +432,15 @@ const ItemChangeRow: React.FC<{ item: any }> = ({ item }) => {
     item.item_type === "New" ||
     origRate !== revRate;
 
+  const origComment = (item.original_comment || "").toString().trim();
+  const revComment = (item.revision_comment ?? item.comment ?? "").toString().trim();
+  const commentChanged =
+    item.item_type === "Deleted"
+      ? !!origComment
+      : item.item_type === "New"
+        ? !!revComment
+        : origComment !== revComment;
+
   return (
     <tr className="hover:bg-slate-50/50 transition-colors border-b border-slate-50 last:border-0">
       <td className="pl-3 py-2.5">
@@ -442,9 +451,21 @@ const ItemChangeRow: React.FC<{ item: any }> = ({ item }) => {
         </span>
       </td>
       <td className="py-2.5 pr-2">
-        <span className="text-[11px] text-slate-700 font-medium line-clamp-1">
-          {item.revision_item_name || item.original_item_name || "--"}
-        </span>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[11px] text-slate-700 font-medium line-clamp-1">
+            {item.revision_item_name || item.original_item_name || "--"}
+          </span>
+          {commentChanged && (
+            <div className="flex flex-col gap-0.5">
+              {item.item_type !== "Deleted" && revComment && (
+                <span className="text-[10px] text-slate-500 italic line-clamp-2">💬 {revComment}</span>
+              )}
+              {origComment && origComment !== revComment && (
+                <span className="text-[10px] text-slate-400 line-through line-clamp-2">{origComment}</span>
+              )}
+            </div>
+          )}
+        </div>
       </td>
       <td className="py-2.5 text-center">
         <div className="flex flex-col items-center gap-1">
@@ -464,6 +485,20 @@ const ItemChangeRow: React.FC<{ item: any }> = ({ item }) => {
               revised={revRate}
               formatFn={formatToIndianRupee}
             />
+          )}
+          {commentChanged && (
+            <div className="flex items-center gap-1 px-1.5 py-0.5 bg-slate-50 rounded border border-slate-100/50">
+              <span className="text-[9px] font-medium text-slate-400 uppercase tracking-tighter">
+                Cmt
+              </span>
+              <span className="text-[10px] font-medium text-slate-600">
+                {item.item_type === "Deleted"
+                  ? "removed"
+                  : item.item_type === "New"
+                    ? "added"
+                    : "updated"}
+              </span>
+            </div>
           )}
         </div>
       </td>

--- a/frontend/src/pages/ProjectDesignTracker/config/taskTableColumns.tsx
+++ b/frontend/src/pages/ProjectDesignTracker/config/taskTableColumns.tsx
@@ -186,6 +186,9 @@ export const getTaskTableColumns = (
             cell: ({ row }) => (
                 <span className="text-xs truncate block max-w-[90px]">{row.original.design_category || '--'}</span>
             ),
+            // Pin a case-insensitive string sort so ordering is identical across phases
+            // (default 'auto' samples each phase's rows and can pick a case-sensitive comparator).
+            sortingFn: "text",
             enableColumnFilter: true,
             filterFn: facetedFilterFn,
             size: 100,
@@ -198,6 +201,8 @@ export const getTaskTableColumns = (
             cell: ({ row }) => (
                 <span className="font-medium text-gray-900 text-xs truncate block max-w-[140px]">{row.original.task_name}</span>
             ),
+            // Case-insensitive string sort (see Category column note) for consistent ordering.
+            sortingFn: "text",
             size: 150,
             minSize: 120,
             maxSize: 180,

--- a/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
+++ b/frontend/src/pages/ProjectDesignTracker/project-design-tracker-details.tsx
@@ -851,7 +851,10 @@ export const ProjectDesignTrackerDetailV2: React.FC<ProjectDesignTrackerDetailPr
                 .filter(v => v !== 'Not Applicable'),
         },
     ]);
-    const [sorting, setSorting] = useState<SortingState>([{ id: 'deadline', desc: false }]);
+    const [sorting, setSorting] = useState<SortingState>([
+        { id: 'design_category', desc: false },
+        { id: 'task_name', desc: false },
+    ]);
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 });
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
     const [isBulkAssignOpen, setIsBulkAssignOpen] = useState(false);

--- a/nirmaan_stack/api/po_revisions/revision_history.py
+++ b/nirmaan_stack/api/po_revisions/revision_history.py
@@ -72,6 +72,8 @@ def get_po_revision_history(po_id):
                 "original_rate",
                 "original_tax",
                 "original_amount",
+                "revision_comment",
+                "original_comment",
             ],
             order_by="idx asc",
         )

--- a/nirmaan_stack/api/po_revisions/revision_logic.py
+++ b/nirmaan_stack/api/po_revisions/revision_logic.py
@@ -17,12 +17,51 @@ from nirmaan_stack.api.vendor_credit import recalculate_vendor_credit
 PO_REVISION_AUTO_APPROVAL_THRESHOLD = 5000.0
 
 
+def _is_comment_only_revision(rev_doc):
+    """True when the revision changes nothing financial/structural — only comments.
+
+    A comment edit on an existing line arrives as a 'Revised' item whose qty / rate /
+    tax / item / unit all equal the original (only the comment differs). New / Deleted /
+    Replace rows are structural and disqualify. Such a revision has zero money impact,
+    so it auto-approves regardless of the ₹ single + cumulative thresholds.
+    """
+    if flt(rev_doc.total_amount_difference) != 0:
+        return False
+
+    for item in rev_doc.get("revision_items", []):
+        it = item.item_type
+        if it == "Original":
+            continue
+        if it != "Revised":
+            # New / Deleted / Replace are real structural changes.
+            return False
+        # A "Revised" row qualifies only when every non-comment field is unchanged.
+        if (
+            flt(item.revision_qty) != flt(item.original_qty)
+            or flt(item.revision_rate) != flt(item.original_rate)
+            or flt(item.revision_tax) != flt(item.original_tax)
+            or (item.revision_item_id or "") != (item.original_item_id or "")
+            or (item.revision_unit or "") != (item.original_unit or "")
+        ):
+            return False
+
+    return True
+
+
 def _should_auto_approve_revision(rev_doc):
     """Returns True only if ALL three rules pass:
     1. Single Impact — abs(diff) < threshold
     2. Cumulative Impact — sum of prior approved diffs + current < threshold
     3. Rate Change — no Revised/Replace item has a different rate
+
+    A comment-only (zero-impact) revision short-circuits to True ahead of the rules,
+    so a pure comment edit never needs manual approval even on a PO that has already
+    crossed the cumulative threshold.
     """
+    # Comment-only revisions: zero financial/structural impact → always auto-approve.
+    if _is_comment_only_revision(rev_doc):
+        return True
+
     diff = flt(rev_doc.total_amount_difference)
 
     # Rule 1: Single Impact
@@ -92,6 +131,7 @@ def make_po_revisions(po_id, justification, revision_items, total_amount_differe
                     "original_tax": flt(item.get("original_tax")),
                     "original_category": item.get("original_category"),
                     "original_procurement_package": item.get("original_procurement_package"),
+                    "original_comment": item.get("original_comment"),
                 })
 
             # Revision Details - Skip for "Original" and "Deleted" items
@@ -105,6 +145,7 @@ def make_po_revisions(po_id, justification, revision_items, total_amount_differe
                     "revision_rate": flt(item.get("quote")),
                     "revision_amount": flt(item.get("amount")),
                     "revision_tax": flt(item.get("tax")),
+                    "revision_comment": item.get("comment"),
                 })
 
                 cat = item.get("category") or item.get("original_category")
@@ -478,6 +519,7 @@ def sync_original_po_items(revision_doc):
             new_row.amount = flt(rev_item.revision_amount)
             new_row.tax = flt(rev_item.revision_tax)
             new_row.make = rev_item.revision_make
+            new_row.comment = rev_item.revision_comment
             new_row.tax_amount = (new_row.amount * new_row.tax) / 100
             new_row.total_amount = new_row.amount + new_row.tax_amount
             new_row.received_quantity = 0.0
@@ -513,6 +555,7 @@ def sync_original_po_items(revision_doc):
                 orig_row.amount = flt(rev_item.revision_amount)
                 orig_row.tax = flt(rev_item.revision_tax)
                 orig_row.make = rev_item.revision_make
+                orig_row.comment = rev_item.revision_comment
                 orig_row.tax_amount = (orig_row.amount * orig_row.tax) / 100
                 orig_row.total_amount = orig_row.amount + orig_row.tax_amount
 
@@ -546,6 +589,7 @@ def sync_original_po_items(revision_doc):
                 orig_row.amount = flt(rev_item.revision_amount)
                 orig_row.tax = flt(rev_item.revision_tax)
                 orig_row.make = rev_item.revision_make
+                orig_row.comment = rev_item.revision_comment
                 orig_row.tax_amount = (orig_row.amount * orig_row.tax) / 100
                 orig_row.total_amount = orig_row.amount + orig_row.tax_amount
 

--- a/nirmaan_stack/nirmaan_stack/doctype/po_revisions_items/po_revisions_items.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/po_revisions_items/po_revisions_items.json
@@ -21,6 +21,7 @@
   "revision_amount",
   "revision_category",
   "revision_procurement_package",
+  "revision_comment",
   "original_details_section",
   "original_item_id",
   "original_item_name",
@@ -31,7 +32,8 @@
   "original_tax",
   "original_amount",
   "original_category",
-  "original_procurement_package"
+  "original_procurement_package",
+  "original_comment"
  ],
  "fields": [
   {
@@ -163,6 +165,16 @@
    "fieldname": "original_procurement_package",
    "fieldtype": "Data",
    "label": "Original Procurement Package"
+  },
+  {
+   "fieldname": "revision_comment",
+   "fieldtype": "Small Text",
+   "label": "Revision Comment"
+  },
+  {
+   "fieldname": "original_comment",
+   "fieldtype": "Small Text",
+   "label": "Original Comment"
   }
  ],
  "grid_page_length": 50,


### PR DESCRIPTION
## What's in this (4 commits)

### ✨ Feature
- **Per-item comments on PO revisions.** Add an optional note to each line
  when revising a PO. The comment is shown across the revise, summary,
  history, and detail views, and comment changes are highlighted (💬 / "Cmt
  updated/added/removed" chip). Comment-only revisions are auto-approved.
  *(New `revision_comment` / `original_comment` fields on PO Revisions Items.)*

### 🐛 Fixes
- **Design tracker sort consistency** — task table now sorts by Category then
  Task Name (case-insensitive) the same way in every phase.
- **PO Order Details table** — long item comments no longer stretch the Item
  Name column and squeeze Rate/Tax/Amount.
- **PO PDF preview** — the in-app PO PDF sheet now matches the Frappe "PO
  Orders" print format (with a rate-hidden version for Project Managers).
