### PR TITLE
PO Item invoice_qty + backfill + credit-note handling

### DIFF
--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
@@ -201,7 +201,7 @@ export const DocumentAttachments = <T extends DocumentType>({
   } = useFrappeGetDocList<VendorInvoice>(
     "Vendor Invoices",
     {
-      fields: ["name", "invoice_no", "invoice_date", "invoice_amount", "invoice_attachment", "status", "reconciliation_status", "uploaded_by", "autofill_used"],
+      fields: ["name", "invoice_no", "invoice_date", "invoice_amount", "invoice_attachment", "status", "reconciliation_status", "uploaded_by", "autofill_used", "is_credit_note"],
       filters: [
         ["document_type", "=", docType],
         ["document_name", "=", docName],

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/DocumentAttachments.tsx
@@ -201,7 +201,7 @@ export const DocumentAttachments = <T extends DocumentType>({
   } = useFrappeGetDocList<VendorInvoice>(
     "Vendor Invoices",
     {
-      fields: ["name", "invoice_no", "invoice_date", "invoice_amount", "invoice_attachment", "status", "reconciliation_status", "uploaded_by"],
+      fields: ["name", "invoice_no", "invoice_date", "invoice_amount", "invoice_attachment", "status", "reconciliation_status", "uploaded_by", "autofill_used"],
       filters: [
         ["document_type", "=", docType],
         ["document_name", "=", docName],
@@ -597,7 +597,7 @@ export const DocumentAttachments = <T extends DocumentType>({
               </div>
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="p-0">
             {" "}
             {/* Remove padding to let table control it */}
             <div className="overflow-x-auto">
@@ -612,6 +612,7 @@ export const DocumentAttachments = <T extends DocumentType>({
                 canDeleteEntry={canDeleteInvoice}
                 getUserName={getUserName}
                 hideActions={isEstimatesExecutive}
+                poName={isPO ? docName : undefined}
               />
             </div>
           </CardContent>

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
@@ -162,6 +162,33 @@ export function InvoiceDialog<T extends DocumentType>({
     isEditMode && selectedInvoice?.invoice_attachment ? `Nirmaan-Attachment-${selectedInvoice.invoice_attachment}` : null
   );
 
+  // Editing a Pending invoice, you can REPLACE the file to re-run autofill and
+  // pull the exact values again (fields + line-item mapping) — all in this one
+  // dialog, no separate review step. A Pending PO invoice additionally gets its
+  // line → PO-item mapping rebuilt from the fresh extraction on save.
+  const canReExtract = isEditMode && selectedInvoice?.status === "Pending";
+  const canEditMapping = canReExtract && docType === "Procurement Orders";
+  // True once a replaced file has actually been re-extracted (drives rebuild).
+  const [reExtracted, setReExtracted] = useState(false);
+
+  // Load the invoice's existing auto-fill snapshot (line mapping + extracted
+  // entities) + PO items, so a Pending PO invoice's prior extraction is shown
+  // inline and editable. The fresh re-extraction (file replace) takes over.
+  const { data: savedInvoiceDoc } = useFrappeGetDoc<{
+    autofill_line_match_json?: string;
+    autofill_all_entities_json?: string;
+  }>(
+    "Vendor Invoices",
+    selectedInvoice?.name,
+    canEditMapping && selectedInvoice?.name ? `Invoice-Edit-Snapshot-${selectedInvoice.name}` : null
+  );
+
+  const { data: poDocForEdit } = useFrappeGetDoc<{ items?: any[] }>(
+    "Procurement Orders",
+    docName,
+    canEditMapping ? `Invoice-Edit-PO-${docName}` : null
+  );
+
   // Reset form when dialog closes or Populate when editing
   useEffect(() => {
     if (isOpen) {
@@ -190,6 +217,7 @@ export function InvoiceDialog<T extends DocumentType>({
       setPoItemsForMatch(null);
       setLineMatch(null);
       setRawExtraction(null);
+      setReExtracted(false);
     }
   }, [isOpen, selectedInvoice]);
 
@@ -205,7 +233,41 @@ export function InvoiceDialog<T extends DocumentType>({
     setPoItemsForMatch(null);
     setLineMatch(null);
     setRawExtraction(null);
+    setReExtracted(false);
   }, [selectedAttachment]);
+
+  // Edit mode: show the invoice's existing auto-filled mapping + entities inline
+  // (pre-populated) once the snapshot + PO items load. Once the file is
+  // re-extracted, the fresh data wins — don't overwrite it here.
+  useEffect(() => {
+    if (!canEditMapping || reExtracted) return;
+    const raw = savedInvoiceDoc?.autofill_line_match_json;
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as LineMatch;
+      if (!parsed || !Array.isArray(parsed.mappings)) return;
+      setLineMatch(parsed);
+      setPoItemsForMatch(
+        (poDocForEdit?.items || []).map((it: any) => ({
+          item_id: it.item_id,
+          item_name: it.item_name,
+          unit: it.unit,
+          quantity: it.quantity,
+          received_quantity: it.received_quantity,
+          quote: it.quote,
+          amount: it.amount,
+        }))
+      );
+      let entities: any[] = [];
+      try {
+        const e = savedInvoiceDoc?.autofill_all_entities_json
+          ? JSON.parse(savedInvoiceDoc.autofill_all_entities_json)
+          : [];
+        if (Array.isArray(e)) entities = e;
+      } catch { /* ignore malformed entities snapshot */ }
+      setRawExtraction({ entities });
+    } catch { /* ignore malformed mapping snapshot */ }
+  }, [canEditMapping, reExtracted, savedInvoiceDoc?.autofill_line_match_json, savedInvoiceDoc?.autofill_all_entities_json, poDocForEdit]);
 
   // Handle closing manually to clear selectedInvoice
   const handleClose = useCallback(() => {
@@ -394,9 +456,11 @@ export function InvoiceDialog<T extends DocumentType>({
           variant: "success",
         });
       }
-      // When there's a PO mapping to verify, stop at the Review step; otherwise
-      // (SR invoice / no line items) go straight to the form as before.
-      setStage(hasMapping ? "review" : "form");
+      // EDIT never steps through the review screen — the fresh extraction
+      // (fields + mapping) is applied inline and we stay on the form. CREATE
+      // still routes a PO mapping through the Review step to verify it.
+      if (isEditMode) setReExtracted(true);
+      setStage(!isEditMode && hasMapping ? "review" : "form");
     } catch (error) {
       console.error("Auto-fill error:", error);
       toast({
@@ -411,14 +475,16 @@ export function InvoiceDialog<T extends DocumentType>({
     } finally {
       setIsAutofilling(false);
     }
-  }, [docName, docType, upload, extractInvoiceFieldsApi]);
+  }, [docName, docType, upload, extractInvoiceFieldsApi, isEditMode]);
 
   const handleAttachmentSelect = useCallback((file: File | null) => {
     setSelectedAttachment(file);
-    if (file && !isEditMode) {
+    // Create, OR replacing the file while editing a Pending invoice → re-run
+    // autofill so the exact values (fields + mapping) come back.
+    if (file && (!isEditMode || canReExtract)) {
       runAutofillExtraction(file);
     }
-  }, [isEditMode, runAutofillExtraction]);
+  }, [isEditMode, canReExtract, runAutofillExtraction]);
 
   const clearAutofillFlag = useCallback((field: "invoice_no" | "date" | "amount") => {
     setAutofilledFields((prev) => {
@@ -457,6 +523,10 @@ export function InvoiceDialog<T extends DocumentType>({
       // Only mark as autofilled if at least one field was AI-extracted
       // and we're creating a new invoice (not editing).
       const autofillUsed = !isEditMode && autofilledFields.size > 0;
+      // Edit-mode mapping rebuild: a Pending PO invoice with a mapping shown
+      // inline (loaded from the snapshot, re-extracted, or edited). Rebuilding
+      // from an unchanged mapping is a no-op. Backend re-guards on status.
+      const rebuildMappings = canEditMapping && !!lineMatch;
 
       const apiPayload = {
         docname: docName,
@@ -480,20 +550,23 @@ export function InvoiceDialog<T extends DocumentType>({
         autofill_extracted_receiver_gstin:
           autofillUsed ? (autofillExtractedValues?.receiver_gstin || null) : null,
         autofill_all_entities_json:
-          autofillUsed && autofillAllEntities && autofillAllEntities.length > 0
+          (autofillUsed || rebuildMappings) && autofillAllEntities && autofillAllEntities.length > 0
             ? JSON.stringify(autofillAllEntities)
             : null,
-        // Line items + the user-VERIFIED PO mapping (the corrected lineMatch).
+        // Line items + the PO mapping (fresh on create; re-extracted on edit).
         autofill_line_items_json:
-          autofillUsed && lineItems && lineItems.length > 0
+          (autofillUsed || rebuildMappings) && lineItems && lineItems.length > 0
             ? JSON.stringify(lineItems)
             : null,
         autofill_line_match_json:
-          autofillUsed && lineMatch ? JSON.stringify(lineMatch) : null,
+          (autofillUsed || rebuildMappings) && lineMatch ? JSON.stringify(lineMatch) : null,
         // Source file_url AI extracted from. Backend's auto-approve gate 13
         // confirms the saved invoice_attachment maps to the same file (no swap
         // between auto-fill and submit).
         autofill_source_file_url: autofillUsed ? (uploadedFileUrl || null) : null,
+        // Rebuild the child line_mappings from the corrected mapping (edit of a
+        // Pending PO invoice); backend re-guards on status.
+        rebuild_line_mappings: rebuildMappings,
       };
 
       const response = await updateInvoiceApiCall(apiPayload);
@@ -548,6 +621,10 @@ export function InvoiceDialog<T extends DocumentType>({
     autofillExtractedValues,
     autofillAllEntities,
     uploadedFileUrl,
+    canEditMapping,
+    reExtracted,
+    lineMatch,
+    lineItems,
   ]);
 
   const handleSubmit = useCallback(() => {
@@ -677,7 +754,7 @@ export function InvoiceDialog<T extends DocumentType>({
         open={isOpen}
         onOpenChange={(open) => !open && !isLoading && !isAutofilling ? handleClose() : undefined}
       >
-        <AlertDialogContent className={cn("p-0 gap-0 overflow-hidden", stage === "review" ? "max-w-3xl" : "max-w-lg")}>
+        <AlertDialogContent className={cn("p-0 gap-0 overflow-hidden", (stage === "review" || (canEditMapping && !!lineMatch)) ? "max-w-3xl" : "max-w-lg")}>
           {/* Header */}
           <div className="bg-gray-50/80 px-6 py-4 border-b">
             <AlertDialogHeader className="space-y-1">
@@ -755,7 +832,7 @@ export function InvoiceDialog<T extends DocumentType>({
                 />
               </div>
               <div className="bg-gray-50/80 px-6 py-4 border-t flex items-center justify-between gap-3">
-                <Button variant="outline" onClick={() => setStage("upload")}>
+                <Button variant="outline" onClick={() => setStage(isEditMode ? "form" : "upload")}>
                   Back
                 </Button>
                 <Button onClick={() => setStage("form")}>
@@ -766,7 +843,7 @@ export function InvoiceDialog<T extends DocumentType>({
           ) : (
             // ───────── Stage 3: Form (prefilled if autofill ran) ─────────
             <>
-          <div className="px-6 py-5 space-y-4">
+          <div className="px-6 py-5 space-y-4 max-h-[70vh] overflow-y-auto">
             {!isEditMode && autofilledFields.size > 0 && (
               <div className="flex items-center gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2 -mt-1">
                 <Sparkles className="h-3.5 w-3.5 text-amber-700 flex-shrink-0" />
@@ -775,6 +852,7 @@ export function InvoiceDialog<T extends DocumentType>({
                 </span>
               </div>
             )}
+
 
             {/* Hard-block banner: amount overage on PO */}
             {liveAmountValidation?.wouldExceed && (
@@ -999,7 +1077,7 @@ export function InvoiceDialog<T extends DocumentType>({
                 disabled={isLoading || isAutofilling}
               />
 
-              {!isEditMode && isAutofilling && (
+              {isAutofilling && (
                 <div className="mt-2 flex items-center gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2">
                   <Loader2 className="h-4 w-4 text-amber-700 animate-spin" />
                   <span className="text-xs text-amber-900">
@@ -1007,7 +1085,7 @@ export function InvoiceDialog<T extends DocumentType>({
                   </span>
                 </div>
               )}
-              {!isEditMode && !isAutofilling && autofilledFields.size > 0 && (
+              {!isAutofilling && autofilledFields.size > 0 && (
                 <div className="mt-2 flex items-center gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2">
                   <Sparkles className="h-3.5 w-3.5 text-amber-700" />
                   <span className="text-xs text-amber-900">
@@ -1039,6 +1117,21 @@ export function InvoiceDialog<T extends DocumentType>({
                 </div>
               )}
             </div>
+
+            {/* Existing / re-extracted line-item mapping — shown inline & editable. */}
+            {canEditMapping && lineMatch && (
+              <div className="space-y-1.5">
+                <Label className="text-sm font-medium">Line items &amp; PO mapping</Label>
+                <div className="rounded-md border p-3">
+                  <LineItemMappingReview
+                    extracted={rawExtraction}
+                    poItems={poItemsForMatch || []}
+                    lineMatch={lineMatch}
+                    onChange={setLineMatch}
+                  />
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Footer */}
@@ -1061,6 +1154,7 @@ export function InvoiceDialog<T extends DocumentType>({
                     !invoiceData.amount ||
                     (!isEditMode && !selectedAttachment) ||
                     isLoading ||
+                    isAutofilling ||
                     validationState === "error" ||
                     validationState === "checking" ||
                     !!liveAmountValidation?.wouldExceed ||

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "@/components/ui/use-toast";
 import { useUserData } from "@/hooks/useUserData";
 import { ProcurementOrder } from "@/types/NirmaanStack/ProcurementOrders";
@@ -73,6 +74,34 @@ const initialInvoiceState = {
   invoice_no: "",
   amount: "",
   date: "",
+  is_credit_note: false,
+};
+
+// --- Credit / return note sign helpers ---
+// Force an amount string negative (credit / return note). "" / non-numeric → unchanged.
+const forceNegativeAmount = (amt: string): string => {
+  const n = Number(String(amt).replace(/,/g, ""));
+  if (!amt || !isFinite(n) || n === 0) return amt;
+  return String(-Math.abs(n));
+};
+
+// Apply a sign to every row's quantity — negative for a return note, positive otherwise.
+const applyQtySign = <T extends { quantity?: any }>(
+  rows: T[] | null,
+  negative: boolean
+): T[] | null => {
+  if (!Array.isArray(rows)) return rows;
+  return rows.map((r) => {
+    const q = Number(r?.quantity);
+    if (!isFinite(q) || q === 0) return r;
+    return { ...r, quantity: negative ? -Math.abs(q) : Math.abs(q) };
+  });
+};
+
+// Apply the sign to a lineMatch object's mappings[].quantity.
+const applyMatchQtySign = (lm: any, negative: boolean): any => {
+  if (!lm || !Array.isArray(lm.mappings)) return lm;
+  return { ...lm, mappings: applyQtySign(lm.mappings, negative) };
 };
 
 export function InvoiceDialog<T extends DocumentType>({
@@ -140,6 +169,10 @@ export function InvoiceDialog<T extends DocumentType>({
   const [lineItems, setLineItems] = useState<any[] | null>(null);
   const [poItemsForMatch, setPoItemsForMatch] = useState<any[] | null>(null);
   const [lineMatch, setLineMatch] = useState<LineMatch | null>(null);
+  // Gemini classified the uploaded document as a credit note / credit memo.
+  // Drives the sign: amount → negative always; quantities → negative only when the
+  // user leaves "Credit Note" UNticked (a return note that reduces invoiced qty).
+  const [creditNoteDetected, setCreditNoteDetected] = useState(false);
   const [rawExtraction, setRawExtraction] = useState<any | null>(null);
 
   // API hooks
@@ -197,6 +230,7 @@ export function InvoiceDialog<T extends DocumentType>({
           invoice_no: selectedInvoice.invoice_no || "",
           amount: String(selectedInvoice.invoice_amount || ""),
           date: selectedInvoice.invoice_date || "",
+          is_credit_note: !!selectedInvoice.is_credit_note,
         });
         // Edit mode skips the upload-first stage.
         setStage("form");
@@ -218,6 +252,7 @@ export function InvoiceDialog<T extends DocumentType>({
       setLineMatch(null);
       setRawExtraction(null);
       setReExtracted(false);
+      setCreditNoteDetected(false);
     }
   }, [isOpen, selectedInvoice]);
 
@@ -234,6 +269,7 @@ export function InvoiceDialog<T extends DocumentType>({
     setLineMatch(null);
     setRawExtraction(null);
     setReExtracted(false);
+    setCreditNoteDetected(false);
   }, [selectedAttachment]);
 
   // Edit mode: show the invoice's existing auto-filled mapping + entities inline
@@ -405,6 +441,15 @@ export function InvoiceDialog<T extends DocumentType>({
         filled.add("amount");
       }
 
+      // Credit-note handling: if Gemini classified the file as a credit note, the
+      // AMOUNT goes negative (always). Quantities are signed further below based on
+      // the "Credit Note" checkbox (unticked = return note = negative qty).
+      const creditNote = !!extracted.credit_note_detected;
+      setCreditNoteDetected(creditNote);
+      if (creditNote && updates.amount) {
+        updates.amount = forceNegativeAmount(updates.amount);
+      }
+
       setInvoiceData((prev) => ({ ...prev, ...updates }));
       setAutofilledFields(filled);
       if (extracted.confidence && typeof extracted.confidence === "object") {
@@ -437,11 +482,15 @@ export function InvoiceDialog<T extends DocumentType>({
       // route through a dedicated Review step so the user can verify/correct the
       // mapping before the final form.
       setRawExtraction(extracted);
+      // A return note (Gemini says credit note AND user has NOT ticked "Credit Note")
+      // reduces invoiced qty → store its line quantities negative. A ticked credit note
+      // keeps qty positive (it is excluded from invoice_qty entirely).
+      const qtyNegative = creditNote && !invoiceData.is_credit_note;
       const hasLineItems = Array.isArray(extracted.line_items) && extracted.line_items.length > 0;
-      if (hasLineItems) setLineItems(extracted.line_items);
+      if (hasLineItems) setLineItems(applyQtySign(extracted.line_items, qtyNegative));
       if (Array.isArray(extracted.po_items)) setPoItemsForMatch(extracted.po_items);
       const hasMapping = !!extracted.line_match && Array.isArray(extracted.line_match.mappings);
-      if (hasMapping) setLineMatch(extracted.line_match);
+      if (hasMapping) setLineMatch(applyMatchQtySign(extracted.line_match, qtyNegative));
 
       if (filled.size === 0) {
         toast({
@@ -517,6 +566,7 @@ export function InvoiceDialog<T extends DocumentType>({
         invoice_no: invoiceData.invoice_no.trim(),
         amount: parseNumber(invoiceData.amount),
         date: invoiceData.date,
+        is_credit_note: invoiceData.is_credit_note ? 1 : 0,
         updated_by: userData?.user_id,
       };
 
@@ -1059,6 +1109,38 @@ export function InvoiceDialog<T extends DocumentType>({
                     disabled={isLoading || isAutofilling}
                   />
                 </div>
+              </div>
+            </div>
+
+            {/* Credit Note — when ticked, this invoice is EXCLUDED from the PO's
+                invoice_qty (it does not add to the invoiced quantity). */}
+            <div className="flex items-start gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+              <Checkbox
+                id="is_credit_note"
+                checked={invoiceData.is_credit_note}
+                onCheckedChange={(checked) => {
+                  const isChecked = checked === true;
+                  setInvoiceData((prev) => ({ ...prev, is_credit_note: isChecked }));
+                  // On a Gemini-detected credit note, the checkbox decides the qty sign:
+                  // ticked (price credit) → qty positive (invoice is skipped anyway);
+                  // unticked (return note) → qty negative (recompute subtracts).
+                  // The amount stays negative in both cases.
+                  if (creditNoteDetected) {
+                    const neg = !isChecked;
+                    setLineItems((prev) => applyQtySign(prev, neg));
+                    setLineMatch((prev) => applyMatchQtySign(prev, neg));
+                  }
+                }}
+                disabled={isLoading || isAutofilling}
+                className="mt-0.5"
+              />
+              <div className="text-sm leading-snug">
+                <Label htmlFor="is_credit_note" className="font-medium cursor-pointer">
+                  Credit Note
+                </Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Tick if this is a credit note. It will be excluded from the PO's invoiced quantity.
+                </p>
               </div>
             </div>
 

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceLineMappingView.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceLineMappingView.tsx
@@ -1,0 +1,161 @@
+/**
+ * Shared per-invoice line → PO-item mapping view.
+ *
+ * Renders an invoice's MATCHED line items with a PO / Invoiced comparison of
+ * quantity and amount. Two entry points:
+ *   - `InvoiceMappingTable` — pure render given already-fetched `lines`.
+ *   - `InvoiceMappingExpand` — lazily fetches one invoice's `line_mappings`
+ *     (mounts only when a row is expanded) then renders the table.
+ * `usePoItemTotals` builds the PO-side totals used for the comparison.
+ */
+import { useMemo } from "react";
+import { useFrappeGetDoc } from "frappe-react-sdk";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle } from "lucide-react";
+import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
+import { VendorInvoice, VendorInvoiceLine } from "@/types/NirmaanStack/VendorInvoice";
+
+/** PO-side totals for a single PO line, used for the PO / Invoiced comparison. */
+export interface POItemTotals {
+  item_name?: string;
+  unit?: string;
+  quantity?: number;
+  amount?: number;
+}
+
+/**
+ * Build PO-line totals for a PO, keyed by child-row `name` (what
+ * line_mappings.po_item_row stores) with item_id as a fallback for legacy /
+ * post-revision rows. Fetches the PO doc once; disabled when `enabled` is false.
+ */
+export const usePoItemTotals = (poName?: string, enabled: boolean = true) => {
+  const { data: poDoc } = useFrappeGetDoc<{ items?: any[] }>(
+    "Procurement Orders",
+    poName,
+    enabled && poName ? `InvoiceMapping-PO-${poName}` : null
+  );
+
+  return useMemo(() => {
+    const byRow = new Map<string, POItemTotals>();
+    const byId = new Map<string, POItemTotals>();
+    (poDoc?.items || []).forEach((it: any) => {
+      const totals: POItemTotals = {
+        item_name: it.item_name,
+        unit: it.unit,
+        quantity: it.quantity,
+        amount: it.amount,
+      };
+      if (it.name) byRow.set(it.name, totals);
+      if (it.item_id) byId.set(it.item_id, totals);
+    });
+    return { poItemsByRow: byRow, poItemsById: byId };
+  }, [poDoc]);
+};
+
+interface InvoiceMappingTableProps {
+  lines: VendorInvoiceLine[];
+  poItemsByRow: Map<string, POItemTotals>;
+  poItemsById: Map<string, POItemTotals>;
+}
+
+/** Matched items of one invoice, with a PO / Invoiced comparison of qty + amount. */
+export const InvoiceMappingTable = ({ lines, poItemsByRow, poItemsById }: InvoiceMappingTableProps) => {
+  const matched = lines.filter((l) => l.match_status === "Matched");
+  const unmatched = lines.filter((l) => l.match_status === "Unmatched").length;
+  const nonItem = lines.filter((l) => l.match_status === "Non-Item").length;
+
+  const poFor = (l: VendorInvoiceLine): POItemTotals | undefined =>
+    (l.po_item_row ? poItemsByRow.get(l.po_item_row) : undefined) ??
+    (l.po_item_id ? poItemsById.get(l.po_item_id) : undefined);
+
+  if (matched.length === 0) {
+    return (
+      <div className="p-3 text-xs text-gray-500">
+        No matched items on this invoice
+        {unmatched + nonItem > 0
+          ? ` (${unmatched} unmatched, ${nonItem} charge${nonItem === 1 ? "" : "s"}).`
+          : "."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="py-2">
+      <div className="flex flex-wrap items-center gap-2 text-xs mb-2 px-2">
+        <span className="font-medium text-gray-700">
+          {matched.length}/{lines.length} lines matched to PO items
+        </span>
+        {unmatched > 0 && <Badge variant="orange">{unmatched} unmatched</Badge>}
+        {nonItem > 0 && <Badge variant="gray">{nonItem} charge{nonItem === 1 ? "" : "s"}</Badge>}
+      </div>
+
+      <div className="border-y overflow-hidden bg-white">
+        <table className="w-full text-xs">
+          <thead className="bg-gray-100 text-gray-600">
+            <tr>
+              <th className="text-left px-2 py-1.5 font-medium">Matched PO Item</th>
+              <th className="text-right px-2 py-1.5 font-medium w-40">Qty (PO / Inv)</th>
+              <th className="text-right px-2 py-1.5 font-medium w-48">Amount (PO / Inv)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matched.map((l, i) => {
+              const po = poFor(l);
+              return (
+                <tr key={l.name || i} className={`border-t align-top ${l.is_over_billed ? "bg-red-50" : ""}`}>
+                  <td className="px-2 py-1.5 text-gray-900">
+                    <div className="break-words">
+                      {l.po_item_name || po?.item_name || l.po_item_id || "—"}
+                      {po?.unit ? <span className="text-gray-400"> · {po.unit}</span> : null}
+                    </div>
+                    {l.is_over_billed ? (
+                      <Badge
+                        variant="red"
+                        className="mt-0.5 text-[10px] px-1.5 py-0 inline-flex items-center gap-0.5"
+                      >
+                        <AlertTriangle className="h-2.5 w-2.5" /> over PO
+                      </Badge>
+                    ) : null}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-gray-700">
+                    <span className="text-gray-500">{po?.quantity ?? "—"}</span>
+                    {" / "}
+                    <span className={l.is_over_billed ? "text-red-700 font-semibold" : "text-gray-900"}>
+                      {l.quantity ?? "—"}
+                    </span>
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-gray-700">
+                    <span className="text-gray-500">
+                      {po?.amount != null ? formatToRoundedIndianRupee(po.amount) : "—"}
+                    </span>
+                    {" / "}
+                    <span className={l.is_over_billed ? "text-red-700 font-semibold" : "text-gray-900"}>
+                      {l.amount != null ? formatToRoundedIndianRupee(l.amount) : "—"}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Fetch one invoice's `line_mappings` and report whether it has MATCHED items.
+ * `enabled` gates the fetch (pass false for non-autofilled invoices, which can
+ * never have mappings) so we only hit the network for real candidates. Used to
+ * decide upfront whether an expand chevron should be shown at all.
+ */
+export const useInvoiceMatchedLines = (invoiceName: string, enabled: boolean) => {
+  const { data, isLoading } = useFrappeGetDoc<VendorInvoice>(
+    "Vendor Invoices",
+    invoiceName,
+    enabled ? `InvoiceMapping-Lines-${invoiceName}` : null
+  );
+  const lines: VendorInvoiceLine[] = data?.line_mappings ?? [];
+  const matched = lines.filter((l) => l.match_status === "Matched");
+  return { lines, matched, hasMapping: matched.length > 0, isLoading };
+};

--- a/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceTable.tsx
+++ b/frontend/src/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment, useState } from 'react';
 import {
     Table,
     TableBody,
@@ -9,12 +9,13 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Trash2, Pencil } from 'lucide-react';
+import { Trash2, Pencil, ChevronDown, ChevronRight } from 'lucide-react';
 import { formatDate } from 'date-fns';
 import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { VendorInvoice } from '@/types/NirmaanStack/VendorInvoice';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { TailSpin } from 'react-loader-spinner';
+import { InvoiceMappingTable, POItemTotals, usePoItemTotals, useInvoiceMatchedLines } from "./InvoiceLineMappingView";
 
 interface InvoiceTableProps {
     /** Array of Vendor Invoice documents */
@@ -33,7 +34,26 @@ interface InvoiceTableProps {
     getUserName?: (userId: string | undefined) => string;
     /** Whether to hide the actions column */
     hideActions?: boolean;
+    /**
+     * When set (the PO name), each invoice row gets an expand chevron that
+     * reveals its line → PO-item mapping. Omit to disable the feature entirely
+     * (e.g. Project Invoices tables). The chevron is shown ONLY for invoices
+     * that actually have matched line items.
+     */
+    poName?: string;
 }
+
+// Status badge variant (pure).
+const getStatusBadgeVariant = (
+    status?: VendorInvoice['status']
+): 'default' | 'secondary' | 'destructive' | 'outline' | 'red' | 'green' => {
+    switch (status) {
+        case 'Pending': return 'red';
+        case 'Approved': return 'green';
+        case 'Rejected': return 'destructive';
+        default: return 'secondary';
+    }
+};
 
 export const InvoiceTable: React.FC<InvoiceTableProps> = ({
     items,
@@ -44,26 +64,27 @@ export const InvoiceTable: React.FC<InvoiceTableProps> = ({
     canDeleteEntry,
     getUserName,
     hideActions = false,
+    poName,
 }) => {
     const invoiceList = items || [];
 
-    // Determine if the delete column should be shown at all
-    const showDeleteColumn = onDeleteEntry && canDeleteEntry && invoiceList.some((item) => canDeleteEntry(item));
+    // Line-mapping expand is opt-in via `poName` (PO context needed for the
+    // PO / Invoiced comparison). PO totals are fetched once here; each candidate
+    // invoice's lines are fetched inside its row (see InvoiceTableRow).
+    const enableMapping = !!poName;
+    const { poItemsByRow, poItemsById } = usePoItemTotals(poName, enableMapping);
 
-    // Function to get status badge variant
-    const getStatusBadgeVariant = (status?: VendorInvoice['status']): 'default' | 'secondary' | 'destructive' | 'outline' | 'red' | 'green' => {
-        switch (status) {
-            case 'Pending': return 'red';
-            case 'Approved': return 'green';
-            case 'Rejected': return 'destructive';
-            default: return 'secondary';
-        }
-    };
+    // Determine if the delete column should be shown at all
+    const showDeleteColumn = !!(onDeleteEntry && canDeleteEntry && invoiceList.some((item) => canDeleteEntry(item)));
+
+    // Total columns (for colSpan on the empty-state + expand rows).
+    const colCount = (enableMapping ? 1 : 0) + 5 + (hideActions ? 0 : 1);
 
     return (
         <Table>
             <TableHeader className="bg-red-100">
                 <TableRow>
+                    {enableMapping && <TableHead className="w-6 px-1" />}
                     <TableHead className="w-[150px] text-black font-bold">Date</TableHead>
                     <TableHead className="w-[150px] text-black font-bold">Amount</TableHead>
                     <TableHead className="text-black font-bold">Invoice No.</TableHead>
@@ -74,93 +95,176 @@ export const InvoiceTable: React.FC<InvoiceTableProps> = ({
             </TableHeader>
             <TableBody>
                 {invoiceList.length > 0 ? (
-                    invoiceList.map((invoice) => {
-                        const showDeleteButton = showDeleteColumn && canDeleteEntry?.(invoice);
-
-                        return (
-                            <TableRow key={invoice.name}>
-                                <TableCell>{formatDate(new Date(invoice.invoice_date), "dd-MMM-yyyy")}</TableCell>
-                                <TableCell>{formatToRoundedIndianRupee(invoice.invoice_amount)}</TableCell>
-                                <TableCell>
-                                    {invoice.invoice_attachment ? (
-                                        <Button
-                                            variant="link"
-                                            className="p-0 h-auto text-blue-600 hover:underline"
-                                            onClick={() => onViewAttachment(invoice.invoice_attachment)}
-                                            title={`View Invoice ${invoice.invoice_no}`}
-                                        >
-                                            {invoice.invoice_no || 'View'}
-                                        </Button>
-                                    ) : (
-                                        <span className="text-gray-600">{invoice.invoice_no || '--'}</span>
-                                    )}
-                                </TableCell>
-                                <TableCell>
-                                    <Badge variant={getStatusBadgeVariant(invoice.status)}>
-                                        {invoice.status || 'Approved'}
-                                    </Badge>
-                                </TableCell>
-                                <TableCell className="text-gray-600 text-sm">
-                                    {getUserName ? getUserName(invoice.uploaded_by) : invoice.uploaded_by || '--'}
-                                </TableCell>
-                                {!hideActions && <TableCell className="text-center space-x-1">
-                                    {onEditEntry && (
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            className="text-blue-600 hover:text-blue-800"
-                                            onClick={() => onEditEntry(invoice)}
-                                            title={`Edit Invoice ${invoice.invoice_no}`}
-                                        >
-                                            <Pencil className="h-4 w-4" />
-                                        </Button>
-                                    )}
-                                    {showDeleteButton && (
-                                        <Dialog>
-                                            <DialogTrigger asChild>
-                                                <Button
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    className="text-red-600 hover:text-red-800"
-                                                    disabled={isLoading}
-                                                    title={`Delete Invoice Entry ${invoice.invoice_no}`}
-                                                >
-                                                    <Trash2 className="h-4 w-4" />
-                                                </Button>
-                                            </DialogTrigger>
-                                            <DialogContent>
-                                                <DialogHeader>
-                                                    <DialogTitle>Are you sure?</DialogTitle>
-                                                </DialogHeader>
-                                                <DialogDescription className="text-primary">
-                                                    Click on Confirm to delete this invoice entry!
-                                                </DialogDescription>
-                                                <div className="flex items-center justify-end gap-2">
-                                                    {isLoading ? <TailSpin color="red" height={40} width={40} /> : (
-                                                        <>
-                                                            <DialogClose asChild>
-                                                                 <Button variant={"outline"} className="border-primary text-primary">Cancel</Button>
-                                                            </DialogClose>
-                                                            <Button disabled={isLoading} onClick={() => onDeleteEntry?.(invoice.name)}>Confirm</Button>
-                                                        </>
-                                                    )}
-                                                </div>
-                                            </DialogContent>
-                                        </Dialog>
-                                    )}
-                                    {!onEditEntry && !showDeleteButton && "--"}
-                                </TableCell>}
-                            </TableRow>
-                        );
-                    })
+                    invoiceList.map((invoice) => (
+                        <InvoiceTableRow
+                            key={invoice.name}
+                            invoice={invoice}
+                            enableMapping={enableMapping}
+                            colCount={colCount}
+                            poItemsByRow={poItemsByRow}
+                            poItemsById={poItemsById}
+                            onViewAttachment={onViewAttachment}
+                            onEditEntry={onEditEntry}
+                            onDeleteEntry={onDeleteEntry}
+                            isLoading={isLoading}
+                            showDeleteColumn={showDeleteColumn}
+                            canDeleteEntry={canDeleteEntry}
+                            getUserName={getUserName}
+                            hideActions={hideActions}
+                        />
+                    ))
                 ) : (
                     <TableRow>
-                        <TableCell colSpan={hideActions ? 5 : 6} className="text-center py-4 text-gray-500">
+                        <TableCell colSpan={colCount} className="text-center py-4 text-gray-500">
                             No Invoices Found
                         </TableCell>
                     </TableRow>
                 )}
             </TableBody>
         </Table>
+    );
+};
+
+interface InvoiceTableRowProps {
+    invoice: VendorInvoice;
+    enableMapping: boolean;
+    colCount: number;
+    poItemsByRow: Map<string, POItemTotals>;
+    poItemsById: Map<string, POItemTotals>;
+    onViewAttachment: (attachmentId: string | undefined) => void;
+    onEditEntry?: (item: VendorInvoice) => void;
+    onDeleteEntry?: (invoiceId: string) => void;
+    isLoading?: boolean;
+    showDeleteColumn: boolean;
+    canDeleteEntry?: (item: VendorInvoice) => boolean;
+    getUserName?: (userId: string | undefined) => string;
+    hideActions: boolean;
+}
+
+const InvoiceTableRow: React.FC<InvoiceTableRowProps> = ({
+    invoice,
+    enableMapping,
+    colCount,
+    poItemsByRow,
+    poItemsById,
+    onViewAttachment,
+    onEditEntry,
+    onDeleteEntry,
+    isLoading,
+    showDeleteColumn,
+    canDeleteEntry,
+    getUserName,
+    hideActions,
+}) => {
+    const [expanded, setExpanded] = useState(false);
+    const showDeleteButton = showDeleteColumn && canDeleteEntry?.(invoice);
+
+    // Only autofilled invoices can carry line mappings — gate the fetch on that
+    // so we never hit the network for a plain manual invoice. The chevron then
+    // appears ONLY when the fetch confirms matched items exist.
+    const candidate = enableMapping && !!invoice.autofill_used;
+    const { lines, hasMapping } = useInvoiceMatchedLines(invoice.name, candidate);
+
+    return (
+        <Fragment>
+            <TableRow>
+                {enableMapping && (
+                    <TableCell className="w-6 px-1 text-gray-500">
+                        {hasMapping && (
+                            <button
+                                type="button"
+                                onClick={() => setExpanded((o) => !o)}
+                                className="p-0.5 text-gray-500 hover:text-gray-800"
+                                title="Show item mapping"
+                            >
+                                {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                            </button>
+                        )}
+                    </TableCell>
+                )}
+                <TableCell>{formatDate(new Date(invoice.invoice_date), "dd-MMM-yyyy")}</TableCell>
+                <TableCell>{formatToRoundedIndianRupee(invoice.invoice_amount)}</TableCell>
+                <TableCell>
+                    {invoice.invoice_attachment ? (
+                        <Button
+                            variant="link"
+                            className="p-0 h-auto text-blue-600 hover:underline"
+                            onClick={() => onViewAttachment(invoice.invoice_attachment)}
+                            title={`View Invoice ${invoice.invoice_no}`}
+                        >
+                            {invoice.invoice_no || 'View'}
+                        </Button>
+                    ) : (
+                        <span className="text-gray-600">{invoice.invoice_no || '--'}</span>
+                    )}
+                </TableCell>
+                <TableCell>
+                    <Badge variant={getStatusBadgeVariant(invoice.status)}>
+                        {invoice.status || 'Approved'}
+                    </Badge>
+                </TableCell>
+                <TableCell className="text-gray-600 text-sm">
+                    {getUserName ? getUserName(invoice.uploaded_by) : invoice.uploaded_by || '--'}
+                </TableCell>
+                {!hideActions && <TableCell className="text-center space-x-1">
+                    {onEditEntry && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="text-blue-600 hover:text-blue-800"
+                            onClick={() => onEditEntry(invoice)}
+                            title={`Edit Invoice ${invoice.invoice_no}`}
+                        >
+                            <Pencil className="h-4 w-4" />
+                        </Button>
+                    )}
+                    {showDeleteButton && (
+                        <Dialog>
+                            <DialogTrigger asChild>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="text-red-600 hover:text-red-800"
+                                    disabled={isLoading}
+                                    title={`Delete Invoice Entry ${invoice.invoice_no}`}
+                                >
+                                    <Trash2 className="h-4 w-4" />
+                                </Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                                <DialogHeader>
+                                    <DialogTitle>Are you sure?</DialogTitle>
+                                </DialogHeader>
+                                <DialogDescription className="text-primary">
+                                    Click on Confirm to delete this invoice entry!
+                                </DialogDescription>
+                                <div className="flex items-center justify-end gap-2">
+                                    {isLoading ? <TailSpin color="red" height={40} width={40} /> : (
+                                        <>
+                                            <DialogClose asChild>
+                                                 <Button variant={"outline"} className="border-primary text-primary">Cancel</Button>
+                                            </DialogClose>
+                                            <Button disabled={isLoading} onClick={() => onDeleteEntry?.(invoice.name)}>Confirm</Button>
+                                        </>
+                                    )}
+                                </div>
+                            </DialogContent>
+                        </Dialog>
+                    )}
+                    {!onEditEntry && !showDeleteButton && "--"}
+                </TableCell>}
+            </TableRow>
+            {enableMapping && expanded && hasMapping && (
+                <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={colCount} className="bg-gray-50 p-0">
+                        <InvoiceMappingTable
+                            lines={lines}
+                            poItemsByRow={poItemsByRow}
+                            poItemsById={poItemsById}
+                        />
+                    </TableCell>
+                </TableRow>
+            )}
+        </Fragment>
     );
 };

--- a/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
@@ -1224,6 +1224,7 @@ export const PurchaseOrder = ({
                     {["Partially Delivered", "Delivered"].includes(PO?.status) && (
                       <th className="text-center py-3">Delivered Qty</th>
                     )}
+                    <th className="text-center py-3">Invoice Qty</th>
                     {!isProjectManager && <th className="text-center py-3">Rate</th>}
                     {!isProjectManager && <th className="text-center py-3">Tax</th>}
                     {!isProjectManager && <th className="text-center py-3">Amount</th>}
@@ -1261,6 +1262,7 @@ export const PurchaseOrder = ({
                           {item?.received_quantity || 0}
                         </td>
                       )}
+                      <td className="text-center py-3 align-top">{item?.invoice_qty || 0}</td>
                       {!isProjectManager && <td className="text-center py-3 align-top">{formatToIndianRupee(item?.quote)}</td>}
                       {!isProjectManager && <td className="text-center py-3 align-top">{item?.tax}%</td>}
                       {!isProjectManager && <td className="text-center py-3 align-top font-medium">{formatToIndianRupee(item?.amount)}</td>}
@@ -1313,6 +1315,10 @@ export const PurchaseOrder = ({
                   <div className="flex justify-between">
                     <span className="text-gray-500">Qty:</span>
                     <span className="font-medium text-gray-900">{item.quantity}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Invoice Qty:</span>
+                    <span className="font-medium text-gray-900">{item?.invoice_qty || 0}</span>
                   </div>
 
                   {["Partially Delivered", "Delivered"].includes(PO?.status) && (

--- a/frontend/src/pages/ProcurementOrders/purchase-order/components/InvoiceDataDialog.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/components/InvoiceDataDialog.tsx
@@ -3,26 +3,20 @@ import { Label } from "@/components/ui/label";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import SITEURL from "@/constants/siteURL";
 import { NirmaanAttachment } from "@/types/NirmaanStack/NirmaanAttachment";
-import { VendorInvoice } from "@/types/NirmaanStack/VendorInvoice";
+import { VendorInvoice, VendorInvoiceLine } from "@/types/NirmaanStack/VendorInvoice";
 import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { formatDate } from "@/utils/FormatDate";
-import { useFrappeGetDocList, useFrappeGetCall } from "frappe-react-sdk";
-import { useMemo } from "react";
+import { useFrappeGetDocList, useFrappeGetDoc } from "frappe-react-sdk";
+import { Fragment, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 
-interface POItemBilling {
-  po_item_id: string;
-  po_item_name?: string;
+/** PO-side totals for a single PO line, used for the PO / Invoiced comparison. */
+interface POItemTotals {
+  item_name?: string;
   unit?: string;
-  po_quantity: number;
-  po_amount: number;
-  invoiced_quantity: number;
-  invoiced_amount: number;
-  invoice_count: number;
-  over_billed_amount: number;
-  over_billed_quantity: number;
-  is_over_billed: boolean;
+  quantity?: number;
+  amount?: number;
 }
 
 interface InvoiceDataDialogProps {
@@ -32,6 +26,17 @@ interface InvoiceDataDialogProps {
   project?: string;
   poNumber?: string;
   vendor?: string;
+  /**
+   * Parent doctype of the invoices — controls the number label (PO vs WO) and
+   * whether the PO-items comparison is fetched. Defaults to Procurement Orders.
+   */
+  documentType?: "Procurement Orders" | "Service Requests";
+  /**
+   * Which invoice statuses to list. Defaults to Approved only (the original
+   * behavior for the All-POs / vendor dialogs). Pass e.g. ["Pending","Approved"]
+   * to also surface pending invoices (and their item-mapping expand).
+   */
+  visibleStatuses?: Array<VendorInvoice["status"]>;
 }
 
 export const InvoiceDataDialog = ({
@@ -40,16 +45,20 @@ export const InvoiceDataDialog = ({
   vendorInvoices,
   project,
   poNumber,
-  vendor
+  vendor,
+  documentType = "Procurement Orders",
+  visibleStatuses = ["Approved"],
 }: InvoiceDataDialogProps) => {
-  const approvedInvoices = vendorInvoices?.filter(inv => inv.status === "Approved") ?? [];
+  const isPO = documentType === "Procurement Orders";
+  const docNumberLabel = isPO ? "PO Number:" : "WO Number:";
+  const visibleInvoices = vendorInvoices?.filter(inv => visibleStatuses.includes(inv.status)) ?? [];
 
   // `invoice_attachment` on a Vendor Invoice is a Link to a `Nirmaan Attachments`
   // doc (an ID, not a file URL). Resolve IDs → file URLs in one batch when the
   // dialog is open.
   const attachmentIds = useMemo(
-    () => approvedInvoices.map(inv => inv.invoice_attachment).filter((id): id is string => !!id),
-    [approvedInvoices]
+    () => visibleInvoices.map(inv => inv.invoice_attachment).filter((id): id is string => !!id),
+    [visibleInvoices]
   );
 
   const { data: attachmentDocs } = useFrappeGetDocList<NirmaanAttachment>(
@@ -72,24 +81,37 @@ export const InvoiceDataDialog = ({
     return map;
   }, [attachmentDocs]);
 
-  // Cross-invoice item-level billing rollup (Approved + Pending invoices).
-  // Surfaces "invoiced so far" per PO item and cumulative over-billing.
-  const { data: billingResp } = useFrappeGetCall<{ message: { items: POItemBilling[]; summary: any } }>(
-    "nirmaan_stack.api.invoices.get_po_item_billing.get_po_item_billing",
-    { po: poNumber },
-    open && poNumber ? `po-item-billing-${poNumber}` : null
+  // PO line totals for the "PO / Invoiced" comparison. Fetched once per open
+  // dialog; child rows resolve by their `name` (what line_mappings.po_item_row
+  // stores) with item_id as a fallback for legacy / post-revision rows.
+  const { data: poDoc } = useFrappeGetDoc<{ items?: any[] }>(
+    "Procurement Orders",
+    poNumber,
+    open && poNumber && isPO ? `InvoiceDataDialog-PO-${poNumber}` : null
   );
-  const billing = billingResp?.message;
-  // Only show the rollup once there's mapped invoice data (legacy invoices have
-  // no line_mappings → an all-zero table would just be noise).
-  const showBilling = !!billing && (billing.summary?.total_invoiced_amount ?? 0) > 0;
+
+  const { poItemsByRow, poItemsById } = useMemo(() => {
+    const byRow = new Map<string, POItemTotals>();
+    const byId = new Map<string, POItemTotals>();
+    (poDoc?.items || []).forEach((it: any) => {
+      const totals: POItemTotals = {
+        item_name: it.item_name,
+        unit: it.unit,
+        quantity: it.quantity,
+        amount: it.amount,
+      };
+      if (it.name) byRow.set(it.name, totals);
+      if (it.item_id) byId.set(it.item_id, totals);
+    });
+    return { poItemsByRow: byRow, poItemsById: byId };
+  }, [poDoc]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="text-start">
-        <DialogHeader className="text-start py-6">
-          <DialogTitle />
-          <div className="flex flex-wrap gap-4 mb-6">
+      <DialogContent className="text-start max-h-[85vh] overflow-y-auto sm:max-w-3xl md:max-w-4xl">
+        <DialogHeader className="text-start">
+          <DialogTitle className="sr-only">Invoice Details</DialogTitle>
+          <div className="flex flex-wrap gap-4 mb-2">
             {project && (
               <div className="flex items-center gap-2">
                 <Label className="text-red-700 min-w-[80px]">Project:</Label>
@@ -98,7 +120,7 @@ export const InvoiceDataDialog = ({
             )}
             {poNumber && (
               <div className="flex items-center gap-2">
-                <Label className="text-red-700 min-w-[100px]">PO Number:</Label>
+                <Label className="text-red-700 min-w-[100px]">{docNumberLabel}</Label>
                 <span className="text-sm font-medium">{poNumber}</span>
               </div>
             )}
@@ -109,121 +131,208 @@ export const InvoiceDataDialog = ({
               </div>
             )}
           </div>
-
-          <div className="border rounded-lg overflow-hidden">
-            <Table>
-              <TableHeader className="bg-gray-100">
-                <TableRow>
-                  <TableHead>Invoice Date</TableHead>
-                  <TableHead>Invoice No.</TableHead>
-                  <TableHead className="text-right">Amount</TableHead>
-                  <TableHead>Attachment</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {approvedInvoices.length > 0 ? (
-                  approvedInvoices.map((inv) => (
-                    <TableRow key={inv.name}>
-                      <TableCell className="font-medium">
-                        {inv.invoice_date ? formatDate(inv.invoice_date) : 'N/A'}
-                      </TableCell>
-                      <TableCell>{inv.invoice_no || '--'}</TableCell>
-                      <TableCell className="text-right">
-                        {formatToRoundedIndianRupee(inv.invoice_amount)}
-                      </TableCell>
-                      <TableCell>
-                        {(() => {
-                          const fileUrl = inv.invoice_attachment
-                            ? attachmentUrlById.get(inv.invoice_attachment)
-                            : undefined;
-                          return fileUrl ? (
-                            <a
-                              href={`${SITEURL}${fileUrl}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 hover:underline"
-                            >
-                              View Attachment
-                            </a>
-                          ) : (
-                            'N/A'
-                          );
-                        })()}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell colSpan={4} className="text-center h-24">
-                      No valid invoice data available
-                    </TableCell>
-                  </TableRow>
-                )}
-              </TableBody>
-            </Table>
-          </div>
-
-          {/* Item-level billing rollup across submitted invoices (Phase C). */}
-          {showBilling && billing && (
-            <div className="mt-6">
-              <div className="flex flex-wrap items-center gap-2 mb-2">
-                <Label className="text-red-700">Item-Level Billing</Label>
-                <span className="text-xs text-muted-foreground">
-                  invoiced so far across Approved + Pending invoices
-                </span>
-                {billing.summary?.over_billed > 0 && (
-                  <Badge variant="red" className="inline-flex items-center gap-0.5">
-                    <AlertTriangle className="h-3 w-3" /> {billing.summary.over_billed} item
-                    {billing.summary.over_billed > 1 ? "s" : ""} over PO
-                  </Badge>
-                )}
-              </div>
-              <div className="border rounded-lg overflow-hidden">
-                <Table>
-                  <TableHeader className="bg-gray-100">
-                    <TableRow>
-                      <TableHead>Item</TableHead>
-                      <TableHead className="text-right">Invoiced</TableHead>
-                      <TableHead className="text-right">PO Amount</TableHead>
-                      <TableHead className="text-right">Qty (inv / PO)</TableHead>
-                      <TableHead></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {billing.items.map((it) => (
-                      <TableRow key={it.po_item_id} className={it.is_over_billed ? "bg-red-50" : ""}>
-                        <TableCell className="font-medium">
-                          {it.po_item_name || it.po_item_id}
-                          {it.unit ? <span className="text-gray-400 text-xs"> · {it.unit}</span> : null}
-                        </TableCell>
-                        <TableCell className={`text-right tabular-nums ${it.is_over_billed ? "text-red-700 font-semibold" : ""}`}>
-                          {formatToRoundedIndianRupee(it.invoiced_amount)}
-                          {it.invoice_count > 0 && (
-                            <span className="text-gray-400 text-xs"> ({it.invoice_count})</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums text-gray-600">
-                          {formatToRoundedIndianRupee(it.po_amount)}
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums text-gray-600">
-                          {it.invoiced_quantity} / {it.po_quantity}
-                        </TableCell>
-                        <TableCell>
-                          {it.is_over_billed && (
-                            <Badge variant="red" className="inline-flex items-center gap-0.5">
-                              <AlertTriangle className="h-3 w-3" /> over PO
-                            </Badge>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            </div>
-          )}
         </DialogHeader>
+
+        <div className="border rounded-lg overflow-x-auto">
+          <Table>
+            <TableHeader className="bg-gray-100">
+              <TableRow>
+                <TableHead className="w-8" />
+                <TableHead>Invoice Date</TableHead>
+                <TableHead>Invoice No.</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Attachment</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visibleInvoices.length > 0 ? (
+                visibleInvoices.map((inv) => (
+                  <InvoiceRow
+                    key={inv.name}
+                    inv={inv}
+                    open={open}
+                    fileUrl={inv.invoice_attachment ? attachmentUrlById.get(inv.invoice_attachment) : undefined}
+                    poItemsByRow={poItemsByRow}
+                    poItemsById={poItemsById}
+                  />
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center h-24">
+                    No valid invoice data available
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
       </DialogContent>
     </Dialog>
+  );
+};
+
+interface InvoiceRowProps {
+  inv: VendorInvoice;
+  /** Dialog open — gates the per-invoice fetch so closed dialogs fetch nothing. */
+  open: boolean;
+  fileUrl?: string;
+  poItemsByRow: Map<string, POItemTotals>;
+  poItemsById: Map<string, POItemTotals>;
+}
+
+/**
+ * One invoice row. Fetches its own `line_mappings` (same pattern the approval
+ * screen uses) so we know upfront whether it has matched items: the expand
+ * chevron is shown ONLY when there is a mapping to reveal.
+ */
+const InvoiceRow = ({ inv, open, fileUrl, poItemsByRow, poItemsById }: InvoiceRowProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const { data: fullInvoice } = useFrappeGetDoc<VendorInvoice>(
+    "Vendor Invoices",
+    inv.name,
+    open ? `InvoiceDataDialog-Mapping-${inv.name}` : null
+  );
+
+  const lines: VendorInvoiceLine[] = fullInvoice?.line_mappings ?? [];
+  const matched = lines.filter((l) => l.match_status === "Matched");
+  const hasMapping = matched.length > 0;
+
+  // Pending invoices are tinted red so reviewers can tell them apart from the
+  // already-approved ones (the list can now be mixed-status).
+  const isPending = inv.status === "Pending";
+  const rowClass = [
+    isPending ? "bg-red-50" : "",
+    hasMapping ? `cursor-pointer ${isPending ? "hover:bg-red-100" : "hover:bg-gray-50"}` : "",
+  ].filter(Boolean).join(" ");
+
+  return (
+    <Fragment>
+      <TableRow
+        className={rowClass}
+        onClick={() => hasMapping && setExpanded((o) => !o)}
+      >
+        <TableCell className="w-8 text-gray-500">
+          {hasMapping ? (
+            expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />
+          ) : null}
+        </TableCell>
+        <TableCell className="font-medium whitespace-nowrap">
+          {inv.invoice_date ? formatDate(inv.invoice_date) : 'N/A'}
+        </TableCell>
+        <TableCell>{inv.invoice_no || '--'}</TableCell>
+        <TableCell className="text-right">
+          {formatToRoundedIndianRupee(inv.invoice_amount)}
+        </TableCell>
+        <TableCell>
+          <Badge variant={inv.status === "Approved" ? "green" : inv.status === "Rejected" ? "destructive" : "red"}>
+            {inv.status}
+          </Badge>
+        </TableCell>
+        <TableCell onClick={(e) => e.stopPropagation()}>
+          {fileUrl ? (
+            <a
+              href={`${SITEURL}${fileUrl}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline inline-flex items-center gap-1"
+            >
+              View Attach <ExternalLink className="h-3 w-3" />
+            </a>
+          ) : (
+            'N/A'
+          )}
+        </TableCell>
+      </TableRow>
+
+      {expanded && hasMapping && (
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={6} className="bg-gray-50 p-0">
+            <InvoiceMappingTable lines={lines} poItemsByRow={poItemsByRow} poItemsById={poItemsById} />
+          </TableCell>
+        </TableRow>
+      )}
+    </Fragment>
+  );
+};
+
+interface InvoiceMappingTableProps {
+  lines: VendorInvoiceLine[];
+  poItemsByRow: Map<string, POItemTotals>;
+  poItemsById: Map<string, POItemTotals>;
+}
+
+/** Matched items of one invoice, with a PO / Invoiced comparison of qty + amount. */
+const InvoiceMappingTable = ({ lines, poItemsByRow, poItemsById }: InvoiceMappingTableProps) => {
+  const matched = lines.filter((l) => l.match_status === "Matched");
+  const unmatched = lines.filter((l) => l.match_status === "Unmatched").length;
+  const nonItem = lines.filter((l) => l.match_status === "Non-Item").length;
+
+  const poFor = (l: VendorInvoiceLine): POItemTotals | undefined =>
+    (l.po_item_row ? poItemsByRow.get(l.po_item_row) : undefined) ??
+    (l.po_item_id ? poItemsById.get(l.po_item_id) : undefined);
+
+  return (
+    <div className="p-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs mb-2">
+        <span className="font-medium text-gray-700">
+          {matched.length}/{lines.length} lines matched to PO items
+        </span>
+        {unmatched > 0 && <Badge variant="orange">{unmatched} unmatched</Badge>}
+        {nonItem > 0 && <Badge variant="gray">{nonItem} charge{nonItem === 1 ? "" : "s"}</Badge>}
+      </div>
+
+      <div className="border rounded-md overflow-x-auto bg-white">
+        <table className="w-full min-w-[420px] text-xs">
+          <thead className="bg-gray-100 text-gray-600">
+            <tr>
+              <th className="text-left px-2 py-1.5 font-medium">Matched PO Item</th>
+              <th className="text-right px-2 py-1.5 font-medium w-40">Qty (PO / Inv)</th>
+              <th className="text-right px-2 py-1.5 font-medium w-48">Amount (PO / Inv)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matched.map((l, i) => {
+              const po = poFor(l);
+              return (
+                <tr key={l.name || i} className={`border-t align-top ${l.is_over_billed ? "bg-red-50" : ""}`}>
+                  <td className="px-2 py-1.5 text-gray-900">
+                    <div className="break-words">
+                      {l.po_item_name || po?.item_name || l.po_item_id || "—"}
+                      {po?.unit ? <span className="text-gray-400"> · {po.unit}</span> : null}
+                    </div>
+                    {l.is_over_billed ? (
+                      <Badge
+                        variant="red"
+                        className="mt-0.5 text-[10px] px-1.5 py-0 inline-flex items-center gap-0.5"
+                      >
+                        <AlertTriangle className="h-2.5 w-2.5" /> over PO
+                      </Badge>
+                    ) : null}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-gray-700">
+                    <span className="text-gray-500">{po?.quantity ?? "—"}</span>
+                    {" / "}
+                    <span className={l.is_over_billed ? "text-red-700 font-semibold" : "text-gray-900"}>
+                      {l.quantity ?? "—"}
+                    </span>
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-gray-700">
+                    <span className="text-gray-500">
+                      {po?.amount != null ? formatToRoundedIndianRupee(po.amount) : "—"}
+                    </span>
+                    {" / "}
+                    <span className={l.is_over_billed ? "text-red-700 font-semibold" : "text-gray-900"}>
+                      {l.amount != null ? formatToRoundedIndianRupee(l.amount) : "—"}
+                    </span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
   );
 };

--- a/frontend/src/pages/ProcurementOrders/purchase-order/release-po-select.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/release-po-select.tsx
@@ -437,7 +437,7 @@ export const ReleasePOSelect: React.FC = () => {
                 }
             }
         },
-        ...([PO_TABS.PARTIALLY_DISPATCHED_PO, PO_TABS.DISPATCHED_PO, PO_TABS.PARTIALLY_DELIVERED_PO, PO_TABS.DELIVERED_PO].includes(tab as any) ? [
+        ...([PO_TABS.ALL_POS, PO_TABS.PARTIALLY_DISPATCHED_PO, PO_TABS.DISPATCHED_PO, PO_TABS.PARTIALLY_DELIVERED_PO, PO_TABS.DELIVERED_PO].includes(tab as any) ? [
             {
                 id: "invoice_amount",
                 header: ({ column }) => {

--- a/frontend/src/pages/tasks/invoices/components/PendingTasksTable.tsx
+++ b/frontend/src/pages/tasks/invoices/components/PendingTasksTable.tsx
@@ -87,7 +87,7 @@ export const PendingTasksTable: React.FC = () => {
 
     const { getTotalAmount, getDeliveredAmount, getVendorName } = useOrderTotals();
     const { getAmount } = useOrderPayments();
-    const { getTotalInvoiced } = useTotalInvoicedByDocument();
+    const { getTotalInvoiced, getInvoicesFor } = useTotalInvoicedByDocument();
 
     // --- Column Definitions ---
     const columns = React.useMemo(
@@ -101,7 +101,8 @@ export const PendingTasksTable: React.FC = () => {
                 getAmount,
                 getDeliveredAmount,
                 getVendorName,
-                getTotalInvoiced
+                getTotalInvoiced,
+                getInvoicesFor
             ),
         [
             openConfirmationDialog,
@@ -113,6 +114,7 @@ export const PendingTasksTable: React.FC = () => {
             getDeliveredAmount,
             getVendorName,
             getTotalInvoiced,
+            getInvoicesFor,
         ]
     );
 

--- a/frontend/src/pages/tasks/invoices/components/TaskHistoryTable.tsx
+++ b/frontend/src/pages/tasks/invoices/components/TaskHistoryTable.tsx
@@ -132,7 +132,7 @@ export const TaskHistoryTable: React.FC = () => {
         []
     );
 
-    const { getTotalInvoiced } = useTotalInvoicedByDocument();
+    const { getTotalInvoiced, getInvoicesFor } = useTotalInvoicedByDocument();
 
     // Columns for history view
     const columns = React.useMemo(
@@ -144,7 +144,8 @@ export const TaskHistoryTable: React.FC = () => {
                 getDeliveredAmount,
                 getAmount,
                 getVendorName,
-                getTotalInvoiced
+                getTotalInvoiced,
+                getInvoicesFor
             ),
         [
             getUserName,
@@ -154,6 +155,7 @@ export const TaskHistoryTable: React.FC = () => {
             getDeliveredAmount,
             getVendorName,
             getTotalInvoiced,
+            getInvoicesFor,
         ]
     );
 

--- a/frontend/src/pages/tasks/invoices/components/columns.tsx
+++ b/frontend/src/pages/tasks/invoices/components/columns.tsx
@@ -3,10 +3,16 @@
  *
  * Updated to use VendorInvoice type instead of InvoiceApprovalTask.
  */
-import React from "react";
+import React, { useState } from "react";
 import { ColumnDef } from "@tanstack/react-table";
 import { Link } from 'react-router-dom';
 import { VendorInvoice } from '@/types/NirmaanStack/VendorInvoice';
+import {
+    InvoiceMappingTable,
+    useInvoiceMatchedLines,
+    usePoItemTotals,
+} from "@/pages/ProcurementOrders/invoices-and-dcs/components/InvoiceLineMappingView";
+import { InvoiceDataDialog } from "@/pages/ProcurementOrders/purchase-order/components/InvoiceDataDialog";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -93,6 +99,138 @@ const AutofillEntitiesHoverCard: React.FC<{ invoice: VendorInvoice }> = ({ invoi
 };
 
 /**
+ * "Invoice Amt" cell with a hover card. On hover-open (and only then, to avoid
+ * a fetch-per-row on render) it lazily loads a PO invoice's line mapping and
+ * shows the PO / Invoiced comparison. WO/SR or non-mapped invoices show a basic
+ * detail card (no, date, amount, status).
+ */
+const InvoiceAmtHoverCell: React.FC<{
+    invoice: VendorInvoice;
+    getVendorName?: (orderId: string, type: string) => string;
+}> = ({ invoice, getVendorName }) => {
+    const [open, setOpen] = useState(false);
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const isPO = invoice.document_type === "Procurement Orders";
+    // Only autofilled PO invoices can carry a mapping; gate the fetch on the
+    // hover being open so a table of N rows fires nothing until hovered.
+    const candidate = open && isPO && !!invoice.autofill_used;
+    const { lines, hasMapping, isLoading } = useInvoiceMatchedLines(invoice.name, candidate);
+    const { poItemsByRow, poItemsById } = usePoItemTotals(invoice.document_name, candidate);
+
+    const amount = formatToRoundedIndianRupee(parseNumber(invoice.invoice_amount));
+    // Clicking opens the dialog for THIS invoice only (not the whole document).
+    const dialogInvoices = [invoice];
+
+    return (
+        <>
+        <HoverCard openDelay={150} closeDelay={100} onOpenChange={setOpen}>
+            <HoverCardTrigger asChild>
+                <div
+                    className="cursor-pointer text-blue-600 hover:text-blue-800 underline decoration-dotted underline-offset-2"
+                    onClick={() => setDialogOpen(true)}
+                >
+                    {amount}
+                </div>
+            </HoverCardTrigger>
+            <HoverCardContent className="w-[440px] p-0 overflow-hidden" align="end">
+                <div className="bg-gray-50 border-b px-3 py-2">
+                    <div className="flex items-center justify-between gap-2">
+                        <span className="text-xs font-medium text-gray-900 truncate">
+                            {invoice.invoice_no || "Invoice"}
+                        </span>
+                        {invoice.status && (
+                            <Badge
+                                variant={invoice.status === "Approved" ? "green" : invoice.status === "Rejected" ? "destructive" : "red"}
+                                className="text-[10px] px-1.5 py-0 shrink-0"
+                            >
+                                {invoice.status}
+                            </Badge>
+                        )}
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-gray-500">
+                        <span>{invoice.invoice_date ? formatDate(new Date(invoice.invoice_date), "dd-MMM-yyyy") : "—"}</span>
+                        <span className="text-gray-300">|</span>
+                        <span className="font-semibold text-gray-800">{amount}</span>
+                        {isPO && <span className="text-gray-300">|</span>}
+                        {isPO && (
+                            <Link
+                                to={`/purchase-orders/${invoice.document_name.replace(/\//g, "&=")}?tab=Dispatched+PO`}
+                                className="text-blue-600 hover:underline"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                {invoice.document_name}
+                            </Link>
+                        )}
+                    </div>
+                </div>
+                {hasMapping ? (
+                    <InvoiceMappingTable lines={lines} poItemsByRow={poItemsByRow} poItemsById={poItemsById} />
+                ) : (
+                    <div className="p-3 text-xs text-gray-500">
+                        {isLoading ? "Loading item mapping…" : "No item mapping for this invoice."}
+                    </div>
+                )}
+            </HoverCardContent>
+        </HoverCard>
+        <InvoiceDataDialog
+            open={dialogOpen}
+            onOpenChange={setDialogOpen}
+            vendorInvoices={dialogInvoices}
+            visibleStatuses={["Pending", "Approved", "Rejected"]}
+            project={invoice.project}
+            poNumber={invoice.document_name}
+            documentType={invoice.document_type}
+            vendor={getVendorName?.(invoice.document_name, invoice.document_type)}
+        />
+        </>
+    );
+};
+
+/**
+ * "Invoice Total" cell — the running total for the parent PO/SR, clickable to
+ * open the InvoiceDataDialog (the same dialog the All-POs table uses) listing
+ * that document's invoices + per-invoice item mapping. The invoice list is
+ * already in memory (from useTotalInvoicedByDocument) — the dialog only fetches
+ * PO items / line mappings when opened.
+ */
+const InvoiceTotalCell: React.FC<{
+    invoice: VendorInvoice;
+    getTotalInvoiced?: (docName: string, docType: string) => number;
+    getInvoicesFor?: (docName: string, docType: string) => VendorInvoice[];
+    getVendorName?: (orderId: string, type: string) => string;
+}> = ({ invoice, getTotalInvoiced, getInvoicesFor, getVendorName }) => {
+    const [open, setOpen] = useState(false);
+
+    if (!getTotalInvoiced) return <span className="text-gray-400 italic">—</span>;
+    const total = getTotalInvoiced(invoice.document_name, invoice.document_type);
+    if (!total) return <span className="text-gray-400 italic">—</span>;
+
+    const invoices = getInvoicesFor?.(invoice.document_name, invoice.document_type) || [];
+
+    return (
+        <>
+            <div
+                className="underline cursor-pointer text-blue-600 hover:text-blue-800"
+                onClick={() => setOpen(true)}
+                title="View invoices for this document"
+            >
+                {formatToRoundedIndianRupee(total)}
+            </div>
+            <InvoiceDataDialog
+                open={open}
+                onOpenChange={setOpen}
+                vendorInvoices={invoices}
+                visibleStatuses={["Pending", "Approved"]}
+                project={invoice.project || invoices[0]?.project}
+                poNumber={invoice.document_name}
+                documentType={invoice.document_type}
+                vendor={getVendorName?.(invoice.document_name, invoice.document_type)}
+            />
+        </>
+    );
+};
+
+/**
  * Helper function for common columns shared between pending and history tables.
  */
 const getCommonColumns = (
@@ -104,7 +242,9 @@ const getCommonColumns = (
     // Returns sum of `invoice_amount` for all Vendor Invoices with same parent
     // (document_type + document_name) AND status in ['Pending', 'Approved'].
     // Same scope as `_existing_invoiced_sum` used by autofill validation.
-    getTotalInvoiced?: (docName: string, docType: string) => number
+    getTotalInvoiced?: (docName: string, docType: string) => number,
+    // Returns the individual invoices composing that total (for the hover breakdown).
+    getInvoicesFor?: (docName: string, docType: string) => VendorInvoice[]
 ): ColumnDef<VendorInvoice>[] => [
         {
             accessorKey: "document_name",
@@ -260,7 +400,10 @@ const getCommonColumns = (
                 />
             ),
             cell: ({ row }) => (
-                <div>{formatToRoundedIndianRupee(parseNumber(row.original.invoice_amount))}</div>
+                <InvoiceAmtHoverCell
+                    invoice={row.original}
+                    getVendorName={getVendorName}
+                />
             ),
             size: 150,
             sortingFn: 'alphanumeric',
@@ -278,16 +421,14 @@ const getCommonColumns = (
             // see how much of the order has been invoiced so far.
             id: "total_invoiced_for_parent",
             header: ({ column }) => <DataTableColumnHeader column={column} title="Invoice Total" />,
-            cell: ({ row }) => {
-                if (!getTotalInvoiced) {
-                    return <span className="text-gray-400 italic">—</span>;
-                }
-                const total = getTotalInvoiced(row.original.document_name, row.original.document_type);
-                if (!total) {
-                    return <span className="text-gray-400 italic">—</span>;
-                }
-                return <div>{formatToRoundedIndianRupee(total)}</div>;
-            },
+            cell: ({ row }) => (
+                <InvoiceTotalCell
+                    invoice={row.original}
+                    getTotalInvoiced={getTotalInvoiced}
+                    getInvoicesFor={getInvoicesFor}
+                    getVendorName={getVendorName}
+                />
+            ),
             size: 160,
             enableSorting: false,
             meta: {
@@ -329,9 +470,10 @@ export const getPendingTaskColumns = (
     getAmount?: (orderId: string, statuses: string[]) => number,
     getDeliveredAmount?: (orderId: string, type: string) => number,
     getVendorName?: (orderId: string, type: string) => string,
-    getTotalInvoiced?: (docName: string, docType: string) => number
+    getTotalInvoiced?: (docName: string, docType: string) => number,
+    getInvoicesFor?: (docName: string, docType: string) => VendorInvoice[]
 ): ColumnDef<VendorInvoice>[] => [
-        ...getCommonColumns(attachmentsMap, getTotalAmount, getAmount, getDeliveredAmount, getVendorName, getTotalInvoiced),
+        ...getCommonColumns(attachmentsMap, getTotalAmount, getAmount, getDeliveredAmount, getVendorName, getTotalInvoiced, getInvoicesFor),
         {
             id: "actions",
             header: () => <div className="">Actions</div>,
@@ -396,9 +538,10 @@ export const getTaskHistoryColumns = (
     getDeliveredAmount?: (orderId: string, type: string) => number,
     getAmount?: (orderId: string, statuses: string[]) => number,
     getVendorName?: (orderId: string, type: string) => string,
-    getTotalInvoiced?: (docName: string, docType: string) => number
+    getTotalInvoiced?: (docName: string, docType: string) => number,
+    getInvoicesFor?: (docName: string, docType: string) => VendorInvoice[]
 ): ColumnDef<VendorInvoice>[] => [
-        ...getCommonColumns(attachmentsMap, getTotalAmount, getAmount, getDeliveredAmount, getVendorName, getTotalInvoiced),
+        ...getCommonColumns(attachmentsMap, getTotalAmount, getAmount, getDeliveredAmount, getVendorName, getTotalInvoiced, getInvoicesFor),
         {
             accessorKey: "status",
             header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,

--- a/frontend/src/pages/tasks/invoices/hooks/useTotalInvoicedByDocument.ts
+++ b/frontend/src/pages/tasks/invoices/hooks/useTotalInvoicedByDocument.ts
@@ -20,7 +20,9 @@ export const useTotalInvoicedByDocument = () => {
     const { data, isLoading, error } = useFrappeGetDocList<VendorInvoice>(
         "Vendor Invoices",
         {
-            fields: ["document_type", "document_name", "invoice_amount"],
+            // These extra fields feed the InvoiceDataDialog opened from the
+            // "Invoice Total" cell (invoice list + attachment links).
+            fields: ["name", "document_type", "document_name", "invoice_amount", "invoice_no", "invoice_date", "status", "invoice_attachment", "project"],
             filters: [["status", "in", ["Pending", "Approved"]]],
             limit: 100000,
         },
@@ -37,11 +39,29 @@ export const useTotalInvoicedByDocument = () => {
         return map;
     }, [data]);
 
+    // Per-parent list of the invoices composing the running total (for the hover).
+    const invoicesMap = useMemo(() => {
+        const map = new Map<string, VendorInvoice[]>();
+        (data || []).forEach((row) => {
+            const key = `${row.document_type}|${row.document_name}`;
+            const list = map.get(key) || [];
+            list.push(row);
+            map.set(key, list);
+        });
+        return map;
+    }, [data]);
+
     const getTotalInvoiced = useCallback(
         (docName: string, docType: string) =>
             totalsMap.get(`${docType}|${docName}`) || 0,
         [totalsMap]
     );
 
-    return { getTotalInvoiced, isLoading, error };
+    const getInvoicesFor = useCallback(
+        (docName: string, docType: string): VendorInvoice[] =>
+            invoicesMap.get(`${docType}|${docName}`) || [],
+        [invoicesMap]
+    );
+
+    return { getTotalInvoiced, getInvoicesFor, isLoading, error };
 };

--- a/frontend/src/types/NirmaanStack/ProcurementOrders.ts
+++ b/frontend/src/types/NirmaanStack/ProcurementOrders.ts
@@ -19,6 +19,7 @@ export interface PurchaseOrderItem {
 	unit: string;
 	quantity: number;
 	received_quantity?: number;
+	invoice_qty?: number;
 	is_dispatched?: 0 | 1;
 	category: string;
 	procurement_package?: string;

--- a/frontend/src/types/NirmaanStack/VendorInvoice.ts
+++ b/frontend/src/types/NirmaanStack/VendorInvoice.ts
@@ -26,6 +26,8 @@ export interface VendorInvoice {
   invoice_date: string;
   invoice_amount: number;
   invoice_attachment?: string;
+  /** 1 if this invoice is a credit note — EXCLUDED from Purchase Order Item.invoice_qty. */
+  is_credit_note?: 0 | 1;
 
   /** Approval workflow */
   status: "Pending" | "Approved" | "Rejected";

--- a/nirmaan_stack/api/delivery_notes/update_invoice_data.py
+++ b/nirmaan_stack/api/delivery_notes/update_invoice_data.py
@@ -134,6 +134,7 @@ def update_invoice_data(
                     "invoice_no": new_invoice_entry_data.get("invoice_no"),
                     "invoice_date": new_invoice_entry_data.get("date"),
                     "invoice_amount": new_invoice_entry_data.get("amount"),
+                    "is_credit_note": 1 if new_invoice_entry_data.get("is_credit_note") else 0,
                 })
 
                 # If a new attachment was provided, update it
@@ -147,8 +148,12 @@ def update_invoice_data(
                 # snapshot is refreshed to match. invoice_qty resyncs via the
                 # recompute call before commit below.
                 if rebuild_line_mappings and vendor_invoice.status == "Pending":
-                    vendor_invoice.line_mappings = build_line_mapping_rows(
-                        autofill_line_match_json, doc
+                    # Use .set() (NOT direct attribute assignment) so the dict rows are
+                    # converted into child documents — a raw list of dicts left on the
+                    # attribute makes save() call .is_new() on a dict and blow up.
+                    vendor_invoice.set(
+                        "line_mappings",
+                        build_line_mapping_rows(autofill_line_match_json, doc),
                     )
                     vendor_invoice.autofill_used = 1
                     vendor_invoice.autofill_line_match_json = autofill_line_match_json
@@ -421,6 +426,7 @@ def create_vendor_invoice(
         "invoice_date": invoice_data.get("date"),
         "invoice_amount": invoice_data.get("amount"),
         "invoice_attachment": attachment_id,
+        "is_credit_note": 1 if invoice_data.get("is_credit_note") else 0,
         "status": "Pending",
         "uploaded_by": uploaded_by,
         "autofill_used": 1 if autofill_used else 0,

--- a/nirmaan_stack/api/delivery_notes/update_invoice_data.py
+++ b/nirmaan_stack/api/delivery_notes/update_invoice_data.py
@@ -18,6 +18,7 @@ from nirmaan_stack.api.invoices._auto_approve import (
     apply_auto_approval,
     evaluate_auto_approve_eligibility,
 )
+from nirmaan_stack.api.invoices._item_billing_sync import recompute_po_invoice_qty
 
 
 @frappe.whitelist()
@@ -38,6 +39,7 @@ def update_invoice_data(
     autofill_line_items_json: str = None,
     autofill_line_match_json: str = None,
     autofill_source_file_url: str = None,
+    rebuild_line_mappings: bool = False,
 ):
     """
     Creates or updates an invoice entry for a document (PO or SR).
@@ -133,10 +135,27 @@ def update_invoice_data(
                     "invoice_date": new_invoice_entry_data.get("date"),
                     "invoice_amount": new_invoice_entry_data.get("amount"),
                 })
-                
+
                 # If a new attachment was provided, update it
                 if attachment_id and attachment_id != vendor_invoice.invoice_attachment:
                     vendor_invoice.invoice_attachment = attachment_id
+
+                # Rebuild the verified line → PO-item mapping from the (corrected)
+                # mapping the frontend sent. PENDING invoices ONLY — an approved
+                # invoice's mapping is locked because its invoice_qty/billing
+                # already counts. The child rows are fully regenerated; the audit
+                # snapshot is refreshed to match. invoice_qty resyncs via the
+                # recompute call before commit below.
+                if rebuild_line_mappings and vendor_invoice.status == "Pending":
+                    vendor_invoice.line_mappings = build_line_mapping_rows(
+                        autofill_line_match_json, doc
+                    )
+                    vendor_invoice.autofill_used = 1
+                    vendor_invoice.autofill_line_match_json = autofill_line_match_json
+                    if autofill_line_items_json is not None:
+                        vendor_invoice.autofill_line_items_json = autofill_line_items_json
+                    if autofill_all_entities_json is not None:
+                        vendor_invoice.autofill_all_entities_json = autofill_all_entities_json
 
                 vendor_invoice.save(ignore_permissions=True)
             else:
@@ -213,6 +232,11 @@ def update_invoice_data(
                 },
                 update_modified=False
             )
+
+        # Refresh the stored per-item invoiced quantity from the invoice lines
+        # (new invoice → its matched lines now count toward each PO row).
+        if doctype == "Procurement Orders":
+            recompute_po_invoice_qty(docname)
 
         # --- Commit Transaction ---
         frappe.db.commit()
@@ -478,6 +502,13 @@ def delete_invoice_entry(docname: str, date_key: str = None, isSR: bool = False,
         invoice = frappe.get_doc("Vendor Invoices", vendor_invoice_name)
         invoice_no = invoice.invoice_no
         attachment_id = invoice.invoice_attachment
+        # Capture the PO before deletion so we can refresh its per-item invoiced
+        # quantities once this invoice's lines are gone.
+        po_for_sync = (
+            invoice.document_name
+            if invoice.document_type == "Procurement Orders"
+            else None
+        )
 
         # 2. Delete associated attachment (if exists)
         if attachment_id:
@@ -509,6 +540,11 @@ def delete_invoice_entry(docname: str, date_key: str = None, isSR: bool = False,
 
         # 4. Delete the Vendor Invoice document
         frappe.delete_doc("Vendor Invoices", vendor_invoice_name, ignore_permissions=True, force=True)
+
+        # 5. Refresh the PO's stored per-item invoiced quantities (this invoice's
+        # lines no longer count).
+        if po_for_sync:
+            recompute_po_invoice_qty(po_for_sync)
 
         # --- Commit Transaction ---
         frappe.db.commit()

--- a/nirmaan_stack/api/invoice_autofill.py
+++ b/nirmaan_stack/api/invoice_autofill.py
@@ -161,6 +161,10 @@ def extract_invoice_fields(file_url, docname=None):
         "line_items": line_items,
         "line_item_validation": line_item_validation,
         "line_match": line_match,
+        # True if the document itself is a credit note / credit memo (Gemini classified
+        # it). The frontend uses this to flip the amount (and, when NOT marked a credit
+        # note by the user, the line quantities) negative.
+        "credit_note_detected": any(e.get("type") == "is_credit_note" for e in entities),
         "po_items": po_items_out,
         "min_confidence": MIN_CONFIDENCE,
         "processor_id": settings.get("gemini_model"),

--- a/nirmaan_stack/api/invoices/_item_billing_sync.py
+++ b/nirmaan_stack/api/invoices/_item_billing_sync.py
@@ -1,17 +1,26 @@
 # Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
 # For license information, please see license.txt
 
-"""Keep the stored `Purchase Order Item.invoice_qty` in sync with invoice lines.
+"""Keep the stored `Purchase Order Item.invoice_qty` in sync — SELF-CLASSIFYING.
 
-`invoice_qty` is a DERIVED per-PO-row field: the sum of Matched
-`Vendor Invoice Line.quantity` across that PO's Pending+Approved invoices
-(Rejected excluded), grouped by the exact PO child row (`po_item_row`, which
-`build_line_mapping_rows` sets to `Purchase Order Item.name`).
+`invoice_qty` is a DERIVED per-PO-row field, RECOMPUTED FROM SOURCE on every call
+(never incremented by deltas, so it cannot drift). Per PO, `counted` = Pending+
+Approved invoices with Credit Notes excluded (`is_credit_note = 1` -> skipped, like
+Rejected). It resolves to one of three states:
 
-It is always RECOMPUTED FROM SOURCE — never incremented by deltas — so it cannot
-drift. Call `recompute_po_invoice_qty(po_name)` inside the transaction of every
-endpoint that changes the counted set of invoice lines (create, approve/reject,
-delete), BEFORE the commit. The counted-status set mirrors get_po_item_billing.
+  EXACT   -- EVERY counted invoice is line-mapped -> Σ signed Matched line quantity
+             per PO row. ALL-OR-NOTHING: trusted only when every invoice has line
+             data, else summing the mapped ones would UNDERCOUNT the unmapped
+             invoices (the "last added invoice" bug). A return note's negative qty
+             subtracts here.
+  ORDERED -- not all mapped, but the PO HAS counted invoices (or its project is
+             Completed) -> ordered quantity per row. Legacy / not-yet-extracted POs
+             are trusted fully invoiced; extraction later adds line data -> EXACT.
+  ZERO    -- no counted invoices (none / all rejected / only credit notes) and the
+             project is not Completed -> 0.
+
+Call `recompute_po_invoice_qty(po_name)` inside the transaction of every invoice
+event (create / approve / reject / delete / edit), BEFORE the commit.
 """
 
 import frappe
@@ -21,48 +30,88 @@ _COUNTED_STATUSES = ("Pending", "Approved")
 
 
 def recompute_po_invoice_qty(po_name: str) -> None:
-    """Rewrite invoice_qty on every `Purchase Order Item` row of `po_name`.
+    """Self-classify invoice_qty on every `Purchase Order Item` row of `po_name`.
 
-    Rows with no matched invoice lines are reset to 0. Writes go straight to the
-    child rows via db.set_value (update_modified=False) so the PO's own on_update
-    controller does NOT fire — invoice_qty is a derived cache, not a PO edit.
-    No-op for a blank / missing PO.
+    Resolves the PO to EXACT / ORDERED / ZERO (see module docstring) and writes each
+    row via db.set_value (update_modified=False) so the PO's on_update controller does
+    NOT fire — invoice_qty is a derived cache, not a PO edit. No-op for blank/missing PO.
     """
     if not po_name:
         return
 
-    # Matched line quantity per PO child row, across counted invoices only.
-    # Postgres: double-quoted identifiers, %(name)s params (see project CLAUDE.md).
-    rows = frappe.db.sql(
+    po_rows = frappe.db.get_all(
+        "Purchase Order Item",
+        filters={"parent": po_name, "parenttype": "Procurement Orders"},
+        fields=["name", "quantity"],
+    )
+    if not po_rows:
+        return
+
+    # counted invoices = real billing exposure: Pending+Approved, credit notes excluded.
+    # n_lines = how many Vendor Invoice Line rows each carries (0 = not yet extracted).
+    counted = frappe.db.sql(
         """
-        SELECT vil.po_item_row              AS row_name,
-               SUM(COALESCE(vil.quantity, 0)) AS qty
-        FROM "tabVendor Invoice Line" vil
-        JOIN "tabVendor Invoices" vi ON vil.parent = vi.name
-        WHERE vil.parenttype = 'Vendor Invoices'
-          AND vil.match_status = 'Matched'
-          AND vil.po_item_row IS NOT NULL
-          AND vil.po_item_row != ''
-          AND vi.document_type = 'Procurement Orders'
+        SELECT vi.name,
+               (SELECT COUNT(*) FROM "tabVendor Invoice Line" vil
+                 WHERE vil.parent = vi.name AND vil.parenttype = 'Vendor Invoices') AS n_lines
+        FROM "tabVendor Invoices" vi
+        WHERE vi.document_type = 'Procurement Orders'
           AND vi.document_name = %(po)s
           AND vi.status IN %(statuses)s
-        GROUP BY vil.po_item_row
+          AND COALESCE(vi.is_credit_note, 0) = 0
         """,
         {"po": po_name, "statuses": _COUNTED_STATUSES},
         as_dict=True,
     )
-    invoiced = {r.row_name: float(r.qty or 0) for r in rows}
 
-    po_rows = frappe.db.get_all(
-        "Purchase Order Item",
-        filters={"parent": po_name, "parenttype": "Procurement Orders"},
-        fields=["name"],
-    )
-    for r in po_rows:
-        frappe.db.set_value(
-            "Purchase Order Item",
-            r.name,
-            "invoice_qty",
-            invoiced.get(r.name, 0),
-            update_modified=False,
+    def _write(value_fn):
+        for r in po_rows:
+            frappe.db.set_value(
+                "Purchase Order Item", r.name, "invoice_qty", value_fn(r),
+                update_modified=False,
+            )
+
+    # 1) EXACT — every counted invoice has line data -> Σ signed Matched qty per row.
+    # WHY all-or-nothing: if even one counted invoice is unmapped, summing the mapped
+    # ones would UNDERCOUNT (the unmapped invoice contributes 0) -> the "last added
+    # invoice" bug. Only trust the line sum when every invoice has been read.
+    if counted and all((c.n_lines or 0) > 0 for c in counted):
+        rows = frappe.db.sql(
+            """
+            SELECT vil.po_item_row              AS row_name,
+                   SUM(COALESCE(vil.quantity, 0)) AS qty
+            FROM "tabVendor Invoice Line" vil
+            JOIN "tabVendor Invoices" vi ON vil.parent = vi.name
+            WHERE vil.parenttype = 'Vendor Invoices'
+              AND vil.match_status = 'Matched'
+              AND vil.po_item_row IS NOT NULL
+              AND vil.po_item_row != ''
+              AND vi.document_type = 'Procurement Orders'
+              AND vi.document_name = %(po)s
+              AND vi.status IN %(statuses)s
+              AND COALESCE(vi.is_credit_note, 0) = 0
+            GROUP BY vil.po_item_row
+            """,
+            {"po": po_name, "statuses": _COUNTED_STATUSES},
+            as_dict=True,
         )
+        invoiced = {r.row_name: float(r.qty or 0) for r in rows}
+        _write(lambda r: invoiced.get(r.name, 0))
+        return
+
+    # 2) ORDERED — not all mapped, but the PO HAS counted invoices, OR its project is
+    # Completed -> trust it's (fully) invoiced -> ordered quantity per row. (The short-
+    # circuit keeps the project lookup off the hot path when invoices exist.)
+    if counted or _project_is_completed(po_name):
+        _write(lambda r: float(r.quantity or 0))
+        return
+
+    # 3) ZERO — no counted invoices and project not Completed.
+    _write(lambda r: 0)
+
+
+def _project_is_completed(po_name: str) -> bool:
+    project = frappe.db.get_value("Procurement Orders", po_name, "project")
+    return bool(project) and (
+        frappe.db.get_value("Projects", project, "status") == "Completed"
+    )

--- a/nirmaan_stack/api/invoices/_item_billing_sync.py
+++ b/nirmaan_stack/api/invoices/_item_billing_sync.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+"""Keep the stored `Purchase Order Item.invoice_qty` in sync with invoice lines.
+
+`invoice_qty` is a DERIVED per-PO-row field: the sum of Matched
+`Vendor Invoice Line.quantity` across that PO's Pending+Approved invoices
+(Rejected excluded), grouped by the exact PO child row (`po_item_row`, which
+`build_line_mapping_rows` sets to `Purchase Order Item.name`).
+
+It is always RECOMPUTED FROM SOURCE — never incremented by deltas — so it cannot
+drift. Call `recompute_po_invoice_qty(po_name)` inside the transaction of every
+endpoint that changes the counted set of invoice lines (create, approve/reject,
+delete), BEFORE the commit. The counted-status set mirrors get_po_item_billing.
+"""
+
+import frappe
+
+# Invoice statuses that represent real billing exposure (mirror get_po_item_billing).
+_COUNTED_STATUSES = ("Pending", "Approved")
+
+
+def recompute_po_invoice_qty(po_name: str) -> None:
+    """Rewrite invoice_qty on every `Purchase Order Item` row of `po_name`.
+
+    Rows with no matched invoice lines are reset to 0. Writes go straight to the
+    child rows via db.set_value (update_modified=False) so the PO's own on_update
+    controller does NOT fire — invoice_qty is a derived cache, not a PO edit.
+    No-op for a blank / missing PO.
+    """
+    if not po_name:
+        return
+
+    # Matched line quantity per PO child row, across counted invoices only.
+    # Postgres: double-quoted identifiers, %(name)s params (see project CLAUDE.md).
+    rows = frappe.db.sql(
+        """
+        SELECT vil.po_item_row              AS row_name,
+               SUM(COALESCE(vil.quantity, 0)) AS qty
+        FROM "tabVendor Invoice Line" vil
+        JOIN "tabVendor Invoices" vi ON vil.parent = vi.name
+        WHERE vil.parenttype = 'Vendor Invoices'
+          AND vil.match_status = 'Matched'
+          AND vil.po_item_row IS NOT NULL
+          AND vil.po_item_row != ''
+          AND vi.document_type = 'Procurement Orders'
+          AND vi.document_name = %(po)s
+          AND vi.status IN %(statuses)s
+        GROUP BY vil.po_item_row
+        """,
+        {"po": po_name, "statuses": _COUNTED_STATUSES},
+        as_dict=True,
+    )
+    invoiced = {r.row_name: float(r.qty or 0) for r in rows}
+
+    po_rows = frappe.db.get_all(
+        "Purchase Order Item",
+        filters={"parent": po_name, "parenttype": "Procurement Orders"},
+        fields=["name"],
+    )
+    for r in po_rows:
+        frappe.db.set_value(
+            "Purchase Order Item",
+            r.name,
+            "invoice_qty",
+            invoiced.get(r.name, 0),
+            update_modified=False,
+        )

--- a/nirmaan_stack/api/invoices/approve_vendor_invoice.py
+++ b/nirmaan_stack/api/invoices/approve_vendor_invoice.py
@@ -7,6 +7,8 @@ This replaces the old update_task_status API that operated on Task documents.
 import frappe
 from frappe import _
 
+from nirmaan_stack.api.invoices._item_billing_sync import recompute_po_invoice_qty
+
 
 @frappe.whitelist()
 def approve_vendor_invoice(invoice_id: str, action: str, rejection_reason: str = None):
@@ -74,6 +76,11 @@ def approve_vendor_invoice(invoice_id: str, action: str, rejection_reason: str =
 
         # 4. Save the invoice
         invoice.save(ignore_permissions=True)
+
+        # 5. Refresh the PO's stored per-item invoiced quantities. A rejection
+        # pulls this invoice's lines out of the counted (Pending+Approved) set.
+        if invoice.document_type == "Procurement Orders":
+            recompute_po_invoice_qty(invoice.document_name)
 
         # --- Commit Transaction ---
         frappe.db.commit()

--- a/nirmaan_stack/dry_run_invoice_qty.py
+++ b/nirmaan_stack/dry_run_invoice_qty.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+"""
+invoice_qty backfill — PLAN + EXTRACTION PREVIEW in ONE file. READ-ONLY.
+
+Stage 1 (dry run, ALL projects, NO AI): classify every live PO and print the
+  invoice_qty it would get. Self-classifying — mirrors recompute_po_invoice_qty:
+    EXACT   -- every counted invoice is line-mapped        -> sum of signed matched qty.
+    ORDERED -- not all mapped, has invoices (or Completed)  -> ordered qty.
+    ZERO    -- no invoices (and project not Completed)      -> 0.
+  An UNDER-invoiced ORDERED PO ("mismatch") gets ordered qty NOW; the HELD Gemini
+  extraction will later read ALL its invoices and refine it to the exact qty.
+
+Stage 2 (extraction preview, Gemini): HELD in dev (RUN_EXTRACTION = False). For each
+  mismatched PO it reads every invoice image, maps the lines, shows the exact qty.
+
+CREDIT NOTES: an invoice with a NEGATIVE amount is skipped (like Rejected) -- it never
+  adds qty or corrects price; invoice_qty derives only from positive invoices.
+
+It WRITES NOTHING (no set_value, no commit).
+
+Run inside the dev container:
+  docker exec -w /workspace/development/frappe-bench frappe_docker_devcontainer-frappe-1 \
+      env/bin/python /workspace/development/frappe-bench/dry_run_invoice_qty.py
+"""
+import os
+os.chdir("/workspace/development/frappe-bench/sites")   # required before frappe.init
+import frappe
+frappe.init(site="localhost")
+frappe.connect()
+from collections import defaultdict
+
+# ---- config -----------------------------------------------------------------
+TOL                = 1.0      # Rs rounding cushion: a few Rs under the PO still counts as fully invoiced
+MIN_MATCH          = 0.70     # extraction quality gate: >=70% of item lines must map or the invoice FAILs
+RUN_EXTRACTION     = False     # Stage 2 on/off. False = pure dry run (no Gemini, no cost, no file reads).
+EXTRACTION_PROJECT = None   # limit Stage 2 Gemini to this project; None = ALL mismatched POs
+
+
+def num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ---- bulk reads (read-only) -------------------------------------------------
+proj_status = dict(frappe.db.sql("""SELECT name, COALESCE(status, '') FROM "tabProjects" """))
+proj_name = dict(frappe.db.sql("""SELECT name, COALESCE(project_name, name) FROM "tabProjects" """))
+
+pos = frappe.db.sql(
+    """SELECT name, project, COALESCE(total_amount, 0) AS amt
+       FROM "tabProcurement Orders" WHERE status != 'Merged'""",   # Merged -> superseded by revisions
+    as_dict=True,
+)
+
+invs = frappe.db.sql(
+    """SELECT document_name AS po, name, invoice_no, status,
+              COALESCE(invoice_amount, 0) AS invoice_amount, invoice_attachment
+       FROM "tabVendor Invoices" WHERE document_type = 'Procurement Orders'""",
+    as_dict=True,
+)
+inv_by_po = defaultdict(list)
+for i in invs:
+    inv_by_po[i.po].append(i)
+
+# invoices that already carry line mappings (exact truth we must not clobber)
+has_lines = {
+    r[0] for r in frappe.db.sql(
+        """SELECT DISTINCT parent FROM "tabVendor Invoice Line" WHERE parenttype = 'Vendor Invoices'"""
+    )
+}
+
+# ordered-qty item-row count per PO (for the "rows written" tally)
+item_count = dict(frappe.db.sql(
+    """SELECT parent, COUNT(*) FROM "tabPurchase Order Item"
+       WHERE parenttype = 'Procurement Orders' GROUP BY parent"""))
+
+
+# =============================================================================
+# STAGE 1 — classify every live PO (mirrors the patch's derivation)
+# =============================================================================
+def classify(project_status, po_total, po_invs):
+    """Return (bucket, reason). bucket ∈ EXACT / COMPLETED / DIRECT / MISMATCH / ZERO.
+
+    COMPLETED, DIRECT and MISMATCH all get invoice_qty = ordered qty (choice-i) -- the
+    split is only for the review lists. `reason` explains WHY a MISMATCH PO is flagged.
+    """
+    # COUNTED = not Rejected AND amount >= 0 (a credit note = negative amount = skipped).
+    active = [i for i in po_invs if i.status != "Rejected" and num(i.invoice_amount) >= 0]
+
+    # EXACT -- every counted invoice has line data (ALL-OR-NOTHING) -> sum signed matched qty.
+    if active and all(i.name in has_lines for i in active):
+        return "EXACT", ""
+
+    # COMPLETED project -> ordered qty directly (trusted fully billed, NO amount check).
+    if project_status == "Completed":
+        return "COMPLETED", ""
+
+    # No counted invoices (and not Completed) -> 0.
+    if not active:
+        return "ZERO", ""
+
+    # Has invoices, not all mapped, not Completed:
+    net = sum(num(i.invoice_amount) for i in active)
+    all_approved = all(i.status == "Approved" for i in active)
+    if all_approved and net >= po_total - TOL:
+        return "DIRECT", ""              # fully invoiced -> ordered qty, no extraction needed
+
+    # MISMATCH -> ordered qty NOW, needs extraction to refine. Build the WHY.
+    reasons = []
+    if not all_approved:
+        n_pending = sum(1 for i in active if i.status != "Approved")
+        reasons.append(f"{n_pending} pending invoice(s)")
+    if net < po_total - TOL:
+        reasons.append(f"under-invoiced short {po_total - net:,.0f}")
+    return "MISMATCH", " + ".join(reasons) or "under-invoiced"
+
+
+counts = defaultdict(int)
+ordered_rows = 0
+extraction = []       # MISMATCH POs (under-invoiced) -> the (held) Gemini extraction list
+direct_ordered = []   # COMPLETED + DIRECT POs -> ordered qty directly, no extraction
+
+for p in pos:
+    bucket, reason = classify(proj_status.get(p.project, ""), num(p.amt), inv_by_po.get(p.name, []))
+    counts[bucket] += 1
+    if bucket in ("COMPLETED", "DIRECT", "MISMATCH"):
+        ordered_rows += int(item_count.get(p.name, 0))
+    if bucket in ("COMPLETED", "DIRECT"):
+        direct_ordered.append({
+            "project": p.project or "(no project)", "po": p.name,
+            "amt": num(p.amt), "bucket": bucket,
+        })
+    elif bucket == "MISMATCH":
+        active = [i for i in inv_by_po[p.name]
+                  if i.status != "Rejected" and num(i.invoice_amount) >= 0]   # positive invoices to extract
+        credits = [i for i in inv_by_po[p.name]
+                   if i.status != "Rejected" and num(i.invoice_amount) < 0]   # credit notes (skipped)
+        net = sum(num(i.invoice_amount) for i in active)
+        extraction.append({
+            "project": p.project or "(no project)", "po": p.name,
+            "amt": num(p.amt), "net": net, "n_inv": len(active),
+            "invoices": active, "n_credit": len(credits), "reason": reason,
+        })
+
+n_completed = sum(1 for s in proj_status.values() if s == "Completed")
+print("\n=========== STAGE 1: DRY RUN (all projects, no AI) — NOTHING WRITTEN ===========")
+print(f"Projects: {n_completed} Completed  |  {len(proj_status) - n_completed} others")
+print(f"Live POs (excl. Merged): {len(pos)}\n")
+print("Bucket counts (POs) — the invoice_qty each PO gets NOW:")
+print(f"  COMPLETED {counts['COMPLETED']:>5}   -> ordered qty  (project Completed -> directly)")
+print(f"  DIRECT    {counts['DIRECT']:>5}   -> ordered qty  (fully invoiced, not completed -> directly)")
+print(f"  MISMATCH  {counts['MISMATCH']:>5}   -> ordered qty NOW  (under-invoiced -> HELD Gemini refines to exact)")
+print(f"  EXACT     {counts['EXACT']:>5}   -> sum of mapped line qty")
+print(f"  ZERO      {counts['ZERO']:>5}   -> 0  (no invoices)")
+print(f"\n  ordered qty on ~{ordered_rows} Purchase Order Item rows"
+      f"  (COMPLETED {counts['COMPLETED']} + DIRECT {counts['DIRECT']} + MISMATCH {counts['MISMATCH']})")
+
+# ---- mismatch breakdown, PROJECT-WISE (how many POs + invoices mismatched per project) ----
+by_proj = defaultdict(lambda: {"pos": 0, "invoices": 0})
+for e in extraction:
+    by_proj[e["project"]]["pos"] += 1
+    by_proj[e["project"]]["invoices"] += e["n_inv"]
+
+tot_pos = sum(d["pos"] for d in by_proj.values())
+tot_inv = sum(d["invoices"] for d in by_proj.values())
+
+print(f"\nMISMATCH SUMMARY — per project  "
+      f"({len(by_proj)} projects · {tot_pos} mismatched POs · {tot_inv} invoices):")
+print(f"  {'PROJECT':<34}{'mismatch POs':>14}{'invoices':>10}")
+for proj in sorted(by_proj):
+    d = by_proj[proj]
+    print(f"  {proj:<34}{d['pos']:>14}{d['invoices']:>10}")
+print(f"  {'TOTAL':<34}{tot_pos:>14}{tot_inv:>10}")
+
+# resolve which invoice attachments actually have a file (extraction needs the file)
+att_ids = tuple({i.invoice_attachment for e in extraction for i in e["invoices"] if i.invoice_attachment})
+has_file = set()
+if att_ids:
+    has_file = {r[0] for r in frappe.db.sql(
+        """SELECT name FROM "tabNirmaan Attachments"
+           WHERE name IN %(ids)s AND COALESCE(attachment, '') != ''""",
+        {"ids": att_ids})}
+
+print("\nMISMATCHED POs — full detail (amount gap + the invoices to extract):")
+last = None
+for e in sorted(extraction, key=lambda x: (x["project"], x["po"])):
+    if e["project"] != last:
+        d = by_proj[e["project"]]
+        print(f"\n  === {e['project']}  ({d['pos']} POs · {d['invoices']} invoices) ===")
+        last = e["project"]
+    tag = f"   ({e['n_credit']} credit note skipped)" if e["n_credit"] else ""
+    print(f"     {e['po']:<24} PO {e['amt']:>13,.0f}  invoiced {e['net']:>13,.0f}"
+          f"  short {e['amt'] - e['net']:>12,.0f}   [{e['n_inv']} inv]{tag}")
+    print(f"          WHY mismatched: {e['reason']}")
+    for inv in e["invoices"]:
+        ok = "file OK" if inv.invoice_attachment in has_file else "NO FILE"
+        print(f"          - {(inv.invoice_no or inv.name):<24} {inv.status:<10}"
+              f" Rs {num(inv.invoice_amount):>12,.0f}   [{ok}]")
+
+# extraction feasibility: how many of the to-extract invoices actually have a file
+all_inv = [i for e in extraction for i in e["invoices"]]
+with_file = sum(1 for i in all_inv if i.invoice_attachment in has_file)
+print(f"\nEXTRACTION FEASIBILITY: {with_file}/{len(all_inv)} invoices have a file (extractable)"
+      f"  |  {len(all_inv) - with_file} missing file -> manual")
+
+# ---- FLAT LIST: every mismatched invoice (project | PO | invoice_no | invoice amount) ----
+print(f"\nFLAT LIST — all mismatched invoices ({len(all_inv)}):")
+print(f"  {'#':>3}  {'PROJECT':<32}  {'PO':<24}  {'INVOICE NO':<24}  {'INVOICE AMT':>13}")
+n = 0
+for e in sorted(extraction, key=lambda x: (x["project"], x["po"])):
+    for inv in e["invoices"]:
+        n += 1
+        print(f"  {n:>3}  {e['project']:<32}  {e['po']:<24}  "
+              f"{(inv.invoice_no or inv.name):<24}  {num(inv.invoice_amount):>13,.0f}")
+
+# ---- CSV exports (output files, NOT DB changes) -----------------------------
+import csv
+_BENCH = "/workspace/development/frappe-bench"
+
+# 1) MISMATCHED invoices — one row per invoice, WITH the reason it's mismatched.
+with open(f"{_BENCH}/mismatched_invoices.csv", "w", newline="") as fh:
+    w = csv.writer(fh)
+    w.writerow(["project_name", "project_id", "po", "po_amount", "invoice_no",
+                "invoice_amount", "status", "file_ok", "reason"])
+    for e in sorted(extraction, key=lambda x: (x["project"], x["po"])):
+        for inv in e["invoices"]:
+            w.writerow([
+                proj_name.get(e["project"], e["project"]), e["project"], e["po"], f"{e['amt']:.2f}",
+                inv.invoice_no or inv.name, f"{num(inv.invoice_amount):.2f}",
+                inv.status, "yes" if inv.invoice_attachment in has_file else "no", e["reason"],
+            ])
+print(f"\nCSV written: {_BENCH}/mismatched_invoices.csv  ({len(all_inv)} rows)")
+
+# 2) DIRECT-ORDERED POs — the ones that get ordered qty WITHOUT extraction, one row
+#    per PO, with bucket = COMPLETED (project done) or DIRECT (fully invoiced, not completed).
+with open(f"{_BENCH}/direct_ordered_pos.csv", "w", newline="") as fh:
+    w = csv.writer(fh)
+    w.writerow(["bucket", "project_name", "project_id", "po", "po_amount"])
+    for d in sorted(direct_ordered, key=lambda x: (x["bucket"], x["project"], x["po"])):
+        w.writerow([d["bucket"], proj_name.get(d["project"], d["project"]),
+                    d["project"], d["po"], f"{d['amt']:.2f}"])
+n_comp = sum(1 for d in direct_ordered if d["bucket"] == "COMPLETED")
+n_dir = sum(1 for d in direct_ordered if d["bucket"] == "DIRECT")
+print(f"CSV written: {_BENCH}/direct_ordered_pos.csv  "
+      f"({len(direct_ordered)} POs — COMPLETED {n_comp} + DIRECT {n_dir})")
+
+
+# =============================================================================
+# STAGE 2 — extraction preview (Gemini) on the mismatched POs from Stage 1
+# =============================================================================
+if not RUN_EXTRACTION:
+    print("\n(Stage 2 skipped: RUN_EXTRACTION = False)\n")
+    frappe.destroy()
+    raise SystemExit
+
+from nirmaan_stack.api.invoice_autofill import extract_invoice_fields   # reuse the real extractor
+
+targets = [(e["project"], e["po"]) for e in sorted(extraction, key=lambda x: (x["project"], x["po"]))
+           if EXTRACTION_PROJECT is None or e["project"] == EXTRACTION_PROJECT]
+
+print("\n=========== STAGE 2: EXTRACTION PREVIEW (Gemini) — NOTHING WRITTEN ===========")
+print(f"Scope: {EXTRACTION_PROJECT or 'ALL projects'}   |   mismatched POs to read: {len(targets)}\n")
+
+
+def resolve(att):
+    # invoice_attachment -> Nirmaan Attachments.attachment (a file_url)
+    return frappe.db.get_value("Nirmaan Attachments", att, "attachment") if att else None
+
+
+overall = {"PASS": 0, "FAIL": 0}
+for proj, po in targets:
+    active = [i for i in inv_by_po[po]
+              if i.status != "Rejected" and num(i.invoice_amount) >= 0]   # positive invoices only (skip credit notes)
+    print(f"================ {po}  ({proj}) ================")
+    po_ok = True
+    per_item = defaultdict(float)   # po_item_name -> NET matched qty (credit notes subtract)
+
+    for inv in active:
+        f = resolve(inv.invoice_attachment)
+        sign = -1.0 if num(inv.invoice_amount) < 0 else 1.0   # credit note (negative amount) -> SUBTRACT
+        kind = "CREDIT" if sign < 0 else "invoice"
+        if not f:
+            print(f"  {kind} {inv.invoice_no or inv.name}: NO FILE -> FAIL")
+            po_ok = False
+            continue
+        try:
+            res = extract_invoice_fields(f, docname=po)                 # reads file + calls Gemini
+            lm = (res or {}).get("line_match") or {}
+            s = lm.get("summary", {})
+            m, u = s.get("matched", 0), s.get("unmatched", 0)
+            success = m / max(1, m + u)
+            verdict = "PASS" if success >= MIN_MATCH else "FAIL"
+            print(f"  {kind} {inv.invoice_no or inv.name} (Rs {num(inv.invoice_amount):,.0f}): "
+                  f"{m} matched / {u} unmatched ({success:.0%}) -> {verdict}")
+            for x in (lm.get("mappings") or []):
+                tgt = x.get("po_item_name") or "-"
+                print(f"       {(x.get('description') or '')[:38]:<40} q={num(x.get('quantity')):<8,.0f}"
+                      f" amt={num(x.get('amount')):<10,.0f} [{x.get('status')}] -> {tgt}")
+                if x.get("status") == "matched" and x.get("po_item_name"):
+                    per_item[x["po_item_name"]] += sign * num(x.get("quantity"))
+            if success < MIN_MATCH:
+                po_ok = False
+        except Exception as e:
+            print(f"  {kind} {inv.invoice_no or inv.name}: ERROR {str(e)[:50]} -> FAIL")
+            po_ok = False
+
+    if po_ok:
+        overall["PASS"] += 1
+        rows = frappe.db.sql(
+            """SELECT item_name, COALESCE(quantity, 0) AS ordered
+               FROM "tabPurchase Order Item"
+               WHERE parent = %s AND parenttype = 'Procurement Orders' ORDER BY idx""",
+            (po,), as_dict=True,
+        )
+        print("  >>> PO PASS — resulting NET invoice_qty vs ordered:")
+        for r in rows:
+            q = per_item.get(r.item_name, 0.0)
+            flag = "OVER" if q > r.ordered else ("full" if q == r.ordered else "partial")
+            print(f"        {r.item_name[:44]:<46} ordered {r.ordered:>10,.0f}  invoice_qty {q:>10,.0f}  {flag}")
+    else:
+        overall["FAIL"] += 1
+        print("  >>> PO FAIL — one+ invoice errored / <80% / no file -> MANUAL (writes nothing)")
+    print()
+
+print(f"STAGE 2 SUMMARY:  PASS {overall['PASS']}  |  FAIL {overall['FAIL']}  (of {len(targets)} mismatched POs)")
+print("(no changes committed — preview only)\n")
+frappe.destroy()

--- a/nirmaan_stack/nirmaan_stack/doctype/purchase_order_item/purchase_order_item.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/purchase_order_item/purchase_order_item.json
@@ -12,6 +12,7 @@
   "unit",
   "quantity",
   "received_quantity",
+  "invoice_qty",
   "is_dispatched",
   "category",
   "po",
@@ -64,6 +65,14 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Quantity Received"
+  },
+  {
+   "default": "0",
+   "description": "Quantity invoiced so far (derived from verified invoice line mappings; read-only).",
+   "fieldname": "invoice_qty",
+   "fieldtype": "Float",
+   "label": "Invoice Qty",
+   "read_only": 1
   },
   {
    "default": "0",

--- a/nirmaan_stack/nirmaan_stack/doctype/vendor_invoice_line/vendor_invoice_line.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/vendor_invoice_line/vendor_invoice_line.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "creation": "2026-06-13 10:00:00.000000",
+ "creation": "2026-06-13 10:00:00",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -94,7 +94,7 @@
   },
   {
    "fieldname": "po_item_name",
-   "fieldtype": "Data",
+   "fieldtype": "Text",
    "label": "PO Item Name"
   },
   {
@@ -109,7 +109,7 @@
    "options": "\nFuzzy\nAI\nManual"
   },
   {
-   "description": "Fuzzy confidence 0–1 (blank for manual / AI).",
+   "description": "Fuzzy confidence 0\u20131 (blank for manual / AI).",
    "fieldname": "match_score",
    "fieldtype": "Float",
    "label": "Match Score",
@@ -126,12 +126,14 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-13 10:00:00.000000",
- "modified_by": "Administrator",
+ "modified": "2026-07-03 18:55:15.955407",
+ "modified_by": "nitesh@nirmaan.app",
  "module": "Nirmaan Stack",
  "name": "Vendor Invoice Line",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/nirmaan_stack/nirmaan_stack/doctype/vendor_invoices/vendor_invoices.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/vendor_invoices/vendor_invoices.json
@@ -19,6 +19,7 @@
   "column_break_invoice",
   "invoice_amount",
   "invoice_attachment",
+  "is_credit_note",
   "approval_section",
   "status",
   "uploaded_by",
@@ -134,6 +135,15 @@
    "fieldtype": "Link",
    "label": "Invoice Attachment",
    "options": "Nirmaan Attachments"
+  },
+  {
+   "default": "0",
+   "description": "Tick if this Vendor Invoice is a credit note. Credit notes are EXCLUDED from Purchase Order Item.invoice_qty (they do not add to the invoiced quantity).",
+   "fieldname": "is_credit_note",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Credit Note"
   },
   {
    "fieldname": "approval_section",

--- a/nirmaan_stack/patches/v3_0/RUNBOOK_invoice_qty_backfill.md
+++ b/nirmaan_stack/patches/v3_0/RUNBOOK_invoice_qty_backfill.md
@@ -1,0 +1,109 @@
+# Invoice Qty Backfill — Production Deployment Runbook
+
+**Audience:** whoever runs the production deployment (not the author).
+**File:** `nirmaan_stack/patches/v3_0/backfill_invoice_qty.py`
+**Nature:** manual scripts — **NOT** wired into `patches.txt`, so they run **only** when you execute them (they will *not* fire automatically on `bench migrate`).
+
+---
+
+## 1. What this does (in one paragraph)
+
+It fills `Purchase Order Item.invoice_qty` — "how much of each PO line has been invoiced" — for **all existing POs**.
+- Most POs are filled **deterministically** (pure DB math, **no AI**): fully-invoiced / completed-project POs get their **ordered quantity**; POs with no invoices get **0**.
+- The **under-invoiced ("mismatch") POs** get their **exact** invoiced quantity from a **pre-computed cache** (`extraction_cache.json`) that the test team already produced by reading the invoice images. So production needs **little or no** AI/Gemini.
+
+---
+
+## 2. Prerequisites (before you start)
+
+1. ✅ **App code deployed** and **`bench migrate` run** — this creates the two new columns:
+   - `Purchase Order Item.invoice_qty`
+   - `Vendor Invoices.is_credit_note`
+2. ✅ **`extraction_cache.json` copied into the bench directory** (same folder as your site's bench, e.g. `/workspace/development/frappe-bench/extraction_cache.json`). **The test team provides this file.**
+3. ✅ In `backfill_invoice_qty.py`, the config line at the top:
+   ```python
+   PROJECT = None      # None = ALL projects (full production run)
+   ```
+   > It may currently be set to a single project (used for testing). **Set it to `None`** for the full production run. (Or set a project name to roll out one project at a time.)
+4. ⚠️ Only needed **if the cache is incomplete** (some invoice not in it): **Document AI must be enabled** and the **invoice files reachable (S3)**. If the cache covers everything, this is not required.
+
+Replace `<SITE>` below with your site name (e.g. `prod.nirmaan.app`).
+
+---
+
+## 3. Deployment steps — run IN THIS ORDER
+
+### Step 1 — Backfill (fast, no AI, ~seconds)
+```bash
+bench --site <SITE> execute nirmaan_stack.patches.v3_0.backfill_invoice_qty.execute
+```
+- Classifies every live PO and writes `invoice_qty`:
+  `COMPLETED`/`DIRECT` → ordered qty · `ZERO` → 0 · `EXACT` → summed line qty · **`MISMATCH` → left for Step 2**.
+- Prints the bucket counts, e.g. `{EXACT: 1, COMPLETED: 2268, DIRECT: 2196, MISMATCH: 54, ZERO: 137}`.
+- Safe and **idempotent** — re-running produces the same result.
+
+### Step 2 — Import the extraction cache (replay, mostly no AI)
+```bash
+bench --site <SITE> console
+```
+then, inside the console:
+```python
+from nirmaan_stack.patches.v3_0 import backfill_invoice_qty as b
+
+b.import_cache(apply=False)      # DRY RUN — prints HIT/MISS counts, writes NOTHING
+b.import_cache(apply=True)       # APPLY — writes the mappings, recomputes -> EXACT
+```
+- **HIT** = the invoice is in the cache → its mapping is applied **without any AI call** (fast, cheap).
+- **MISS** = invoice not in the cache → one Gemini read (needs Document AI + files). If Gemini can't read it, it's logged (see §6).
+- After each PO's invoices are filled, `invoice_qty` is recomputed to the **exact** value.
+
+> Always run `apply=False` first and eyeball the HIT/MISS numbers. HIT should be the large majority; MISS should be near zero if the cache is complete.
+
+---
+
+## 4. What to verify after
+
+- Step 1 printed sensible bucket counts (no errors).
+- Step 2 printed mostly **HIT**, few/no **MISS**, **0 failed**.
+- Spot-check a few POs in the UI: `invoice_qty` on the PO's items looks right.
+
+---
+
+## 5. Safety guarantees (why this is low-risk)
+
+- **Invoice files are READ-ONLY** — they are only downloaded to be read; **never** modified, replaced, moved, or deleted.
+- **Does NOT bump `modified`** on any record (`update_modified=False` / modified-preserving saves everywhere). Nothing shows as "recently edited by System."
+- **Idempotent** — safe to re-run any step.
+- **`import_cache(apply=False)`** writes nothing — a true dry preview.
+- **Not in `patches.txt`** — nothing runs on migrate; only your explicit commands do.
+- Only two fields are ever written: `invoice_qty` (on PO items) and, on the invoices, `line_mappings` + the `autofill_*` fields.
+
+---
+
+## 6. If something fails
+
+- A cache MISS that Gemini also can't read is appended to **`extraction_failures.log`** (in the bench dir) with the PO + invoice.
+- Those POs simply keep the safe estimate; nothing breaks.
+- To fix one later, in the console:
+  ```python
+  b.manual_fix("<vendor-invoice-name>", {"EXACT PO ITEM NAME": 1234, ...})
+  ```
+  This writes the mapping by hand and recomputes that PO.
+
+---
+
+## 7. Rollback
+
+`invoice_qty` is a **derived** field — it's always recomputed from source. To re-derive at any time, just re-run **Step 1** (and **Step 2** if needed). There is no destructive change to undo.
+
+---
+
+## Quick reference
+
+| Step | Command | AI? | Writes |
+|---|---|---|---|
+| 1. Backfill | `bench --site <SITE> execute nirmaan_stack.patches.v3_0.backfill_invoice_qty.execute` | no | invoice_qty |
+| 2a. Preview | `b.import_cache(apply=False)` (in console) | no | nothing |
+| 2b. Apply | `b.import_cache(apply=True)` (in console) | only for cache MISS | mappings + invoice_qty |
+
+**Do NOT run** `run_extraction()` or `export_cache()` on production — those are **test-server** steps (they produce the cache that Step 2 consumes).

--- a/nirmaan_stack/patches/v3_0/backfill_invoice_qty.py
+++ b/nirmaan_stack/patches/v3_0/backfill_invoice_qty.py
@@ -1,0 +1,331 @@
+import frappe
+
+# Backfill `Purchase Order Item.invoice_qty`. THREE steps, run IN ORDER, deliberately:
+#
+#   1. execute()          -- deterministic backfill for EVERY live PO. No AI. Run FIRST.
+#                            Leaves the under-invoiced ("MISMATCH") POs at ordered qty.
+#
+#   2. run_extraction()   -- run AFTER the backfill. Reads the MISMATCH POs' invoices with
+#                            Gemini, ONE AT A TIME, and prints ✓/✗ for each. When an invoice
+#                            FAILS (no file, or < MIN_MATCH) it PAUSES and lets you fix it in
+#                            the terminal (type the qty per item); once fixed it continues to
+#                            the next. Anything you SKIP is written to the failure log so you
+#                            can come back to it. Needs the files (S3) + Document AI live.
+#
+#   3. manual_fix()       -- fix a single logged/failed invoice later, from the terminal.
+#
+# invoice_qty is durable because every fix is saved as LINE MAPPINGS (never a raw number),
+# so recompute keeps deriving it. NOT wired into patches.txt -- run each step deliberately.
+
+MIN_MATCH = 0.70
+TOL = 1.0
+# TESTING SCOPE: run on ONE project only. Set to None to backfill ALL projects.
+PROJECT = "GAUTAM_BUDDHA_NAGAR-PROJ-00074"   # Maconns Noida (set None for the full run)
+_COUNTED = ("Pending", "Approved")
+_FAIL_LOG = "/workspace/development/frappe-bench/extraction_failures.log"
+
+
+# =============================================================================
+# STEP 1 — deterministic backfill (no AI). Run first.
+# =============================================================================
+def execute():
+    completed = set(frappe.get_all("Projects", filters={"status": "Completed"}, pluck="name"))
+    filters = {"status": ["!=", "Merged"]}
+    if PROJECT:
+        filters["project"] = ["=", PROJECT]
+    pos = frappe.get_all(
+        "Procurement Orders",
+        filters=filters,
+        fields=["name", "project", "total_amount"],
+    )
+    print(f"[backfill_invoice_qty] scope: {PROJECT or 'ALL projects'}")
+    counts = {"EXACT": 0, "COMPLETED": 0, "DIRECT": 0, "MISMATCH": 0, "ZERO": 0}
+    for i, po in enumerate(pos):
+        bucket = _po_bucket(po.name, po.project, float(po.total_amount or 0), completed)
+        _write_bucket(po.name, bucket)
+        counts[bucket] += 1
+        if i % 200 == 0:
+            frappe.db.commit()   # batch-commit: thousands of POs, avoid one giant txn
+    frappe.db.commit()
+    print(f"[backfill_invoice_qty] backfill done — {len(pos)} POs: {counts}")
+    print(f"    {counts['MISMATCH']} MISMATCH POs left at ordered qty — run run_extraction() next.")
+
+
+def _po_bucket(po_name, project, po_total, completed):
+    """Classify one PO -> EXACT / COMPLETED / DIRECT / MISMATCH / ZERO (READ-ONLY)."""
+    active = _active_invoices(po_name)
+    if active and all(_has_lines(i.name) for i in active):
+        return "EXACT"
+    if project in completed:
+        return "COMPLETED"
+    if not active:
+        return "ZERO"
+    net = sum(float(i.invoice_amount or 0) for i in active)
+    all_approved = all(i.status == "Approved" for i in active)
+    return "DIRECT" if (all_approved and net >= po_total - TOL) else "MISMATCH"
+
+
+def _write_bucket(po_name, bucket):
+    """Write invoice_qty on the PO's item rows for its classified bucket.
+
+    MISMATCH is deliberately NOT written here -- an under-invoiced PO is left untouched so
+    the extraction path (run_extraction) can read its files, write the line mappings, and
+    recompute the EXACT invoice_qty. The backfill only sets the CERTAIN cases.
+    """
+    if bucket == "MISMATCH":
+        return                                        # left for the extraction path
+    items = frappe.get_all(
+        "Purchase Order Item",
+        filters={"parent": po_name, "parenttype": "Procurement Orders"},
+        fields=["name", "quantity"],
+    )
+    if bucket == "EXACT":
+        summed = _line_sums(po_name)
+        value_of = lambda it: summed.get(it.name, 0)
+    elif bucket == "ZERO":
+        value_of = lambda it: 0
+    else:  # COMPLETED / DIRECT -> ordered qty
+        value_of = lambda it: float(it.quantity or 0)
+    for it in items:
+        frappe.db.set_value("Purchase Order Item", it.name, "invoice_qty",
+                            value_of(it), update_modified=False)
+
+
+def _active_invoices(po_name):
+    invs = frappe.get_all(
+        "Vendor Invoices",
+        filters={"document_type": "Procurement Orders", "document_name": po_name,
+                 "status": ["in", _COUNTED]},
+        fields=["name", "invoice_no", "status", "invoice_amount", "invoice_attachment"],
+    )
+    return [i for i in invs if float(i.invoice_amount or 0) >= 0]   # credit notes (negative) skipped
+
+
+def _has_lines(invoice):
+    return bool(frappe.db.count(
+        "Vendor Invoice Line", {"parent": invoice, "parenttype": "Vendor Invoices"}))
+
+
+def _line_sums(po_name):
+    rows = frappe.db.sql(
+        """
+        SELECT vil.po_item_row              AS row_name,
+               SUM(COALESCE(vil.quantity, 0)) AS qty
+        FROM "tabVendor Invoice Line" vil
+        JOIN "tabVendor Invoices" vi ON vil.parent = vi.name
+        WHERE vil.parenttype = 'Vendor Invoices'
+          AND vil.match_status = 'Matched'
+          AND vil.po_item_row IS NOT NULL AND vil.po_item_row != ''
+          AND vi.document_type = 'Procurement Orders'
+          AND vi.document_name = %(po)s
+          AND vi.status IN %(statuses)s
+          AND COALESCE(vi.invoice_amount, 0) >= 0
+        GROUP BY vil.po_item_row
+        """,
+        {"po": po_name, "statuses": _COUNTED},
+        as_dict=True,
+    )
+    return {r.row_name: float(r.qty or 0) for r in rows}
+
+
+# =============================================================================
+# STEP 2 — interactive extraction of the MISMATCH POs (run AFTER execute()).
+# One invoice at a time: ✓ auto-map on success, ✗ pause + fix on failure, skip -> log.
+# =============================================================================
+def run_extraction(project=None):
+    from nirmaan_stack.api.invoices._item_billing_sync import recompute_po_invoice_qty
+
+    project = project or PROJECT   # default to the test scope; pass a project to override
+    mismatched = _find_mismatched(project)
+    print(f"[extraction] {len(mismatched)} MISMATCH POs to read"
+          f"{f' in {project}' if project else ''}. Failures log -> {_FAIL_LOG}\n")
+
+    exact, incomplete = 0, 0
+    for idx, po in enumerate(mismatched, 1):
+        po_doc = frappe.get_doc("Procurement Orders", po)
+        active = _active_invoices(po)
+        print(f"\n[{idx}/{len(mismatched)}] {po}  ({len(active)} invoices)")
+
+        any_skipped = False
+        for inv in active:
+            if _has_lines(inv.name):                 # already mapped (earlier run) -> leave it
+                print(f"    · {inv.invoice_no or inv.name}: already mapped")
+                continue
+            result = _extract_one(inv, po, po_doc)    # ("auto", res) | ("manual", rows) | None
+            if result is None:
+                any_skipped = True
+                _log_failure(po, inv)
+                continue
+            kind, payload = result
+            vi = frappe.get_doc("Vendor Invoices", inv.name)
+            if kind == "auto":
+                _apply_autofill(vi, payload, po_doc)  # line_mappings + all autofill_* fields
+            else:                                     # manual fix -> line_mappings only
+                vi.set("line_mappings", payload)
+            vi.save(ignore_permissions=True)
+
+        recompute_po_invoice_qty(po)                  # EXACT if ALL mapped, else stays ordered qty
+        frappe.db.commit()
+        if any_skipped:
+            incomplete += 1
+            print(f"  → {po}: INCOMPLETE — stays ordered qty (skipped invoices logged)")
+        else:
+            exact += 1
+            print(f"  → {po}: EXACT ✓")
+
+    print(f"\n[extraction] EXACT {exact}  |  incomplete {incomplete}  of {len(mismatched)}")
+    if incomplete:
+        print(f"  skipped/failed invoices are in {_FAIL_LOG} — fix each with manual_fix(...)")
+
+
+def _extract_one(inv, po, po_doc):
+    """Read + map ONE invoice. Returns:
+        ("auto", res)    -- Gemini succeeded -> line_mappings + all autofill_* fields from res
+        ("manual", rows) -- you hand-fixed it -> line_mappings only
+        None             -- you skipped it
+    Prints ✓ on success, ✗ + reason on failure (then prompts to fix or skip)."""
+    from nirmaan_stack.api.invoice_autofill import extract_invoice_fields
+
+    fu = (frappe.db.get_value("Nirmaan Attachments", inv.invoice_attachment, "attachment")
+          if inv.invoice_attachment else None)
+    reason, line_match = None, None
+    if not fu:
+        reason = "no file"
+    else:
+        try:
+            res = extract_invoice_fields(fu, docname=po)          # reads file + Gemini
+            lm = (res or {}).get("line_match") or {}
+            s = lm.get("summary", {})
+            m, u = s.get("matched", 0), s.get("unmatched", 0)
+            success = m / max(1, m + u)
+            if success >= MIN_MATCH:
+                print(f"    ✓ {inv.invoice_no or inv.name}: {m} matched ({success:.0%})")
+                return ("auto", res)
+            reason = f"match {success:.0%} < {MIN_MATCH:.0%}"
+            line_match = lm       # keep the read lines so the fix can DROPDOWN-map the unmatched ones
+        except Exception as e:
+            reason = str(e)[:50]
+
+    print(f"    ✗ {inv.invoice_no or inv.name}: FAILED ({reason})")
+    rows = _prompt_fix(inv, po_doc, line_match)
+    return ("manual", rows) if rows is not None else None
+
+
+def _apply_autofill(vi, res, po_doc):
+    """MINIMAL change on the invoice: write line_mappings (the data recompute reads) and mark
+    autofill_used = 1. Nothing else -- no audit-JSON snapshots. recompute (called right after
+    the save, in run_extraction) then derives invoice_qty from these mappings."""
+    import json
+    from nirmaan_stack.api.delivery_notes.update_invoice_data import build_line_mapping_rows
+
+    lm = (res or {}).get("line_match") or {}
+    vi.set("line_mappings", build_line_mapping_rows(json.dumps(lm), po_doc))
+    vi.autofill_used = 1
+
+
+def _prompt_fix(inv, po_doc, line_match=None):
+    """Terminal fix for a failed invoice. Shows the PO items as a NUMBERED DROPDOWN, then:
+      - Gemini read lines (match-failure): keeps the matched lines and asks you to pick the
+        item # for each UNMATCHED line (its qty comes from the read);
+      - no lines (file unreadable): you type the qty per item.
+    Returns line-mapping rows, or None to skip (and log)."""
+    import json
+    from nirmaan_stack.api.delivery_notes.update_invoice_data import build_line_mapping_rows
+
+    ans = input(f"      fix invoice {inv.invoice_no or inv.name} now? "
+                f"[y = map, n = skip & log]: ").strip().lower()
+    if ans != "y":
+        return None
+
+    items = po_doc.items
+    print("      PO items — pick by number:")
+    for i, it in enumerate(items, 1):
+        print(f"        [{i}] {it.item_name}  (ordered {it.quantity})")
+
+    mappings = (line_match or {}).get("mappings") or []
+    if mappings:
+        # match-failure: keep matched lines; DROPDOWN-map each UNMATCHED line to a PO item #.
+        for mrow in mappings:
+            if mrow.get("status") == "matched" and mrow.get("po_row") is not None:
+                continue                                  # already matched -> keep
+            desc = (mrow.get("description") or "")[:40]
+            sel = input(f"        map '{desc}' qty {mrow.get('quantity')} -> item # [0=skip]: ").strip()
+            if sel.isdigit() and 1 <= int(sel) <= len(items):
+                mrow["status"] = "matched"
+                mrow["source"] = "manual"
+                mrow["po_row"] = int(sel) - 1             # index into po_doc.items
+        rows = build_line_mapping_rows(json.dumps(line_match), po_doc)
+    else:
+        # file-failure: no lines -> type the qty per item (same numbering).
+        rows = []
+        for i, it in enumerate(items, 1):
+            val = input(f"        [{i}] {it.item_name} qty [blank=none]: ").strip()
+            if not val:
+                continue
+            try:
+                q = float(val)
+            except ValueError:
+                print("        ?? not a number — item skipped")
+                continue
+            rows.append({
+                "description": it.item_name, "quantity": q, "match_status": "Matched",
+                "match_source": "Manual", "po_item_id": it.item_id,
+                "po_item_row": it.name, "po_item_name": it.item_name,
+            })
+    matched = sum(1 for r in rows if r.get("match_status") == "Matched")
+    print(f"        → {matched} line(s) mapped")
+    return rows
+
+
+def _find_mismatched(project):
+    completed = set(frappe.get_all("Projects", filters={"status": "Completed"}, pluck="name"))
+    filt = {"status": ["!=", "Merged"]}
+    if project:
+        filt["project"] = project
+    pos = frappe.get_all("Procurement Orders", filters=filt,
+                         fields=["name", "project", "total_amount"])
+    return [p.name for p in pos
+            if _po_bucket(p.name, p.project, float(p.total_amount or 0), completed) == "MISMATCH"]
+
+
+def _log_failure(po, inv):
+    """Note a skipped/failed PO+invoice so it can be fixed later (tab-separated)."""
+    line = f"{frappe.utils.now()}\t{po}\t{inv.name}\t{inv.invoice_no}\t{inv.invoice_amount}\n"
+    with open(_FAIL_LOG, "a") as fh:
+        fh.write(line)
+
+
+# =============================================================================
+# STEP 3 — fix a single logged/failed invoice from the terminal (no UI).
+# =============================================================================
+def manual_fix(invoice_name, qty_by_item):
+    """Hand-map ONE failed invoice (from the log) in bench console:
+        manual_fix("<vendor-invoice-name>", {"LUGS 1.5 SQMM": 3000, "LUGS 2.5 SQMM": 4800})
+    Writes LINE MAPPINGS (not a raw number) -> recompute -> EXACT once all the PO's invoices
+    are mapped. Item names must match the PO exactly."""
+    from nirmaan_stack.api.invoices._item_billing_sync import recompute_po_invoice_qty
+
+    vi = frappe.get_doc("Vendor Invoices", invoice_name)
+    po_doc = frappe.get_doc("Procurement Orders", vi.document_name)
+    by_name = {it.item_name: it for it in po_doc.items}
+
+    rows, unknown = [], []
+    for item_name, qty in qty_by_item.items():
+        it = by_name.get(item_name)
+        if not it:
+            unknown.append(item_name); continue
+        rows.append({
+            "description": item_name, "quantity": float(qty), "match_status": "Matched",
+            "match_source": "Manual", "po_item_id": it.item_id,
+            "po_item_row": it.name, "po_item_name": it.item_name,
+        })
+    if unknown:
+        print(f"  !! item names not on {vi.document_name}: {unknown} — nothing written")
+        return
+
+    vi.set("line_mappings", rows)
+    vi.save(ignore_permissions=True)
+    recompute_po_invoice_qty(vi.document_name)
+    frappe.db.commit()
+    print(f"  ✓ mapped {invoice_name}; recomputed {vi.document_name} "
+          f"(EXACT once all its invoices are mapped)")

--- a/nirmaan_stack/patches/v3_0/backfill_invoice_qty.py
+++ b/nirmaan_stack/patches/v3_0/backfill_invoice_qty.py
@@ -22,7 +22,28 @@ TOL = 1.0
 # TESTING SCOPE: run on ONE project only. Set to None to backfill ALL projects.
 PROJECT = "GAUTAM_BUDDHA_NAGAR-PROJ-00074"   # Maconns Noida (set None for the full run)
 _COUNTED = ("Pending", "Approved")
-_FAIL_LOG = "/workspace/development/frappe-bench/extraction_failures.log"
+
+import os
+_BENCH = frappe.utils.get_bench_path()          # the bench dir on dev AND prod (portable)
+_FAIL_LOG = os.path.join(_BENCH, "extraction_failures.log")
+_CACHE = os.path.join(_BENCH, "extraction_cache.json")
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _save_no_modified(vi):
+    """Save a Vendor Invoice WITHOUT bumping modified/modified_by -- this is a backfill, not a
+    user edit. doc.save() always sets modified, so we capture the original first and restore it
+    right after (the update_modified=False equivalent for a doc that has a child table)."""
+    orig_m, orig_mb = vi.get("modified"), vi.get("modified_by")
+    vi.save(ignore_permissions=True)
+    frappe.db.set_value("Vendor Invoices", vi.name,
+                        {"modified": orig_m, "modified_by": orig_mb}, update_modified=False)
 
 
 # =============================================================================
@@ -162,7 +183,7 @@ def run_extraction(project=None):
                 _apply_autofill(vi, payload, po_doc)  # line_mappings + all autofill_* fields
             else:                                     # manual fix -> line_mappings only
                 vi.set("line_mappings", payload)
-            vi.save(ignore_permissions=True)
+            _save_no_modified(vi)
 
         recompute_po_invoice_qty(po)                  # EXACT if ALL mapped, else stays ordered qty
         frappe.db.commit()
@@ -212,15 +233,26 @@ def _extract_one(inv, po, po_doc):
 
 
 def _apply_autofill(vi, res, po_doc):
-    """MINIMAL change on the invoice: write line_mappings (the data recompute reads) and mark
-    autofill_used = 1. Nothing else -- no audit-JSON snapshots. recompute (called right after
-    the save, in run_extraction) then derives invoice_qty from these mappings."""
+    """Populate line_mappings AND every autofill_* field from the extract response, so the
+    invoice is identical to a UI-autofilled one (recon UI + auto-approve gates + cacheable)."""
     import json
     from nirmaan_stack.api.delivery_notes.update_invoice_data import build_line_mapping_rows
 
     lm = (res or {}).get("line_match") or {}
+    _j = lambda v: json.dumps(v) if v else None
+
     vi.set("line_mappings", build_line_mapping_rows(json.dumps(lm), po_doc))
     vi.autofill_used = 1
+    vi.autofill_processor_id = res.get("processor_id")
+    vi.autofill_extracted_invoice_no = res.get("invoice_no")
+    vi.autofill_extracted_invoice_date = res.get("invoice_date")
+    vi.autofill_extracted_amount = res.get("amount")
+    vi.autofill_extracted_supplier_gstin = res.get("supplier_gstin")
+    vi.autofill_extracted_receiver_gstin = res.get("receiver_gstin")
+    vi.autofill_confidence_json = _j(res.get("confidence"))
+    vi.autofill_all_entities_json = _j(res.get("entities"))
+    vi.autofill_line_items_json = _j(res.get("line_items"))
+    vi.autofill_line_match_json = _j(lm)
 
 
 def _prompt_fix(inv, po_doc, line_match=None):
@@ -324,8 +356,156 @@ def manual_fix(invoice_name, qty_by_item):
         return
 
     vi.set("line_mappings", rows)
-    vi.save(ignore_permissions=True)
+    _save_no_modified(vi)
     recompute_po_invoice_qty(vi.document_name)
     frappe.db.commit()
     print(f"  ✓ mapped {invoice_name}; recomputed {vi.document_name} "
           f"(EXACT once all its invoices are mapped)")
+
+
+# =============================================================================
+# CACHE — extract once on TEST, replay on PROD (no Gemini for cached invoices).
+# =============================================================================
+_AF_FIELDS = (
+    "autofill_used", "autofill_processor_id", "autofill_extracted_invoice_no",
+    "autofill_extracted_invoice_date", "autofill_extracted_amount",
+    "autofill_extracted_supplier_gstin", "autofill_extracted_receiver_gstin",
+    "autofill_confidence_json", "autofill_all_entities_json",
+    "autofill_line_items_json", "autofill_line_match_json",
+)
+
+
+def export_cache(project=None):
+    """TEST: write every MAPPED invoice's full autofill data -> extraction_cache.json.
+    Opens the file with "w" -> CLEARS any existing content and regenerates it FRESH from
+    the current DB each run (so it always mirrors the latest extraction + manual fixes)."""
+    import json
+    project = project or PROJECT
+
+    po_filter = {"status": ["!=", "Merged"]}
+    if project:
+        po_filter["project"] = ["=", project]
+    pos = set(frappe.get_all("Procurement Orders", filters=po_filter, pluck="name"))
+
+    invs = frappe.get_all(
+        "Vendor Invoices", filters={"document_type": "Procurement Orders"},
+        fields=["name", "document_name", "invoice_no", "invoice_attachment", *_AF_FIELDS])
+
+    entries = []
+    for vi in invs:
+        if vi.document_name not in pos:
+            continue
+        lm = frappe.get_all(
+            "Vendor Invoice Line",
+            filters={"parent": vi.name, "parenttype": "Vendor Invoices"},
+            fields=["description", "quantity", "rate", "amount", "tax_rate",
+                    "match_status", "match_source", "match_score", "po_item_id", "po_item_name"])
+        if not lm:
+            continue                                    # only invoices that actually got mapped
+        entry = {"po": vi.document_name, "invoice_no": vi.invoice_no,
+                 "content_hash": _content_hash(vi.invoice_attachment), "line_mappings": lm}
+        for f in _AF_FIELDS:
+            entry[f] = vi.get(f)
+        entries.append(entry)
+
+    with open(_CACHE, "w") as fh:                       # "w" = truncate (clear) + write fresh
+        json.dump(entries, fh, indent=2, default=str)
+    print(f"[export_cache] wrote {len(entries)} invoices -> {_CACHE} (fresh, {project or 'ALL'})")
+
+
+def import_cache(project=None, apply=False):
+    """PROD: replay the cache onto each mismatched PO's invoices.
+        HIT  (po + invoice_no in cache) -> set all autofill fields + line_mappings, NO Gemini.
+        MISS (not cached)               -> non-interactive Gemini read + apply (else logged).
+    Then recompute per PO. apply=False = dry preview (nothing written)."""
+    import json
+    from nirmaan_stack.api.invoices._item_billing_sync import recompute_po_invoice_qty
+
+    project = project or PROJECT
+    try:
+        with open(_CACHE) as fh:
+            cache = json.load(fh)
+    except FileNotFoundError:
+        print(f"[import_cache] no cache file at {_CACHE}"); return
+    by_key = {(e["po"], e["invoice_no"]): e for e in cache}
+    print(f"[import_cache] {len(cache)} cached invoices. scope={project or 'ALL'}  apply={apply}\n")
+
+    mismatched = _find_mismatched(project)
+    hit = miss = failed = 0
+    for po in mismatched:
+        po_doc = frappe.get_doc("Procurement Orders", po)
+        for inv in _active_invoices(po):
+            if _has_lines(inv.name):
+                continue
+            entry = by_key.get((po, inv.invoice_no))
+            if entry:
+                hit += 1
+                print(f"  HIT  {po} / {inv.invoice_no}")
+                if apply:
+                    _apply_cache_entry(inv.name, entry, po_doc)
+            else:
+                miss += 1
+                print(f"  MISS {po} / {inv.invoice_no} -> Gemini")
+                if apply and not _gemini_apply(inv, po_doc):
+                    failed += 1
+                    _log_failure(po, inv)
+        if apply:
+            recompute_po_invoice_qty(po)
+            frappe.db.commit()
+
+    tag = "applied" if apply else "DRY PREVIEW — nothing written"
+    print(f"\n[import_cache] HIT {hit}  |  MISS→Gemini {miss}  |  failed {failed}  ({tag})")
+
+
+def _apply_cache_entry(invoice_name, entry, po_doc):
+    """Write a cached extract onto an invoice: all autofill fields + re-resolved line_mappings."""
+    vi = frappe.get_doc("Vendor Invoices", invoice_name)
+    for f in _AF_FIELDS:
+        setattr(vi, f, entry.get(f))
+    vi.autofill_used = 1
+    vi.set("line_mappings", [_resolve_row(m, po_doc) for m in entry.get("line_mappings", [])])
+    _save_no_modified(vi)
+
+
+def _resolve_row(m, po_doc):
+    """Re-resolve a cached mapping's po_item_row against THIS PO's items (by name, then id)."""
+    it = (next((x for x in po_doc.items if x.item_name == m.get("po_item_name")), None)
+          or next((x for x in po_doc.items if x.item_id == m.get("po_item_id")), None))
+    row = {
+        "description": m.get("description"), "quantity": _num(m.get("quantity")),
+        "rate": _num(m.get("rate")), "amount": _num(m.get("amount")),
+        "tax_rate": _num(m.get("tax_rate")),
+        "match_status": m.get("match_status") or "Unmatched",
+        "match_source": m.get("match_source") or "", "match_score": _num(m.get("match_score")),
+    }
+    if it and m.get("match_status") == "Matched":
+        row.update({"po_item_id": it.item_id, "po_item_row": it.name, "po_item_name": it.item_name})
+    return row
+
+
+def _content_hash(attachment_id):
+    """Lightweight file identity for the cache (the attachment's file_url)."""
+    return (frappe.db.get_value("Nirmaan Attachments", attachment_id, "attachment")
+            if attachment_id else None)
+
+
+def _gemini_apply(inv, po_doc):
+    """Cache MISS fallback: a non-interactive Gemini read + apply. Returns True on success."""
+    from nirmaan_stack.api.invoice_autofill import extract_invoice_fields
+    fu = (frappe.db.get_value("Nirmaan Attachments", inv.invoice_attachment, "attachment")
+          if inv.invoice_attachment else None)
+    if not fu:
+        return False
+    try:
+        res = extract_invoice_fields(fu, docname=po_doc.name)
+        lm = (res or {}).get("line_match") or {}
+        s = lm.get("summary", {})
+        m, u = s.get("matched", 0), s.get("unmatched", 0)
+        if m / max(1, m + u) < MIN_MATCH:
+            return False
+        vi = frappe.get_doc("Vendor Invoices", inv.name)
+        _apply_autofill(vi, res, po_doc)
+        _save_no_modified(vi)
+        return True
+    except Exception:
+        return False

--- a/nirmaan_stack/services/extraction/gemini.py
+++ b/nirmaan_stack/services/extraction/gemini.py
@@ -79,6 +79,9 @@ _INVOICE_PROMPT = (
     "Do NOT include header rows, sub-totals, tax rows, or charge rows (freight/round-off) "
     "as line_items — those belong in the scalar fields above. If the invoice has no "
     "itemised table, return an empty array.\n"
+    "- is_credit_note = true if this document is a CREDIT NOTE or credit memo (it says "
+    "'Credit Note' / 'Credit Memo', or otherwise reverses / refunds a prior invoice); "
+    "false for a normal tax invoice.\n"
     "- Dates in YYYY-MM-DD format.\n"
     "- If a field is not clearly present, return JSON null. Do NOT guess and do "
     'NOT output the string "null".'
@@ -232,6 +235,8 @@ class GeminiExtractor:
             schema = _schema(fields)
             if is_invoice:
                 schema["properties"]["line_items"] = _line_items_schema()
+                # Document-type classification: did the file itself declare it a credit note?
+                schema["properties"]["is_credit_note"] = {"type": "boolean", "nullable": True}
 
         config = types.GenerateContentConfig(
             response_mime_type="application/json",
@@ -253,7 +258,15 @@ class GeminiExtractor:
 
         data = self._generate(client, model, [part, prompt], config)
         line_items = self._to_line_items(data.get("line_items")) if is_invoice else []
-        return "", self._to_entities(data, fields), line_items
+        entities = self._to_entities(data, fields)
+        # Surface the credit-note classification as a flat entity (only when the model
+        # actually flagged it true), so the (text, entities) contract stays flat.
+        if is_invoice and data.get("is_credit_note") is True:
+            entities.append(
+                {"type": "is_credit_note", "mention_text": "1",
+                 "normalized_text": "1", "confidence": 1.0}
+            )
+        return "", entities, line_items
 
     def _build_client(self, settings):
         mode = "api_key" if "api" in (settings.get("auth_mode") or "").lower() else "vertex"

--- a/nirmaan_stack/services/extraction/gemini.py
+++ b/nirmaan_stack/services/extraction/gemini.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 
 import frappe
 
-from .base import INVOICE, Entity, LineItem
+from .base import CUSTOMER_PO, INVOICE, Entity, LineItem
 from .files import MIME_TYPES, get_gemini_api_key
 from .validation import is_absent
 
@@ -224,15 +224,14 @@ class GeminiExtractor:
             fields = _CUSTOMER_PO_FIELDS + ("payment_terms",)
             prompt = _CUSTOMER_PO_PROMPT
             schema = _customer_po_schema()
+            is_invoice = False
         else:
             is_invoice = doc_kind == INVOICE
             fields = _INVOICE_FIELDS if is_invoice else _PAYMENT_FIELDS
             prompt = _INVOICE_PROMPT if is_invoice else _PAYMENT_PROMPT
             schema = _schema(fields)
-
-        schema = _schema(fields)
-        if is_invoice:
-            schema["properties"]["line_items"] = _line_items_schema()
+            if is_invoice:
+                schema["properties"]["line_items"] = _line_items_schema()
 
         config = types.GenerateContentConfig(
             response_mime_type="application/json",


### PR DESCRIPTION
Adds a derived **`Purchase Order Item.invoice_qty`** ("how much of each PO line has been
invoiced"), kept correct by a self-classifying recompute, plus tooling to backfill it
across all existing POs.

- **invoice_qty** — self-classifying recompute: EXACT (from invoice line mappings) /
  ordered-qty (fully invoiced) / 0. Re-derived on every invoice event, so it never drifts.
- **Credit notes** — new `Vendor Invoices.is_credit_note` checkbox + Gemini auto-detection;
  credit notes are excluded from invoice_qty (with return-note amount/qty sign handling).
- **Backfill** — `patches/v3_0/backfill_invoice_qty.py` (manual, NOT wired into patches.txt):
  a deterministic pass (ordered qty / 0) + Gemini extraction for under-invoiced POs, with an
  interactive terminal fix (item dropdown / qty entry) for any failures.
- **Test → prod cache** — `export_cache` / `import_cache` replay extractions on prod with no
  Gemini for cache hits; see `RUNBOOK_invoice_qty_backfill.md` for the deploy steps.

**Safety:** invoice files are read-only; `modified` is never bumped (`update_modified=False`);
idempotent; schema adds only 2 fields (`invoice_qty`, `is_credit_note`).
