### PR TITLE
Expense -fixes

### DIFF
--- a/.claude/context/domain/expenses.md
+++ b/.claude/context/domain/expenses.md
@@ -1,0 +1,151 @@
+# Expenses Domain — Approval Workflow & Unified Module
+
+As-built reference for the Expense module (Project + Non-Project expenses). Domain
+language lives in `CONTEXT.md` ("Expense workflow & settlement"); the type-normalization
+decision is `docs/adr/0009-project-expense-type-normalization.md`. This doc records
+**what was added, improved, and changed** across the feature.
+
+## Overview
+
+An **Expense** is a cost recorded outside the PO / Service Request flow. Two kinds:
+- **Project Expense** — attributed to a Project (labelled "Misc Project Expense" in the UI).
+- **Non-Project Expense** — company-wide, not tied to a Project.
+
+Both share one approval lifecycle and are entered/managed together in a single unified
+**Expense** area (`/expense`).
+
+## Domain rules (source of truth: `CONTEXT.md`)
+
+- **Status lifecycle:** `Requested → Approved → Paid` (one-way). *Approved* = sanctioned
+  but not yet paid (staging); *Paid* = cash actually went out (final).
+- **Settled spend = Paid only.** Only `Paid` expenses count in **every** financial rollup.
+  `Requested`/`Approved` are commitments, excluded from those numbers.
+- **Auto-approval:** a positive amount `< ₹5,000` is created directly at `Approved`
+  (skips `Requested`); a refund (non-positive) or `≥ ₹5,000` takes the full path.
+- **Project Expenses use only project-flagged (`project=1`) Expense Types** (ADR 0009).
+
+---
+
+## What was ADDED
+
+### Status workflow (both doctypes)
+- `status` Select field (`Requested/Approved/Paid`, default `Requested`) on the
+  `Project Expenses` and `Non Project Expenses` doctypes.
+- **Auto-approval** in each doctype's `validate` (create-time, `is_new()`-guarded):
+  `project_expenses.py`, `non_project_expenses.py` — `0 < amount < 5000` → `Approved`.
+  (Owner preference: this small create-time derivation lives in the doctype `.py`
+  `validate`, not a controller+hooks.)
+- **Backfill patches:** `v3_0.backfill_project_expenses_status`,
+  `v3_0.backfill_non_project_expenses_status #v2` — classify legacy rows
+  (payment attachment ⇒ `Paid`, else `Approved`).
+
+### Unified Expense module (frontend)
+- New `/expense` route with URL-driven tabs: `/expense/project` (Misc Project Expense)
+  and `/expense/non-project` (Non-Project Expense) — `pages/Expenses/ExpenseLayout.tsx`
+  (pill tab strip + `<Outlet/>`). Index redirects to `/expense/project`; legacy
+  `/project-expenses` and `/non-project` redirect in. `components/helpers/routesConfig.tsx`.
+- Single **Expense** sidebar entry (union of both role gates) — `NewSidebar.tsx`.
+- Per-tab right-action button ("Add New Project Expense" / "Add New Expense") —
+  `renderRightActionButton.tsx`.
+
+### Non-Project invoice/payment split
+- Creator records **invoice** details; Accountant records **payment** and marks `Paid`.
+- Split **Inv. Attach** / **Pay. Attach** columns; clickable blue Invoice Ref on Paid/All;
+  two-stage **Mark as Paid** dialog with receipt AI auto-fill
+  (`nirmaan_stack.api.payment_autofill.extract_payment_fields`).
+
+---
+
+## What was IMPROVED / CHANGED
+
+### Paid-only financial rollups (only settled spend counts)
+Every cross-surface expense calculation now filters `status = "Paid"`:
+
+| Surface | Where |
+|---|---|
+| CEO-Hold **cashflow gap** | `integrations/controllers/project_cashflow_hold_update.py` (`_compute_cashflow_gap`) |
+| **30-day Payment dashboard** (Project + Non-Project) | `api/payments/get_project_payment_summary.py` |
+| **Outflow Report(Project)** | `pages/reports/hooks/useOutflowReportData.ts` |
+| **Project-detail Financials** total + Projects-list aggregation | `pages/projects/data/root/useProjectRootApi.ts` (both expense hooks) |
+| **Project Reports** per-project outflow | `pages/reports/hooks/useProjectReportCalculations.ts` |
+| **Outflow Report(Non-Project)** | `NonProjectExpensesPage` report mode (`DisableAction`) forces `Paid` + hides the Status column |
+
+List-page **summary cards stay tab-scoped** (they reflect the active status tab) — by design.
+
+### CEO-Hold trigger correctness
+- `on_project_expense` now only re-evaluates the hold when a row **enters or leaves `Paid`**
+  (mirrors `on_project_payment`); adding/editing a `Requested`/`Approved` expense no longer
+  fires it.
+- The cashflow handler moved from `on_trash` → **`after_delete`** in `hooks.py` (Frappe runs
+  `on_trash` *before* the row is deleted, so the gap query would still count the row);
+  `after_delete` runs after the delete, so removing a `Paid` expense correctly lowers the
+  gap / can release a hold. `generate_versions` stays on `on_trash`.
+
+### PO adjustment
+- The ad-hoc adjustment expense is created directly as **`Paid`** (money has already moved)
+  — `api/po_adjustments/adjustment_logic.py`.
+
+### Data normalization (ADR 0009)
+- Patch `v3_0.normalize_project_expense_types`: repoints Project Expenses using 6
+  non-project-flagged types (Printing & Stationery, Staff Welfare, Hotel, Postage & Courier,
+  Pooja, Travel (Flight)) → **Other Project Related Charges**. Type-only raw `UPDATE`,
+  `modified` preserved, idempotent, Non-Project untouched. Fixes the Outflow(Project) facet
+  so that report reconciles.
+
+### Embedded / read-only views
+- **Project-detail "Misc. Project Expenses" tab** (embedded `ProjectExpensesList`, `projectId`
+  present): `Paid`-only, status tabs hidden, Actions column hidden — a clean read-only view.
+  The standalone `/expense` module is unchanged.
+- **Approved tab:** Procurement Executive + HR Executive see **no Actions column** (both
+  lists) — on `Approved` their only capability was Mark-as-Paid, which they don't have.
+
+### UX polish
+- Pill tabs (active = primary/red, inactive = gray, with count badges); standalone lists grow
+  to natural height for a single page scroll (`autoHeight`); clearly-headed split attachment
+  columns.
+
+---
+
+## Role gating (frontend enforcement)
+
+| Action | Roles |
+|---|---|
+| Record Invoice / edit a `Requested` row | Admin, PMO, Accountant (+ Lead), Procurement, HR |
+| Approve (`Requested → Approved`) | Admin |
+| Mark as Paid (`Approved → Paid`) | Admin, Accountant (+ Lead) |
+| Edit a `Paid` row / Delete | Admin |
+
+Roles come from the `Nirmaan Users.role_profile` (via `useUserData`), not standard Frappe roles.
+
+---
+
+## Key files
+
+- Doctypes: `doctype/project_expenses/`, `doctype/non_project_expenses/` (`.json` + `.py`).
+- Backend calc/controllers: `integrations/controllers/project_cashflow_hold_update.py`,
+  `api/payments/get_project_payment_summary.py`, `api/po_adjustments/adjustment_logic.py`,
+  `hooks.py` (doc_events).
+- Frontend module: `pages/Expenses/ExpenseLayout.tsx`, `pages/ProjectExpenses/*`,
+  `pages/NonProjectExpenses/*` (list pages, `config/*Columns.tsx`, dialogs).
+- Reports/aggregation: `pages/reports/hooks/useOutflowReportData.ts`,
+  `useProjectReportCalculations.ts`, `pages/projects/data/root/useProjectRootApi.ts`,
+  `pages/ProjectPayments/PaymentSummaryCards.tsx`.
+
+## Patches (append-only)
+- `v3_0.backfill_project_expenses_status`
+- `v3_0.backfill_non_project_expenses_status #v2`
+- `v3_0.normalize_project_expense_types`
+
+## Cross-references
+- Glossary: `CONTEXT.md` → "Expense workflow & settlement".
+- Decision: `docs/adr/0009-project-expense-type-normalization.md`.
+
+## Deliberate design decisions (do NOT "fix")
+
+- **Approved-but-unpaid expenses do NOT pressure the CEO-Hold cashflow gap** — only `Paid`
+  expenses count as settled spend (confirmed, Option A). This is an **intentional asymmetry
+  with POs**: a *delivered* PO pressures the gap before payment (via a liability term =
+  delivered − paid), but an expense has no "delivered" milestone to anchor a liability on, so
+  it counts only once `Paid`. Trade-off accepted: a large pile of approved-but-unpaid
+  expenses can make a project look healthier than it is. **Do not add an expense-liability
+  term** unless deliberately reversing this decision.

--- a/.claude/context/domain/expenses.md
+++ b/.claude/context/domain/expenses.md
@@ -35,9 +35,12 @@ Both share one approval lifecycle and are entered/managed together in a single u
   `project_expenses.py`, `non_project_expenses.py` — `0 < amount < 5000` → `Approved`.
   (Owner preference: this small create-time derivation lives in the doctype `.py`
   `validate`, not a controller+hooks.)
-- **Backfill patches:** `v3_0.backfill_project_expenses_status`,
-  `v3_0.backfill_non_project_expenses_status #v2` — classify legacy rows
-  (payment attachment ⇒ `Paid`, else `Approved`).
+- **Backfill patches:** `v3_0.backfill_project_expenses_status` — classify legacy
+  rows (payment attachment ⇒ `Paid`, else `Approved`).
+  `v3_0.backfill_non_project_expenses_status #v3` — **simplified (attachment check
+  dropped, owner decision):** every non-`Paid` row (`Approved` / `Requested` /
+  unclassified) → `Paid`, i.e. all Non Project Expenses end up `Paid`. Local-only
+  patch edited in place + tag-bumped (`#v2`→`#v3`) to force a re-run, not a new file.
 
 ### Unified Expense module (frontend)
 - New `/expense` route with URL-driven tabs: `/expense/project` (Misc Project Expense)
@@ -108,14 +111,58 @@ List-page **summary cards stay tab-scoped** (they reflect the active status tab)
 
 ## Role gating (frontend enforcement)
 
-| Action | Roles |
-|---|---|
-| Record Invoice / edit a `Requested` row | Admin, PMO, Accountant (+ Lead), Procurement, HR |
-| Approve (`Requested → Approved`) | Admin |
-| Mark as Paid (`Approved → Paid`) | Admin, Accountant (+ Lead) |
-| Edit a `Paid` row / Delete | Admin |
+Roles come from `Nirmaan Users.role_profile` (via `useUserData`), NOT standard Frappe
+roles. **Accountant\*** below = both `Nirmaan Accountant Profile` and
+`Nirmaan Accountant Lead Profile` (Lead mirrors Accountant everywhere).
 
-Roles come from the `Nirmaan Users.role_profile` (via `useUserData`), not standard Frappe roles.
+### Module visibility & create
+- **Sees the Expense sidebar entry + can open `/expense`** (`NewSidebar.tsx`): Admin,
+  PMO, Accountant\*, Procurement, HR (+ the `Administrator` user). Everyone else
+  (Project Lead, PM, Estimates, Design, Sales, …) has **no access**.
+- **Create** ("Add New Expense" / "Add New Project Expense",
+  `renderRightActionButton.tsx`): **no extra role gate** — the same 5 groups can create,
+  for both Project and Non-Project.
+- **Default landing tab:** Accountant\* → `Approved`; everyone else → `Requested`.
+
+### Non-Project Expenses — actions per tab
+Primary actions render inline; secondary (Requested-only) sit in a `⋯` overflow menu.
+
+| Tab | Action (placement) | Admin | PMO | Accountant\* | Procurement | HR |
+|---|---|:--:|:--:|:--:|:--:|:--:|
+| Requested | Approve (inline) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Requested | Delete (inline) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Requested | Record Invoice (⋯) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Requested | Edit (⋯) | ✅ | ✅ | ❌ | ✅ | ✅ |
+| Approved | Mark as Paid (inline) | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Approved | Delete (inline) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Paid | Edit (inline) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Paid | Delete (inline) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| All | per row, by row status | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+**Actions column visibility:** Requested → all 5; Approved → Admin/PMO/Accountant\*
+(hidden for Procurement & HR); Paid → Admin only; All → Admin only.
+
+### Project Expenses — actions per tab
+Same profiles/gating, but **no Record Invoice** (no invoice/payment split), all actions
+inline (no `⋯` menu), and **Accountant\* CAN Edit a Requested row**.
+
+| Tab | Action | Admin | PMO | Accountant\* | Procurement | HR |
+|---|---|:--:|:--:|:--:|:--:|:--:|
+| Requested | Edit | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Requested | Approve | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Requested | Delete | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Approved | Mark as Paid | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Approved | Delete | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Paid | Edit / Delete | ✅ | ❌ | ❌ | ❌ | ❌ |
+| All | per row, by row status | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+Actions column visibility: same rule as Non-Project.
+
+### Known asymmetries (by design — do NOT "fix" without owner sign-off)
+- **Accountant\* Edit split:** can Edit a Requested **Project** expense but not a Requested
+  **Non-Project** one (their Non-Project Requested action is *Record Invoice* instead).
+- **Approve = Admin only; Delete = Admin only** in both tables.
+- Enforcement is **frontend-only** (button/column visibility) — no backend `validate` gate.
 
 ---
 
@@ -133,7 +180,7 @@ Roles come from the `Nirmaan Users.role_profile` (via `useUserData`), not standa
 
 ## Patches (append-only)
 - `v3_0.backfill_project_expenses_status`
-- `v3_0.backfill_non_project_expenses_status #v2`
+- `v3_0.backfill_non_project_expenses_status #v3` (was #v2 — now sweeps all legacy → Paid)
 - `v3_0.normalize_project_expense_types`
 
 ## Cross-references

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ All wizard endpoints live in `nirmaan_stack/api/boq/wizard/` (snake_case files; 
 | Projects | `.claude/context/domain/projects.md` |
 | Service Requests | `.claude/context/domain/service-requests.md` |
 | Internal Transfer Memos | `.claude/context/domain/internal-transfer-memos.md` |
+| Expenses (approval workflow, Paid-only, unified module) | `.claude/context/domain/expenses.md` |
 | Invoice Autofill | `.claude/context/domain/invoice-autofill.md` |
 | Vendor Hold | `frontend/.claude/context/domain/vendor-hold.md` |
 | Frontend domain context (full) | `frontend/.claude/context/_index.md` |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,19 @@ A shared glossary of domain terms. Definitions only — no implementation detail
 
 - **Excluded rows (manual)** — rows the reviewer explicitly removes from the data region *in addition to* the header row, expressed as a list of **skip definitions**. Each skip definition is either a **single row** (one row number) or a **row range** (a start row + an end row, inclusive). This is the primary tool for the two cases the single header row can't cover: extra header tiers *below* the header row (rate splits, area tiers), and a column-header that *repeats mid-sheet* or a stray banner between data rows. They exclude *by position* (not by classification), anywhere in the sheet.
 
+## Expense workflow & settlement
+
+- **Expense** — a cost recorded outside the Purchase Order / Service Request flow. Two kinds: a **Project Expense** (attributed to a specific Project; labelled "Misc Project Expense" in the UI) and a **Non-Project Expense** (company-wide, not tied to any Project). Both share the same three-stage approval lifecycle and are entered and managed together in one **Expense** area.
+
+- **Expense status** — the single field describing where an Expense sits in its lifecycle. It advances in one direction: *Requested* → *Approved* → *Paid*. An Expense holds exactly one at a time.
+  - **Requested** — entered, awaiting approval; not yet sanctioned and no cash has gone out.
+  - **Approved** — sanctioned to spend, but the money has **not** yet left. A staging state, not settled spend.
+  - **Paid** — the cash has actually gone out. The **final** state and the **only** one that counts as real spend.
+
+- **Settled spend (outflow)** — expense money that has actually left, i.e. an Expense at status *Paid*. **Only** *Paid* Expenses are included in any financial rollup — project outflow, the cashflow gap / CEO-Hold, project Financials totals, the Outflow reports, and the 30-day payment dashboard. *Requested* and *Approved* Expenses are commitments, not settled spend, and are excluded from every such number.
+
+- **Auto-approval (of a small Expense)** — a positive Expense below ₹5,000 is created directly at *Approved*, skipping *Requested*. It is an **approval shortcut only** — it makes no claim that the money has been paid, so an auto-approved Expense is still not counted as settled spend until it is separately marked *Paid*. A refund (non-positive amount) or an amount of ₹5,000 or more follows the full *Requested → Approved → Paid* path.
+
 ## Module residence
 
 - **Placement vs residence** — *Placement* is which folder a file lives in (already legislated in CLAUDE.md). *Residence* is which single module **owns** a concept — a business calculation, a data shape, a document's state, or write-safety. A concept with no residence scatters across call sites and drifts. The ten residence rules and the residence map live in [ADR-0010](docs/adr/0010-module-residence-rules.md).

--- a/docs/adr/0009-project-expense-type-normalization.md
+++ b/docs/adr/0009-project-expense-type-normalization.md
@@ -1,0 +1,13 @@
+# Project Expenses use only project-flagged Expense Types; legacy non-project types consolidated
+
+Project Expenses may only be categorised with Expense Types flagged `project = 1` — the create/edit dialogs already restrict the type dropdown accordingly. Six non-project-flagged types (Printing & Stationery, Staff Welfare Expenses, Hotel Expenses, Postage & Courier, Pooja Expenses, Travel Expenses (Flight)) had been recorded on ~82 legacy Project Expenses, which broke the Outflow(Project) report's Expense-Type facet — that facet lists only project-flagged types, so those rows could never be selected and the report couldn't reconcile. We normalised the data: patch `v3_0.normalize_project_expense_types` repoints those rows' `type` to the catch-all **Other Project Related Charges** (type-only raw `UPDATE`, `modified` preserved, idempotent, Non-Project Expenses untouched) — rather than broadening the facet to list every type.
+
+## Considered Options
+
+- **Broaden the Outflow facet to list all Expense Types (incl. non-project)** — rejected: it would surface non-project categories on a project report and leave the underlying mis-categorisation in the data.
+- **Map each legacy type to a nearest project-side equivalent** — rejected: most have no faithful project equivalent, and it would mint categories for a handful of legacy rows.
+
+## Consequences
+
+- The six-way category distinction is permanently merged into "Other Project Related Charges" on the affected rows (no snapshot). Acceptable: they were non-project categories misapplied to project expenses.
+- Residual entry path to watch: the PO-adjustment ad-hoc expense sets `type` from a user-chosen value; if that picker is not restricted to `project = 1`, it is the only remaining way a non-project type could reach a Project Expense.

--- a/frontend/src/components/helpers/renderRightActionButton.tsx
+++ b/frontend/src/components/helpers/renderRightActionButton.tsx
@@ -146,21 +146,21 @@ export const RenderRightActionButton = ({
         Add <span className="hidden md:flex pl-1">New Project Invoice</span>
       </Button>
     );
-  } else if (locationPath === "/non-project") {
+  } else if (locationPath === "/expense/non-project") {
     return (
       <Button onClick={toggleNewNonProjectExpenseDialog} className="sm:mr-4 mr-2">
         <CirclePlus className="w-5 h-5 pr-1" />
         Add <span className="hidden md:flex pl-1">New Expense</span>
       </Button>
     );
-  } else if (locationPath === "/project-expenses") {
+  } else if (locationPath === "/expense/project") {
+    // Same access as the Non-Project button: no role gate, shown to everyone
+    // with Expense-module access.
     return (
-      (role === "Nirmaan Admin Profile" || role === "Nirmaan PMO Executive Profile" || role === "Nirmaan Accountant Profile" || role === "Nirmaan Accountant Lead Profile") ? (
-        <Button onClick={toggleNewProjectExpenseDialog} className="sm:mr-4 mr-2">
-          <CirclePlus className="w-5 h-5 pr-1" />
-          Add <span className="hidden md:flex pl-1">New Project Expense</span>
-        </Button>
-      ) : null
+      <Button onClick={toggleNewProjectExpenseDialog} className="sm:mr-4 mr-2">
+        <CirclePlus className="w-5 h-5 pr-1" />
+        Add <span className="hidden md:flex pl-1">New Project Expense</span>
+      </Button>
     );
   } else {
     return (

--- a/frontend/src/components/helpers/routesConfig.tsx
+++ b/frontend/src/components/helpers/routesConfig.tsx
@@ -67,6 +67,7 @@ import AssetsPage from "@/pages/Assets/AssetsPage";
 import AllProjectInvocies from "@/pages/ProjectInvoices/AllProjectInvoices";
 import NonProjectExpensesPage from "@/pages/NonProjectExpenses/NonProjectExpensesPage";
 import AllProjectExpensesPage from "@/pages/ProjectExpenses/AllProjectExpenses";
+import ExpenseLayout from "@/pages/Expenses/ExpenseLayout";
 import AdminApprovedQuotationsTable from "@/pages/ApprovedQuotationsFlow/AdminApprovedQuotationsTable";
 import { MilestonesSummary } from "@/pages/Manpower-and-WorkMilestones/MilestonesSummary";
 import { MilestoneTab } from "@/pages/Manpower-and-WorkMilestones/MilestoneTab";
@@ -341,9 +342,20 @@ export const appRoutes: RouteObject[] = [
               { index: true, element: <EstimatedPriceOverview /> },
             ],
           },
+          // --- Expense: unified module (Misc Project + Non-Project) with URL tabs ---
+          {
+            path: "expense",
+            element: <ExpenseLayout />,
+            children: [
+              { index: true, element: <Navigate to="/expense/project" replace /> },
+              { path: "project", element: <AllProjectExpensesPage /> },
+              { path: "non-project", element: <NonProjectExpensesPage /> },
+            ],
+          },
+          // Legacy path -> redirect into the unified module (keeps old bookmarks working)
           {
             path: "project-expenses",
-            element: <AllProjectExpensesPage />
+            element: <Navigate to="/expense/project" replace />,
           },
           // ======================================================
           // --- START: COMMISSION REPORT SECTION ---
@@ -524,11 +536,10 @@ export const appRoutes: RouteObject[] = [
               { index: true, element: <AllProjectInvocies /> },
             ],
           },
+          // Legacy path -> redirect into the unified Expense module
           {
             path: "non-project",
-            children: [
-              { index: true, element: <NonProjectExpensesPage /> },
-            ],
+            element: <Navigate to="/expense/non-project" replace />,
           },
           // --- Project Payments ---
           {

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -520,7 +520,7 @@ export function NewSidebar() {
         },
       ]
       : []),
-    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile"].includes(role as string)
+    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
       ? [
         {
           key: '/project-expenses',

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -529,7 +529,7 @@ export function NewSidebar() {
         },
       ]
       : []),
-    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile"].includes(role as string)
+    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
       ? [
         {
           key: '/non-project',

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -23,7 +23,6 @@ import {
   ClipboardMinus,
   HandCoins,
   ReceiptText, FileUp,
-  Banknote,
   CreditCard,
   Dices,
   FileSpreadsheet,
@@ -523,18 +522,11 @@ export function NewSidebar() {
     ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
       ? [
         {
-          key: '/project-expenses',
+          // Unified Expense module: Misc Project + Non-Project tabs. Links to the
+          // default (Misc Project) tab; the tab strip handles switching.
+          key: '/expense/project',
           icon: Landmark,
-          label: 'Misc. Project Expenses',
-        },
-      ]
-      : []),
-    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
-      ? [
-        {
-          key: '/non-project',
-          icon: Banknote,
-          label: 'Non Project Expenses',
+          label: 'Expense',
         },
       ]
       : []),
@@ -698,8 +690,7 @@ export function NewSidebar() {
     "in-flow-payments",
     'invoice-reconciliation',
     'project-invoices',
-    'project-expenses',
-    'non-project',
+    'expense',
     'reports',
     'design-tracker',
     'critical-po-tracker',
@@ -741,8 +732,7 @@ export function NewSidebar() {
     "/in-flow-payments": ["in-flow-payments"],
     "/invoice-reconciliation": ["invoice-reconciliation"],
     "/project-invoices": ["project-invoices"],
-    "/project-expenses": ["project-expenses"],
-    "/non-project": ["non-project"],
+    "/expense/project": ["expense"],
     "/reports": ["reports"],
     '/design-tracker': ['design-tracker'],
     '/critical-po-tracker': ['critical-po-tracker'],
@@ -857,8 +847,7 @@ export function NewSidebar() {
                     "Material Plan Tracker",
                     "Cashflow Plan Tracker",
                     "Project Invoices",
-                    "Misc. Project Expenses",
-                    "Non Project Expenses",
+                    "Expense",
                     "Users",
                     "Assets",
                     "Vendors",

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -481,6 +481,17 @@ export function NewSidebar() {
         },
       ]
       : []),
+    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
+      ? [
+        {
+          // Unified Expense module: Misc Project + Non-Project tabs. Links to the
+          // default (Misc Project) tab; the tab strip handles switching.
+          key: '/expense/project',
+          icon: Landmark,
+          label: 'Expense',
+        },
+      ]
+      : []),
     ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan Project Lead Profile"].includes(role as string)
       ? [
         {
@@ -516,17 +527,6 @@ export function NewSidebar() {
           key: '/project-invoices',
           icon: FileUp,
           label: 'Project Invoices',
-        },
-      ]
-      : []),
-    ...(user_id == "Administrator" || ["Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile", "Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Procurement Executive Profile", "Nirmaan HR Executive Profile"].includes(role as string)
-      ? [
-        {
-          // Unified Expense module: Misc Project + Non-Project tabs. Links to the
-          // default (Misc Project) tab; the tab strip handles switching.
-          key: '/expense/project',
-          icon: Landmark,
-          label: 'Expense',
         },
       ]
       : []),

--- a/frontend/src/components/layout/dashboards/dashboard-accountant.tsx
+++ b/frontend/src/components/layout/dashboards/dashboard-accountant.tsx
@@ -94,14 +94,14 @@ const QUICK_ACCESS_SECTIONS: { title: string; items: QuickAccessItem[] }[] = [
         id: "project-expenses",
         title: "Project Expenses",
         description: "Miscellaneous expenses",
-        linkTo: "/project-expenses",
+        linkTo: "/expense/project",
         Icon: Landmark,
       },
       {
         id: "non-project-expenses",
         title: "Non-Project Expenses",
         description: "Company-wide expenses",
-        linkTo: "/non-project",
+        linkTo: "/expense/non-project",
         Icon: Banknote,
       },
       {

--- a/frontend/src/pages/Expenses/ExpenseLayout.tsx
+++ b/frontend/src/pages/Expenses/ExpenseLayout.tsx
@@ -1,0 +1,64 @@
+// src/pages/Expenses/ExpenseLayout.tsx
+//
+// Unified "Expense" module shell. Renders a page-level pill tab strip (Misc
+// Project Expense / Non-Project Expense) above an <Outlet />. The active tab is
+// the primary button color (red) with white text; inactive tabs are gray with
+// dark text — same style as the status pills (Requested/Approved/Paid) below, so
+// the active tab reads clearly. Each tab is its own URL (/expense/project,
+// /expense/non-project) so the active tab is derived from the URL and deep-links
+// / refreshes land on the right tab. The right-action button
+// (renderRightActionButton) keys off the same sub-route to show the matching
+// creation dialog.
+
+import React from "react";
+import { Link, Outlet, useLocation } from "react-router-dom";
+import { useFrappeGetDocCount } from "frappe-react-sdk";
+
+const ExpenseLayout: React.FC = () => {
+  const { pathname } = useLocation();
+
+  const { data: projectCount } = useFrappeGetDocCount("Project Expenses", undefined);
+  const { data: nonProjectCount } = useFrappeGetDocCount("Non Project Expenses", undefined);
+
+  const tabs: { label: string; to: string; count?: number }[] = [
+    { label: "Misc Project Expense", to: "/expense/project", count: projectCount },
+    { label: "Non-Project Expense", to: "/expense/non-project", count: nonProjectCount },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 scrollbar-thin">
+        <div className="flex gap-1.5 sm:flex-wrap pb-1 sm:pb-0" aria-label="Expense sections">
+          {tabs.map((tab) => {
+            const isActive = pathname.startsWith(tab.to);
+            return (
+              <Link
+                key={tab.to}
+                to={tab.to}
+                className={`px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm rounded transition-colors flex items-center gap-1.5 whitespace-nowrap ${
+                  isActive
+                    ? "bg-primary text-white font-semibold"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 font-medium"
+                }`}
+              >
+                {tab.label}
+                {typeof tab.count === "number" && (
+                  <span
+                    className={`text-xs font-bold ${
+                      isActive ? "opacity-90" : "opacity-70"
+                    }`}
+                  >
+                    {tab.count}
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+      <Outlet />
+    </div>
+  );
+};
+
+export default ExpenseLayout;

--- a/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
+++ b/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
@@ -2,38 +2,22 @@
 
 import React, { useMemo, useState, useCallback, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { ColumnDef } from "@tanstack/react-table";
-import {
-  Download,
-  Edit2,
-  FileText,
-  MoreHorizontal,
-  Trash2,
-  DollarSign,
-} from "lucide-react";
 import { DateRange } from "react-day-picker";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import memoize from "lodash/memoize";
 
-import { useFrappeDeleteDoc } from "frappe-react-sdk"; // For delete
-import { useToast } from "@/components/ui/use-toast"; // For delete feedback
+import {
+  useFrappeDeleteDoc,
+  useFrappeUpdateDoc,
+  useFrappeGetDocCount,
+  useFrappeGetDocList,
+} from "frappe-react-sdk";
+import { useToast } from "@/components/ui/use-toast";
 
 // --- UI Components ---
-import {
-  DataTable,
-  SearchFieldOption,
-} from "@/components/data-table/new-data-table"; // Assuming DataTable is correctly imported
+import { DataTable } from "@/components/data-table/new-data-table";
 import { StandaloneDateFilter } from "@/components/ui/StandaloneDateFilter";
 import { useSharedReportDateRange } from "@/pages/reports/store/useReportDateStore";
-import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { Button } from "@/components/ui/button";
 import { AlertDestructive } from "@/components/layout/alert-banner/error-alert";
-import SITEURL from "@/constants/siteURL";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -43,13 +27,13 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from "@/components/ui/alert-dialog"; // For delete confirmation
+} from "@/components/ui/alert-dialog";
 
 // --- Hooks & Utils ---
 import {
   useServerDataTable,
   AggregationConfig,
-  GroupByConfig,
+  GroupByConfig, getUrlStringParam,
 } from "@/hooks/useServerDataTable"; // Your hook
 import { FacetDeclaration } from "@/components/data-table/facetConfig";
 import { formatDate } from "@/utils/FormatDate";
@@ -57,28 +41,38 @@ import {
   formatForReport,
   formatToRoundedIndianRupee,
 } from "@/utils/FormatPrice";
+
+ 
+
+
 import { useDialogStore } from "@/zustand/useDialogStore";
 import { urlStateManager } from "@/utils/urlStateManager";
+import { useUserData } from "@/hooks/useUserData";
 import { parse, formatISO, startOfDay, endOfDay } from "date-fns";
 
 // --- Types ---
 import { NonProjectExpenses as NonProjectExpensesType } from "@/types/NirmaanStack/NonProjectExpenses";
+import { NirmaanUsers } from "@/types/NirmaanStack/NirmaanUsers";
 // --- Config ---
 import {
   DEFAULT_NPE_FIELDS_TO_FETCH,
   NPE_SEARCHABLE_FIELDS,
   NPE_DATE_COLUMNS,
 } from "./config/nonProjectExpensesTable.config";
+import { getNonProjectExpenseColumns } from "./config/nonProjectExpensesColumns";
 
 // --- Child Components ---
 import { NewNonProjectExpense } from "./components/NewNonProjectExpense";
-import { EditNonProjectExpense } from "./components/EditNonProjectExpense"; // NEW
+import { EditNonProjectExpense } from "./components/EditNonProjectExpense";
 import { UpdatePaymentDetailsDialog } from "./components/UpdatePaymentDetailsDialog";
 import { UpdateInvoiceDetailsDialog } from "./components/UpdateInvoiceDetailsDialog";
 import { NonProjectExpenseSummaryCard } from "./components/NonProjectExpenseSummaryCard";
-import { useUserData } from "@/hooks/useUserData";
 
 const DOCTYPE = "Non Project Expenses";
+
+// URL param key for the active status workflow tab (namespaced to avoid collision
+// with the page's own date-range params).
+const NPE_STATUS_TAB_PARAM = "npe_status";
 
 // NEW: Configuration for the summary card aggregations
 const NPE_AGGREGATES_CONFIG: AggregationConfig[] = [
@@ -105,7 +99,6 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
   DisableAction = false,
 }) => {
   const {
-    toggleNewNonProjectExpenseDialog,
     setEditNonProjectExpenseDialog, // NEW
     deleteConfirmationDialog, // NEW
     setDeleteConfirmationDialog, // NEW
@@ -113,6 +106,65 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
   const { toast } = useToast();
   const { role } = useUserData();
   const { deleteDoc, loading: deleteLoading } = useFrappeDeleteDoc(); // For delete operation
+  const { updateDoc, loading: updateLoading } = useFrappeUpdateDoc();
+
+  // --- Status workflow tab (URL-synced, role-based default) ---
+  // Accountant lands on Approved (their action = Record Payment + Mark as Paid);
+  // everyone else on Requested. A ?npe_status= param overrides it.
+  const isAccountantUser =
+    role === "Nirmaan Accountant Profile" ||
+    role === "Nirmaan Accountant Lead Profile";
+  const defaultStatusTab = isAccountantUser ? "Approved" : "Requested";
+  const [statusTab, setStatusTab] = useState<string>(() =>
+    getUrlStringParam(NPE_STATUS_TAB_PARAM, defaultStatusTab)
+  );
+  useEffect(() => {
+    if (urlStateManager.getParam(NPE_STATUS_TAB_PARAM) !== statusTab) {
+      urlStateManager.updateParam(NPE_STATUS_TAB_PARAM, statusTab);
+    }
+  }, [statusTab]);
+  useEffect(() => {
+    const unsubscribe = urlStateManager.subscribe(
+      NPE_STATUS_TAB_PARAM,
+      (_, value) => {
+        const next = value || defaultStatusTab;
+        setStatusTab((prev) => (prev !== next ? next : prev));
+      }
+    );
+    return unsubscribe;
+  }, [defaultStatusTab]);
+
+  // --- Users lookup for the "Created By" column ---
+  const { data: users } = useFrappeGetDocList<NirmaanUsers>("Nirmaan Users", {
+    fields: ["name", "full_name"],
+    limit: 0,
+  });
+  const getUserName = useCallback(
+    memoize(
+      (id?: string) =>
+        users?.find((u) => u.name === id)?.full_name || id || "--"
+    ),
+    [users]
+  );
+
+  // --- Per-status counts for the tab badges (whole dataset, not date-scoped) ---
+  const { data: requestedCount, mutate: mutateRequested } =
+    useFrappeGetDocCount(DOCTYPE, [["status", "=", "Requested"]]);
+  const { data: approvedCount, mutate: mutateApproved } =
+    useFrappeGetDocCount(DOCTYPE, [["status", "=", "Approved"]]);
+  const { data: paidCount, mutate: mutatePaid } =
+    useFrappeGetDocCount(DOCTYPE, [["status", "=", "Paid"]]);
+  const { data: allCount } = useFrappeGetDocCount(DOCTYPE, undefined);
+
+  const statusTabs = useMemo(
+    () => [
+      { label: "Requested", value: "Requested", count: requestedCount ?? 0 },
+      { label: "Approved", value: "Approved", count: approvedCount ?? 0 },
+      { label: "Paid", value: "Paid", count: paidCount ?? 0 },
+      { label: "All", value: "All", count: allCount ?? 0 },
+    ],
+    [requestedCount, approvedCount, paidCount, allCount]
+  );
 
   const urlSyncKey = useMemo(() => `npe_${urlContext}`, [urlContext]);
 
@@ -179,16 +231,25 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
     useState<NonProjectExpensesType | null>(null); // NEW
   const [expenseToDelete, setExpenseToDelete] =
     useState<NonProjectExpensesType | null>(null); // NEW for delete context
+  const [markPaidMode, setMarkPaidMode] = useState(false);
+  const [statusAction, setStatusAction] = useState<{
+    expense: NonProjectExpensesType;
+    next: "Approved" | "Paid";
+  } | null>(null);
 
   // Define handlers (these are dependencies for `columnsDefinition`)
-  const handleOpenPaymentUpdateDialog = useCallback(
+  // Accountant "Mark as Paid" -> opens the payment dialog in mark-paid mode, which
+  // records the payment details AND sets status = "Paid" on submit.
+  const handleOpenMarkPaid = useCallback(
     (expense: NonProjectExpensesType) => {
       setSelectedExpenseForUpdate(expense);
+      setMarkPaidMode(true);
       setIsPaymentUpdateDialogOpen(true);
     },
     []
   );
 
+  // Creator "Record Invoice" -> opens the invoice-details dialog.
   const handleOpenInvoiceUpdateDialog = useCallback(
     (expense: NonProjectExpensesType) => {
       setSelectedExpenseForUpdate(expense);
@@ -196,6 +257,11 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
     },
     []
   );
+
+  // Admin "Approve" -> confirm dialog that moves Requested -> Approved.
+  const handleOpenApprove = useCallback((expense: NonProjectExpensesType) => {
+    setStatusAction({ expense, next: "Approved" });
+  }, []);
 
   const handleOpenEditDialog = useCallback(
     (expense: NonProjectExpensesType) => {
@@ -238,293 +304,66 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
     }
   };
 
-  const actionColumn: ColumnDef<NonProjectExpensesType> = {
-    id: "actions",
-    header: () => <div className="text-right">Actions</div>, // Added text-right for alignment
-    cell: ({ row }) => {
-      const expense = row.original;
-      return (
-        <div className="text-right">
-          {" "}
-          {/* Ensure parent div is also text-right */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
-                <span className="sr-only">Open menu</span>
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {(role === "Nirmaan Admin Profile" ||
-                role === "Nirmaan PMO Executive Profile") && (
-                  <DropdownMenuItem onClick={() => handleOpenEditDialog(expense)}>
-                    <Edit2 className="mr-2 h-4 w-4" /> Edit Expense
-                  </DropdownMenuItem>
-                )}
-              <DropdownMenuItem
-                onClick={() => handleOpenPaymentUpdateDialog(expense)}
-              >
-                <DollarSign className="mr-2 h-4 w-4" /> Update Payment
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => handleOpenInvoiceUpdateDialog(expense)}
-              >
-                <FileText className="mr-2 h-4 w-4" /> Update Invoice
-              </DropdownMenuItem>
-              {(role === "Nirmaan Admin Profile" ||
-                role === "Nirmaan PMO Executive Profile") && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={() => handleOpenDeleteConfirmation(expense)}
-                      className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" /> Delete Expense
-                    </DropdownMenuItem>
-                  </>
-                )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      );
-    },
-    meta: { excludeFromExport: true },
+  const confirmStatusChange = async () => {
+    if (!statusAction) return;
+    try {
+      await updateDoc(DOCTYPE, statusAction.expense.name, {
+        status: statusAction.next,
+      });
+      toast({
+        title: "Success",
+        description: `Expense marked ${statusAction.next}.`,
+        variant: "success",
+      });
+      refetch();
+      mutateRequested();
+      mutateApproved();
+      mutatePaid();
+    } catch (error: any) {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to update status.",
+        variant: "destructive",
+      });
+    } finally {
+      setStatusAction(null);
+    }
   };
 
-  // Now define columns, using the handlers
-  // This `columnsDefinition` will be passed to both useServerDataTable and DataTable
-  const columnsDefinition = useMemo<ColumnDef<NonProjectExpensesType>[]>(
-    () => [
-      {
-        accessorKey: "payment_date",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Payment Date" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium ">
-            {row.original.payment_date
-              ? formatDate(row.original.payment_date)
-              : "--"}
-          </div>
-        ),
+  // Status workflow tab -> base filter (combined with the date-range filter).
+  // In report mode (DisableAction) the status filter is not applied.
+  const additionalFilters = useMemo(() => {
+    const filters: any[] = [...dateFilters];
+    if (!DisableAction && statusTab !== "All") {
+      filters.push(["status", "=", statusTab]);
+    }
+    return filters;
+  }, [dateFilters, statusTab, DisableAction]);
 
-        meta: {
-          exportHeaderName: "Payment Date",
-          exportValue: (row) =>
-            row.payment_date ? formatDate(row.payment_date) : "--",
-        },
-      },
-      {
-        accessorKey: "invoice_date",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Invoice Date" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium ">
-            {row.original.invoice_date
-              ? formatDate(row.original.invoice_date)
-              : "--"}
-          </div>
-        ),
-
-        meta: {
-          exportHeaderName: "Invoice Date",
-          exportValue: (row) =>
-            row.invoice_date ? formatDate(row.invoice_date) : "--",
-        },
-      },
-      {
-        accessorKey: "type",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Expense Type" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium " title={row.original.type}>
-            {row.original.type}
-          </div>
-        ),
-        enableColumnFilter: true, // UPDATED: Explicitly enable filtering for clarity
-        meta: {
-          exportHeaderName: "Expense Type",
-          exportValue: (row) => row.type,
-          facet: {
-            field: "type",
-            title: "Expense Type",
-          } satisfies FacetDeclaration,
-        },
-      },
-      {
-        accessorKey: "description",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Description" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium " title={row.original.description}>
-            {row.original.description || "--"}
-          </div>
-        ),
-
-        meta: {
-          exportHeaderName: "Description",
-          exportValue: (row) => row.description || "--",
-        },
-      },
-      {
-        accessorKey: "comment",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Comment" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium " title={row.original.comment}>
-            {row.original.comment || "--"}
-          </div>
-        ),
-
-        meta: {
-          exportHeaderName: "Comment",
-          exportValue: (row) => row.comment || "--",
-        },
-      },
-      {
-        accessorKey: "amount",
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title="Amount"
-            className="justify-end"
-          />
-        ),
-        cell: ({ row }) => {
-          const amount = row.original.amount;
-          return (
-            <div className={cn(
-              "font-medium",
-              amount < 0 && "text-green-600 dark:text-green-400"
-            )}>
-              {formatToRoundedIndianRupee(amount)}
-            </div>
-          );
-        },
-
-        meta: {
-          exportHeaderName: "Amount",
-          exportValue: (row) => formatForReport(row.amount),
-        },
-      },
-      {
-        accessorKey: "payment_ref",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Payment Ref" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium">{row.original.payment_ref || "--"}</div>
-        ),
-
-        meta: {
-          exportHeaderName: "Payment Ref",
-          exportValue: (row) => row.payment_ref || "--",
-        },
-      },
-      {
-        accessorKey: "invoice_ref",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Invoice Ref" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium">{row.original.invoice_ref || "--"}</div>
-        ),
-
-        meta: {
-          exportHeaderName: "Invoice Ref",
-          exportValue: (row) => row.invoice_ref || "--",
-        },
-      },
-      {
-        id: "attachments",
-        header: "Attachments",
-        cell: ({ row }) => {
-          const data = row.original;
-          return (
-            <div className="flex items-center space-x-2">
-              {row.original.payment_attachment && (
-                <a
-                  href={SITEURL + data.payment_attachment}
-                  target="_blank"
-                  rel="noreferrer"
-                  title="Payment Proof"
-                >
-                  <Download className="h-4 w-4 text-blue-600 hover:text-blue-800" />
-                </a>
-              )}
-              {row.original.invoice_attachment && (
-                <a
-                  href={SITEURL + data.invoice_attachment}
-                  target="_blank"
-                  rel="noreferrer"
-                  title="Invoice Document"
-                >
-                  <FileText className="h-4 w-4 text-green-600 hover:text-green-800" />
-                </a>
-              )}
-              {!row.original.payment_attachment &&
-                !row.original.invoice_attachment && (
-                  <span className="text-xs text-muted-foreground">None</span>
-                )}
-            </div>
-          );
-        },
-
-        enableSorting: false,
-        meta: { excludeFromExport: true },
-      },
-      ...(!DisableAction ? [actionColumn] : []),
-      // {
-      //     id: "actions",
-      //     header: () => <div>Actions</div>,
-      //     cell: ({ row }) => {
-      //         const expense = row.original;
-      //         return (
-      //             <div> {/* Ensure parent div is also text-right */}
-      //                 <DropdownMenu>
-      //                     <DropdownMenuTrigger asChild>
-      //                         <Button variant="ghost" className="h-8 w-8 p-0">
-      //                             <span className="sr-only">Open menu</span>
-      //                             <MoreHorizontal className="h-4 w-4" />
-      //                         </Button>
-      //                     </DropdownMenuTrigger>
-      //                     <DropdownMenuContent align="end">
-      //                         {role === "Nirmaan Admin Profile" && <DropdownMenuItem onClick={() => handleOpenEditDialog(expense)}>
-      //                             <Edit2 className="mr-2 h-4 w-4" /> Edit Expense
-      //                         </DropdownMenuItem>}
-      //                         <DropdownMenuItem onClick={() => handleOpenPaymentUpdateDialog(expense)}>
-      //                             <DollarSign className="mr-2 h-4 w-4" /> Update Payment
-      //                         </DropdownMenuItem>
-      //                         <DropdownMenuItem onClick={() => handleOpenInvoiceUpdateDialog(expense)}>
-      //                             <FileText className="mr-2 h-4 w-4" /> Update Invoice
-      //                         </DropdownMenuItem>
-      //                         {role === "Nirmaan Admin Profile" &&
-      //                             <>
-      //                                 <DropdownMenuSeparator />
-      //                                 <DropdownMenuItem
-      //                                     onClick={() => handleOpenDeleteConfirmation(expense)}
-      //                                     className="text-destructive focus:text-destructive focus:bg-destructive/10"
-      //                                 >
-      //                                     <Trash2 className="mr-2 h-4 w-4" /> Delete Expense
-      //                                 </DropdownMenuItem>
-      //                             </>
-      //                         }
-      //                     </DropdownMenuContent>
-      //                 </DropdownMenu>
-      //             </div>
-      //         );
-      //     },
-      //     meta: { excludeFromExport: true }
-      // },
-    ],
+  // Columns live in ./config/nonProjectExpensesColumns (tab-aware + role-gated).
+  // In report mode (DisableAction) show the full "All" column set with no actions.
+  const columnsDefinition = useMemo(
+    () =>
+      getNonProjectExpenseColumns({
+        statusTab: DisableAction ? "All" : statusTab,
+        role,
+        getUserName,
+        disableActions: DisableAction,
+        onEdit: handleOpenEditDialog,
+        onApprove: handleOpenApprove,
+        onRecordInvoice: handleOpenInvoiceUpdateDialog,
+        onMarkPaid: handleOpenMarkPaid,
+        onDelete: handleOpenDeleteConfirmation,
+      }),
     [
-      handleOpenPaymentUpdateDialog,
-      handleOpenInvoiceUpdateDialog,
+      statusTab,
+      DisableAction,
+      role,
+      getUserName,
       handleOpenEditDialog,
+      handleOpenApprove,
+      handleOpenInvoiceUpdateDialog,
+      handleOpenMarkPaid,
       handleOpenDeleteConfirmation,
     ]
   );
@@ -557,10 +396,10 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
     enableRowSelection: false, // Or true if actions on rows are needed
     aggregatesConfig: NPE_AGGREGATES_CONFIG, // NEW: Pass the config
     groupByConfig: NPE_GROUP_BY_CONFIG, // NEW: Pass the group by config
-    additionalFilters: dateFilters, // NEW: Apply date filters
+    additionalFilters: additionalFilters, // date range + active status tab
   });
 
-  const handleClearDateFilter = useCallback(() => {
+ const handleClearDateFilter = useCallback(() => {
     onDateClear(); // Reset to "ALL" (no date filtering)
   }, [onDateClear]);
 
@@ -584,7 +423,36 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
         onChange={onDateChange}
         onClear={handleClearDateFilter}
       />
-      {/* <span>(PAYMENT DATE)</span> */}
+      {!DisableAction && (
+        <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 scrollbar-thin">
+          <div className="flex gap-1.5 sm:flex-wrap pb-1 sm:pb-0">
+            {statusTabs.map((sTab) => {
+              const isActive = statusTab === sTab.value;
+              return (
+                <button
+                  key={sTab.value}
+                  type="button"
+                  onClick={() => setStatusTab(sTab.value)}
+                  className={`px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm rounded transition-colors flex items-center gap-1.5 whitespace-nowrap ${
+                    isActive
+                      ? "bg-sky-500 text-white"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  }`}
+                >
+                  {sTab.label}
+                  <span
+                    className={`text-xs font-bold ${
+                      isActive ? "opacity-90" : "opacity-70"
+                    }`}
+                  >
+                    {sTab.count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
       <DataTable<NonProjectExpensesType>
         table={table} // This table instance is now created with columns
         columns={columnsDefinition} // Pass the same columns definition for export/etc.
@@ -618,13 +486,23 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
         }
       // errorMessage="Could not load expenses. Please try again." // Already handled by main error display
       />
-      <NewNonProjectExpense refetchList={refetch} />
+      <NewNonProjectExpense
+        refetchList={() => {
+          refetch();
+          mutateRequested();
+          mutateApproved();
+          mutatePaid();
+        }}
+      />
 
       {selectedExpenseForEdit && ( // NEW: Render Edit Dialog
         <EditNonProjectExpense
           expenseToEdit={selectedExpenseForEdit}
           onSuccess={() => {
             refetch();
+            mutateRequested();
+            mutateApproved();
+            mutatePaid();
             setEditNonProjectExpenseDialog(false); // Close dialog on success
           }}
         />
@@ -636,13 +514,24 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
             isOpen={isPaymentUpdateDialogOpen}
             setIsOpen={setIsPaymentUpdateDialogOpen}
             expense={selectedExpenseForUpdate}
-            onSuccess={refetch}
+            markAsPaid={markPaidMode}
+            onSuccess={() => {
+              refetch();
+              mutateRequested();
+              mutateApproved();
+              mutatePaid();
+            }}
           />
           <UpdateInvoiceDetailsDialog
             isOpen={isInvoiceUpdateDialogOpen}
             setIsOpen={setIsInvoiceUpdateDialogOpen}
             expense={selectedExpenseForUpdate}
-            onSuccess={refetch}
+            onSuccess={() => {
+              refetch();
+              mutateRequested();
+              mutateApproved();
+              mutatePaid();
+            }}
           />
         </>
       )}
@@ -674,6 +563,36 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
                 className="bg-destructive hover:bg-destructive/90 text-destructive-foreground"
               >
                 {deleteLoading ? "Deleting..." : "Yes, delete expense"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+      {/* Approve confirmation (Requested -> Approved) */}
+      {statusAction && (
+        <AlertDialog
+          open={!!statusAction}
+          onOpenChange={(open) => !open && setStatusAction(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Approve this expense?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This moves the expense from Requested to Approved.
+                <span className="font-semibold mx-1">
+                  {statusAction.expense.description || statusAction.expense.name}
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={() => setStatusAction(null)}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmStatusChange}
+                disabled={updateLoading}
+              >
+                {updateLoading ? "Updating..." : "Confirm"}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
+++ b/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
@@ -98,6 +98,9 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
   urlContext = "npe_default",
   DisableAction = false,
 }) => {
+  // Standalone page grows to natural height for a single page scroll; the report
+  // embed (DisableAction) keeps the fixed-height internal table scroll.
+  const autoHeight = !DisableAction;
   const {
     setEditNonProjectExpenseDialog, // NEW
     deleteConfirmationDialog, // NEW
@@ -411,11 +414,13 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
     <div
       className={cn(
         "flex flex-col gap-2 overflow-hidden",
-        totalCount > 10
-          ? "h-[calc(100vh-80px)]"
-          : totalCount > 0
-            ? "h-auto"
-            : ""
+        autoHeight
+          ? "h-auto"
+          : totalCount > 10
+            ? "h-[calc(100vh-80px)]"
+            : totalCount > 0
+              ? "h-auto"
+              : ""
       )}
     >
       <StandaloneDateFilter

--- a/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
+++ b/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
@@ -35,12 +35,6 @@ import {
   AggregationConfig,
   GroupByConfig, getUrlStringParam,
 } from "@/hooks/useServerDataTable"; // Your hook
-import { FacetDeclaration } from "@/components/data-table/facetConfig";
-import { formatDate } from "@/utils/FormatDate";
-import {
-  formatForReport,
-  formatToRoundedIndianRupee,
-} from "@/utils/FormatPrice";
 
  
 
@@ -476,6 +470,8 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
         facetDoctype={DOCTYPE}
         facetOverrides={{
           type: { additionalFilters: dateFilters },
+          status: { additionalFilters: dateFilters },
+          owner: { additionalFilters: dateFilters },
         }}
         dateFilterColumns={NPE_DATE_COLUMNS}
         showExportButton={true}

--- a/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
+++ b/frontend/src/pages/NonProjectExpenses/NonProjectExpensesPage.tsx
@@ -334,10 +334,14 @@ export const NonProjectExpensesPage: React.FC<NonProjectExpensesPageProps> = ({
   };
 
   // Status workflow tab -> base filter (combined with the date-range filter).
-  // In report mode (DisableAction) the status filter is not applied.
+  // Report mode (DisableAction) = the Outflow (Non-Project) report -> settled
+  // cash-out only, so force status = Paid. The standalone page uses the active
+  // status tab instead (All tab = no status filter).
   const additionalFilters = useMemo(() => {
     const filters: any[] = [...dateFilters];
-    if (!DisableAction && statusTab !== "All") {
+    if (DisableAction) {
+      filters.push(["status", "=", "Paid"]);
+    } else if (statusTab !== "All") {
       filters.push(["status", "=", statusTab]);
     }
     return filters;

--- a/frontend/src/pages/NonProjectExpenses/components/EditNonProjectExpense.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/EditNonProjectExpense.tsx
@@ -10,7 +10,7 @@ import {
 } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
 import { formatDate as formatDateFns } from "date-fns";
-import { Check, ChevronsUpDown, Paperclip, Download as DownloadIcon, X as XIcon, AlertTriangle } from "lucide-react";
+import { Check, ChevronsUpDown, Download as DownloadIcon, X as XIcon, AlertTriangle } from "lucide-react";
 
 // --- UI Components ---
 import {
@@ -100,14 +100,18 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
                 description: expenseToEdit.description || "",
                 comment: expenseToEdit.comment || "",
                 amount: expenseToEdit.amount?.toString() || "",
-                payment_date: expenseToEdit.payment_date ? formatDateFns(new Date(expenseToEdit.payment_date), "yyyy-MM-dd") : formatDateFns(new Date(), "yyyy-MM-dd"),
+                // Prefill from the saved value, otherwise leave EMPTY (no auto-today).
+                payment_date: expenseToEdit.payment_date ? formatDateFns(new Date(expenseToEdit.payment_date), "yyyy-MM-dd") : "",
                 payment_ref: expenseToEdit.payment_ref || "",
-                invoice_date: expenseToEdit.invoice_date ? formatDateFns(new Date(expenseToEdit.invoice_date), "yyyy-MM-dd") : formatDateFns(new Date(), "yyyy-MM-dd"),
+                invoice_date: expenseToEdit.invoice_date ? formatDateFns(new Date(expenseToEdit.invoice_date), "yyyy-MM-dd") : "",
                 invoice_ref: expenseToEdit.invoice_ref || "",
             });
             // Determine if sections should be initially open
-            setRecordPaymentDetails(!!(expenseToEdit.payment_date || expenseToEdit.payment_ref || expenseToEdit.payment_attachment));
-            setRecordInvoiceDetails(!!(expenseToEdit.invoice_date || expenseToEdit.invoice_ref || expenseToEdit.invoice_attachment));
+            const hasPayment = !!(expenseToEdit.payment_date || expenseToEdit.payment_ref || expenseToEdit.payment_attachment);
+            const hasInvoice = !!(expenseToEdit.invoice_date || expenseToEdit.invoice_ref || expenseToEdit.invoice_attachment);
+            setRecordPaymentDetails(hasPayment);
+            // A Paid expense (has payment) also requires its invoice, so keep both open.
+            setRecordInvoiceDetails(hasInvoice || hasPayment);
 
             setExistingPaymentAttachmentUrl(expenseToEdit.payment_attachment);
             setExistingInvoiceAttachmentUrl(expenseToEdit.invoice_attachment);
@@ -156,11 +160,15 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
         if (!formState.type) errors.type = "Expense Type is required.";
         if (!formState.description.trim()) errors.description = "Description is required.";
         if (!formState.amount || parseNumber(formState.amount) === 0) errors.amount = "Amount cannot be zero. Use negative for refunds.";
+        // Marking Paid (Record Payment Details) makes BOTH dates mandatory.
         if (recordPaymentDetails && !formState.payment_date) errors.payment_date = "Payment date is required.";
-        if (recordInvoiceDetails && !formState.invoice_date) errors.invoice_date = "Invoice date is required.";
+        if ((recordPaymentDetails || recordInvoiceDetails) && !formState.invoice_date) errors.invoice_date = "Invoice date is required.";
+        // An invoice attachment (kept existing or newly staged) requires an Invoice Ref.
+        const hasInvoiceAttachment = !!newInvoiceAttachmentFile || (invoiceAttachmentAction !== "remove" && !!existingInvoiceAttachmentUrl);
+        if (recordInvoiceDetails && hasInvoiceAttachment && !formState.invoice_ref.trim()) errors.invoice_ref = "Invoice reference is required when an invoice is attached.";
         setFormErrors(errors);
         return Object.keys(errors).length === 0;
-    }, [formState, recordPaymentDetails, recordInvoiceDetails]);
+    }, [formState, recordPaymentDetails, recordInvoiceDetails, newInvoiceAttachmentFile, invoiceAttachmentAction, existingInvoiceAttachmentUrl]);
 
     // Attachment Handlers (similar to UpdatePayment/InvoiceDetailsDialog)
     const handleNewPaymentFileSelected = (file: File | null) => {
@@ -258,7 +266,8 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
 
 
     const isLoadingOverall = updateLoading || uploadLoading || expenseTypesLoading;
-    const isSubmitDisabled = isLoadingOverall || !formState.type || !formState.description.trim() || !formState.amount;
+    const editHasInvoiceAttachment = !!newInvoiceAttachmentFile || (invoiceAttachmentAction !== "remove" && !!existingInvoiceAttachmentUrl);
+    const isSubmitDisabled = isLoadingOverall || !formState.type || !formState.description.trim() || !formState.amount || (recordPaymentDetails && (!formState.payment_date || !formState.invoice_date)) || (recordInvoiceDetails && !formState.invoice_date) || (recordInvoiceDetails && editHasInvoiceAttachment && !formState.invoice_ref.trim());
     const selectedExpenseTypeLabel = expenseTypeOptionsForCommand.find(option => option.value === formState.type)?.label || "Select Expense Type...";
 
 
@@ -272,41 +281,38 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
         onRemoveExisting: () => void,
         labelPrefix: string
     ) => {
-        let currentAttachmentDisplayNode: React.ReactNode = null;
         const effectiveExistingUrl = (action === "keep" || action === "replace") && existingUrl;
-
-        if (newFile) {
-            currentAttachmentDisplayNode = ( /* ... New file display ... */
-                <div className="flex items-center justify-between p-2 bg-blue-50 dark:bg-blue-900/30 rounded-md text-sm border border-blue-200 dark:border-blue-700">
-                    <div className="flex items-center gap-2 min-w-0"><Paperclip className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0" /><span className="truncate" title={newFile.name}>{newFile.name}</span><span className="text-xs text-blue-500 dark:text-blue-500 ml-1 whitespace-nowrap">(New)</span></div>
-                </div>
-            );
-        } else if (effectiveExistingUrl) {
-            currentAttachmentDisplayNode = ( /* ... Existing file display ... */
-                <div className="flex items-center justify-between p-2 bg-muted/60 rounded-md text-sm">
-                    <div className="flex items-center gap-2 min-w-0"><DownloadIcon className="h-4 w-4 text-primary flex-shrink-0" /><a href={SITEURL + effectiveExistingUrl} target="_blank" rel="noopener noreferrer" className="truncate hover:underline" title={`View ${effectiveExistingUrl.split('/').pop()}`}>{effectiveExistingUrl.split('/').pop()}</a></div>
-                    <Button variant="ghost" size="icon" onClick={onRemoveExisting} className="h-7 w-7 text-destructive hover:bg-destructive/10"><XIcon className="h-4 w-4" /><span className="sr-only">Remove existing</span></Button>
-                </div>
-            );
-        } else if (action === "remove" && existingUrl) {
-            currentAttachmentDisplayNode = ( /* ... Marked for removal ... */
-                <div className="flex items-center gap-2 p-2 bg-amber-50 dark:bg-amber-900/30 rounded-md text-sm text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-700">
-                    <AlertTriangle className="h-4 w-4 flex-shrink-0" /><span>Attachment will be removed.</span>
-                </div>
-            );
-        }
 
         return (
             <div className="grid grid-cols-4 items-start gap-3">
                 <Label className="text-right col-span-1 pt-2">{labelPrefix} Attachment</Label>
                 <div className="col-span-3 space-y-2">
-                    {currentAttachmentDisplayNode}
-                    {(!newFile && (action === "remove" || !existingUrl)) && (
-                        <CustomAttachment label={`Upload New ${labelPrefix} Attachment`} selectedFile={newFile} onFileSelect={onNewFileSelected} onError={handleAttachmentError} maxFileSize={5 * 1024 * 1024} acceptedTypes={ATTACHMENT_ACCEPTED_TYPES} disabled={isLoadingOverall} />
+                    {/* Existing saved file — hidden once a replacement is staged. */}
+                    {effectiveExistingUrl && !newFile && (
+                        <div className="flex items-center justify-between p-2 bg-muted/60 rounded-md text-sm">
+                            <div className="flex items-center gap-2 min-w-0">
+                                <DownloadIcon className="h-4 w-4 text-primary flex-shrink-0" />
+                                <a href={SITEURL + effectiveExistingUrl} target="_blank" rel="noopener noreferrer" className="truncate hover:underline" title={`View ${effectiveExistingUrl.split('/').pop()}`}>{effectiveExistingUrl.split('/').pop()}</a>
+                            </div>
+                            <Button variant="ghost" size="icon" onClick={onRemoveExisting} className="h-7 w-7 text-destructive hover:bg-destructive/10" disabled={isLoadingOverall}><XIcon className="h-4 w-4" /><span className="sr-only">Remove existing</span></Button>
+                        </div>
                     )}
-                    {!newFile && existingUrl && action === "keep" && (
-                        <CustomAttachment label={`Replace ${labelPrefix} Attachment`} selectedFile={null} onFileSelect={onNewFileSelected} onError={handleAttachmentError} maxFileSize={5 * 1024 * 1024} acceptedTypes={ATTACHMENT_ACCEPTED_TYPES} disabled={isLoadingOverall} />
+                    {action === "remove" && existingUrl && !newFile && (
+                        <div className="flex items-center gap-2 p-2 bg-amber-50 dark:bg-amber-900/30 rounded-md text-sm text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-700">
+                            <AlertTriangle className="h-4 w-4 flex-shrink-0" /><span>Attachment will be removed.</span>
+                        </div>
                     )}
+                    {/* Same uploader format as the create dialog — CustomAttachment shows the
+                        staged file (with its own remove) exactly like creation. */}
+                    <CustomAttachment
+                        label={effectiveExistingUrl ? `Replace ${labelPrefix} Attachment` : `Upload ${labelPrefix} Attachment`}
+                        selectedFile={newFile}
+                        onFileSelect={onNewFileSelected}
+                        onError={handleAttachmentError}
+                        maxFileSize={5 * 1024 * 1024}
+                        acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                        disabled={isLoadingOverall}
+                    />
                 </div>
             </div>
         );
@@ -371,11 +377,14 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
                         </p>
                     </div>
 
+                    {/* Payment Details are recorded via "Mark as Paid"; only expose this
+                        section when editing an already-Paid expense (e.g. Admin corrections). */}
+                    {expenseToEdit.status === "Paid" && (
+                    <>
                     <Separator className="my-4" />
-                    {/* Payment Details Section */}
                     <div className="flex items-center space-x-2">
-                        <Checkbox id="recordPaymentDetails_edit_npe" checked={recordPaymentDetails} onCheckedChange={(checked) => setRecordPaymentDetails(Boolean(checked))} disabled={isLoadingOverall} />
-                        <Label htmlFor="recordPaymentDetails_edit_npe" className="font-medium">Payment Details</Label>
+                        <Checkbox id="recordPaymentDetails_edit_npe" checked={recordPaymentDetails} onCheckedChange={(checked) => { setRecordPaymentDetails(Boolean(checked)); if (checked) setRecordInvoiceDetails(true); }} disabled={isLoadingOverall} />
+                        <Label htmlFor="recordPaymentDetails_edit_npe" className="font-medium">Payment Details (Paid)</Label>
                     </div>
                     {recordPaymentDetails && (
                         <div className="pl-6 space-y-3 border-l-2 ml-2 mt-2 border-dashed">
@@ -391,11 +400,13 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
                             {renderAttachmentSection("payment", existingPaymentAttachmentUrl, newPaymentAttachmentFile, paymentAttachmentAction, handleNewPaymentFileSelected, handleRemoveExistingPaymentAttachment, "Payment")}
                         </div>
                     )}
+                    </>
+                    )}
 
                     <Separator className="my-4" />
                     {/* Invoice Details Section */}
                     <div className="flex items-center space-x-2">
-                        <Checkbox id="recordInvoiceDetails_edit_npe" checked={recordInvoiceDetails} onCheckedChange={(checked) => setRecordInvoiceDetails(Boolean(checked))} disabled={isLoadingOverall} />
+                        <Checkbox id="recordInvoiceDetails_edit_npe" checked={recordInvoiceDetails} onCheckedChange={(checked) => setRecordInvoiceDetails(Boolean(checked))} disabled={isLoadingOverall || recordPaymentDetails} />
                         <Label htmlFor="recordInvoiceDetails_edit_npe" className="font-medium">Invoice Details</Label>
                     </div>
                     {recordInvoiceDetails && (
@@ -406,8 +417,9 @@ export const EditNonProjectExpense: React.FC<EditNonProjectExpenseProps> = ({ ex
                                 {formErrors.invoice_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_date}</p>}
                             </div>
                             <div className="grid grid-cols-4 items-center gap-3"> {/* Ref */}
-                                <Label htmlFor="invoice_ref_edit_npe" className="text-right col-span-1">Invoice Ref</Label>
-                                <Input id="invoice_ref_edit_npe" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className="col-span-3" disabled={isLoadingOverall} />
+                                <Label htmlFor="invoice_ref_edit_npe" className="text-right col-span-1">Invoice Ref{editHasInvoiceAttachment && <sup className="text-destructive"> *</sup>}</Label>
+                                <Input id="invoice_ref_edit_npe" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className={cn("col-span-3", ((editHasInvoiceAttachment && !formState.invoice_ref.trim()) || formErrors.invoice_ref) && "border-destructive")} disabled={isLoadingOverall} />
+                                {((editHasInvoiceAttachment && !formState.invoice_ref.trim()) || formErrors.invoice_ref) && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_ref || "Invoice Ref is required because an invoice is attached."}</p>}
                             </div>
                             {renderAttachmentSection("invoice", existingInvoiceAttachmentUrl, newInvoiceAttachmentFile, invoiceAttachmentAction, handleNewInvoiceFileSelected, handleRemoveExistingInvoiceAttachment, "Invoice")}
                         </div>

--- a/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
@@ -66,9 +66,9 @@ const INITIAL_FORM_STATE: NewExpenseFormState = {
     description: "",
     comment: "",
     amount: "",
-    payment_date: formatDateFns(new Date(), "yyyy-MM-dd"),
+    payment_date: "", // empty by default — user picks it (mandatory only when Paid)
     payment_ref: "",
-    invoice_date: formatDateFns(new Date(), "yyyy-MM-dd"),
+    invoice_date: "", // empty by default — user picks it (mandatory only when Paid)
     invoice_ref: "",
 };
 
@@ -216,21 +216,6 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         }
     }, [runPaymentAutofill]);
 
-    // Wrap the checkbox toggle so unchecking Record Payment Details also
-    // invalidates any in-flight extraction and clears autofill state.
-    // Checking it back ON starts fresh at the upload stage.
-    const handleRecordPaymentDetailsChange = useCallback((checked: boolean) => {
-        extractionSessionRef.current++;
-        if (!checked) {
-            setAutofilledFields(new Set());
-            setIsAutofilling(false);
-            setUploadedPaymentUrl(null);
-            setPaymentAttachmentFile(null);
-        }
-        setPaymentStage("upload");
-        setRecordPaymentDetails(checked);
-    }, []);
-
     // Handler for Expense Type selection from CommandItem
     const handleExpenseTypeSelect = useCallback((currentValue: string) => {
         setFormState(prev => ({ ...prev, type: currentValue === formState.type ? "" : currentValue }));
@@ -255,15 +240,19 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
         if (!formState.description.trim()) errors.description = "Description is required.";
         if (!formState.amount || parseNumber(formState.amount) === 0) errors.amount = "Amount cannot be zero. Use negative for refunds.";
 
+        // Marking Paid (Record Payment Details) makes BOTH dates mandatory.
         if (recordPaymentDetails) {
             if (!formState.payment_date) errors.payment_date = "Payment date is required.";
+            if (!formState.invoice_date) errors.invoice_date = "Invoice date is required.";
         }
         if (recordInvoiceDetails) {
             if (!formState.invoice_date) errors.invoice_date = "Invoice date is required.";
+            // Uploading an invoice attachment requires an Invoice Ref.
+            if (invoiceAttachmentFile && !formState.invoice_ref.trim()) errors.invoice_ref = "Invoice reference is required when an invoice is attached.";
         }
         setFormErrors(errors);
         return Object.keys(errors).length === 0;
-    }, [formState, recordPaymentDetails, recordInvoiceDetails]);
+    }, [formState, recordPaymentDetails, recordInvoiceDetails, invoiceAttachmentFile]);
 
     const handleSubmit = useCallback(async () => {
         if (!validateForm()) {
@@ -296,6 +285,7 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
                 description: formState.description.trim(),
                 comment: formState.comment.trim() || undefined,
                 amount: parseNumber(formState.amount),
+                status: "Requested", // enters the approval workflow at Requested
                 ...(recordPaymentDetails && { payment_date: formState.payment_date, payment_ref: formState.payment_ref.trim() || undefined, payment_attachment: paymentAttachmentUrl }),
                 ...(recordInvoiceDetails && { invoice_date: formState.invoice_date, invoice_ref: formState.invoice_ref.trim() || undefined, invoice_attachment: invoiceAttachmentUrl }),
             };
@@ -337,7 +327,9 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
             extractionSessionRef.current++;
             setFormState(INITIAL_FORM_STATE);
             setFormErrors({});
-            setRecordPaymentDetails(true);
+            // Payment is the Accountant's step (via Mark as Paid) and invoice details are
+            // optional at creation, so default BOTH sections OFF (unchecked).
+            setRecordPaymentDetails(false);
             setRecordInvoiceDetails(false);
             setPaymentAttachmentFile(null);
             setInvoiceAttachmentFile(null);
@@ -350,7 +342,7 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
     }, [newNonProjectExpenseDialog]);
 
     const isLoadingOverall = createLoading || uploadLoading || expenseTypesLoading;
-    const isSubmitDisabled = isLoadingOverall || isAutofilling || !formState.type || !formState.description.trim() || !formState.amount || !formState.payment_date;
+    const isSubmitDisabled = isLoadingOverall || isAutofilling || !formState.type || !formState.description.trim() || !formState.amount || (recordPaymentDetails && (!formState.payment_date || !formState.invoice_date)) || (recordInvoiceDetails && !formState.invoice_date) || (recordInvoiceDetails && !!invoiceAttachmentFile && !formState.invoice_ref.trim());
 
     const selectedExpenseTypeLabel = expenseTypeOptionsForCommand.find(option => option.value === formState.type)?.label || "Select Expense Type...";
 
@@ -427,13 +419,8 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
                         </p>
                     </div>
 
-                    <Separator className="my-4" />
-
-                    {/* Payment Details */}
-                    <div className="flex items-center space-x-2">
-                        <Checkbox id="recordPaymentDetails_new_npe" checked={recordPaymentDetails} onCheckedChange={(checked) => handleRecordPaymentDetailsChange(Boolean(checked))} disabled={isLoadingOverall} />
-                        <Label htmlFor="recordPaymentDetails_new_npe" className="font-medium">Record Payment Details</Label>
-                    </div>
+                    {/* Payment is recorded later by the Accountant (Mark as Paid), so the
+                        payment section is intentionally not shown in the create dialog. */}
                     {recordPaymentDetails && (
                         <div className="pl-6 space-y-3 border-l-2 ml-2 mt-2 border-dashed">
                             {paymentStage === "upload" ? (
@@ -530,8 +517,9 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
                                 {formErrors.invoice_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_date}</p>}
                             </div>
                             <div className="grid grid-cols-4 items-center gap-3">
-                                <Label htmlFor="invoice_ref_new_npe" className="text-right col-span-1">Invoice Ref</Label>
-                                <Input id="invoice_ref_new_npe" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className="col-span-3" disabled={isLoadingOverall} />
+                                <Label htmlFor="invoice_ref_new_npe" className="text-right col-span-1">Invoice Ref{invoiceAttachmentFile && <sup className="text-destructive"> *</sup>}</Label>
+                                <Input id="invoice_ref_new_npe" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className={cn("col-span-3", formErrors.invoice_ref && "border-destructive")} disabled={isLoadingOverall} />
+                                {formErrors.invoice_ref && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_ref}</p>}
                             </div>
                             <div className="grid grid-cols-4 items-start gap-3">
                                 <Label className="text-right col-span-1 pt-2">Invoice Attachment</Label>

--- a/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/NewNonProjectExpense.tsx
@@ -16,7 +16,7 @@ import { Check, ChevronsUpDown, Loader2, Sparkles } from "lucide-react"; // Icon
 // --- UI Components ---
 import {
     AlertDialog, AlertDialogCancel, AlertDialogContent,
-    AlertDialogHeader, AlertDialogTitle, AlertDialogFooter, AlertDialogAction
+    AlertDialogHeader, AlertDialogTitle, AlertDialogFooter
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -79,13 +79,15 @@ interface NewNonProjectExpenseProps {
 }
 
 export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refetchList }) => {
-    const { newNonProjectExpenseDialog, toggleNewNonProjectExpenseDialog, setNewNonProjectExpenseDialog } = useDialogStore();
+    const { newNonProjectExpenseDialog, setNewNonProjectExpenseDialog } = useDialogStore();
     const { toast } = useToast();
 
     const [formState, setFormState] = useState<NewExpenseFormState>(INITIAL_FORM_STATE);
     const [formErrors, setFormErrors] = useState<Partial<Record<keyof NewExpenseFormState, string>>>({});
 
-    const [recordPaymentDetails, setRecordPaymentDetails] = useState(true);
+    // Both sections default OFF (see the dialog-open reset effect below). Payment is
+    // the Accountant's Mark-as-Paid step; invoice details are optional at creation.
+    const [recordPaymentDetails, setRecordPaymentDetails] = useState(false);
     const [recordInvoiceDetails, setRecordInvoiceDetails] = useState(false);
 
     const [paymentAttachmentFile, setPaymentAttachmentFile] = useState<File | null>(null);
@@ -299,7 +301,7 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
             toast({ title: "Failed!", description: error.message || "Failed to add expense.", variant: "destructive" });
         }
     }, [
-        createDoc, formState, validateForm, toast, refetchList, toggleNewNonProjectExpenseDialog, upload,
+        createDoc, formState, validateForm, toast, refetchList, upload,
         recordPaymentDetails, paymentAttachmentFile, uploadedPaymentUrl, recordInvoiceDetails, invoiceAttachmentFile
     ]);
 
@@ -416,6 +418,9 @@ export const NewNonProjectExpense: React.FC<NewNonProjectExpenseProps> = ({ refe
                         {formErrors.amount && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.amount}</p>}
                         <p className="col-span-3 col-start-2 text-xs text-muted-foreground mt-0.5">
                             Use negative amount for refunds.
+                        </p>
+                        <p className="col-span-3 col-start-2 text-xs text-muted-foreground mt-0.5">
+                            Expenses under ₹5,000 are auto-approved; ₹5,000 and above require approval.
                         </p>
                     </div>
 

--- a/frontend/src/pages/NonProjectExpenses/components/UpdateInvoiceDetailsDialog.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/UpdateInvoiceDetailsDialog.tsx
@@ -87,6 +87,9 @@ export const UpdateInvoiceDetailsDialog: React.FC<UpdateInvoiceDetailsDialogProp
     const validate = () => {
         const errors: Partial<InvoiceFormState> = {};
         if (!formState.invoice_date) errors.invoice_date = "Invoice date is required.";
+        // An invoice attachment (kept existing or newly staged) requires an Invoice Ref.
+        const hasAttachment = !!newAttachmentFile || (attachmentAction !== "remove" && !!existingAttachmentUrl);
+        if (hasAttachment && !formState.invoice_ref.trim()) errors.invoice_ref = "Invoice reference is required when an invoice is attached.";
         setFormErrors(errors);
         return Object.keys(errors).length === 0;
     };
@@ -184,7 +187,8 @@ export const UpdateInvoiceDetailsDialog: React.FC<UpdateInvoiceDetailsDialogProp
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">
                         <Label htmlFor="invoice_ref_update_id" className="text-right col-span-1">Invoice Ref</Label>
-                        <Input id="invoice_ref_update_id" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className="col-span-3" />
+                        <Input id="invoice_ref_update_id" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className={cn("col-span-3", formErrors.invoice_ref && "border-destructive")} />
+                        {formErrors.invoice_ref && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_ref}</p>}
                     </div>
 
                     <div className="grid grid-cols-4 items-start gap-3">

--- a/frontend/src/pages/NonProjectExpenses/components/UpdatePaymentDetailsDialog.tsx
+++ b/frontend/src/pages/NonProjectExpenses/components/UpdatePaymentDetailsDialog.tsx
@@ -1,10 +1,10 @@
 // src/pages/non-project-expenses/components/UpdatePaymentDetailsDialog.tsx
 
-import React, { useState, useEffect, useCallback } from "react";
-import { useFrappeUpdateDoc, useFrappeFileUpload } from "frappe-react-sdk";
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useFrappeUpdateDoc, useFrappeFileUpload, useFrappePostCall } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
 import { formatDate as formatDateFns } from "date-fns";
-import { X, Paperclip, Download, AlertTriangle } from "lucide-react";
+import { X, Download, AlertTriangle, Loader2, Sparkles } from "lucide-react";
 
 import {
     AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription,
@@ -18,6 +18,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { Separator } from "@/components/ui/separator";
 import { NonProjectExpenses } from "@/types/NirmaanStack/NonProjectExpenses";
 import SITEURL from "@/constants/siteURL";
+import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { cn } from "@/lib/utils";
 
 interface UpdatePaymentDetailsDialogProps {
@@ -25,11 +26,15 @@ interface UpdatePaymentDetailsDialogProps {
     setIsOpen: (open: boolean) => void;
     expense: NonProjectExpenses;
     onSuccess?: () => void;
+    /** When true, submitting also advances the expense to status "Paid". */
+    markAsPaid?: boolean;
 }
 
 interface PaymentFormState {
     payment_date: string;
     payment_ref: string;
+    invoice_date: string;
+    invoice_ref: string;
 }
 
 type AttachmentUpdateAction = "keep" | "replace" | "remove";
@@ -37,28 +42,94 @@ const ATTACHMENT_ACCEPTED_TYPES: AcceptedFileType[] = ["image/*", "application/p
 
 
 export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProps> = ({
-    isOpen, setIsOpen, expense, onSuccess
+    isOpen, setIsOpen, expense, onSuccess, markAsPaid = false
 }) => {
     const { toast } = useToast();
     const { updateDoc, loading: updateLoading } = useFrappeUpdateDoc();
     const { upload, loading: uploadLoading } = useFrappeFileUpload();
 
-    const [formState, setFormState] = useState<PaymentFormState>({ payment_date: "", payment_ref: "" });
+    const [formState, setFormState] = useState<PaymentFormState>({ payment_date: "", payment_ref: "", invoice_date: "", invoice_ref: "" });
     const [newAttachmentFile, setNewAttachmentFile] = useState<File | null>(null);
+    // Optional: attach the invoice here if the expense doesn't already have one.
+    const [newInvoiceFile, setNewInvoiceFile] = useState<File | null>(null);
     const [existingAttachmentUrl, setExistingAttachmentUrl] = useState<string | undefined>(undefined);
     const [attachmentAction, setAttachmentAction] = useState<AttachmentUpdateAction>("keep");
     const [formErrors, setFormErrors] = useState<Partial<PaymentFormState>>({});
+
+    // --- Payment-receipt AI auto-fill (same feature as the create dialog) ---
+    const { call: extractPaymentFields } = useFrappePostCall("nirmaan_stack.api.payment_autofill.extract_payment_fields");
+    const [isAutofilling, setIsAutofilling] = useState(false);
+    const [uploadedPaymentUrl, setUploadedPaymentUrl] = useState<string | null>(null);
+    const [autofilledFields, setAutofilledFields] = useState<Set<string>>(new Set());
+    const extractionSessionRef = useRef(0);
+    // Two-stage payment UX: "upload" shows only the receipt uploader; after a
+    // successful upload we advance to "form" and reveal Payment Date + Ref.
+    const [paymentStage, setPaymentStage] = useState<"upload" | "form">("upload");
+
+    const SUPPORTED_AUTOFILL_EXTS = ["pdf", "png", "jpg", "jpeg"];
+    const isSupportedForAutofill = (file: File) => {
+        const ext = file.name.split(".").pop()?.toLowerCase() || "";
+        return SUPPORTED_AUTOFILL_EXTS.includes(ext);
+    };
+
+    const runPaymentAutofill = useCallback(async (file: File) => {
+        const session = ++extractionSessionRef.current;
+        setIsAutofilling(true);
+        try {
+            const uploaded = await upload(file, {
+                doctype: "Non Project Expenses",
+                docname: expense.name,
+                fieldname: "payment_attachment",
+                isPrivate: true,
+            });
+            if (session !== extractionSessionRef.current) return;
+            setUploadedPaymentUrl(uploaded.file_url);
+
+            const res = await extractPaymentFields({ file_url: uploaded.file_url });
+            if (session !== extractionSessionRef.current) return;
+            const data = (res as any)?.message ?? res;
+
+            const filled = new Set<string>();
+            const updates: Partial<PaymentFormState> = {};
+            if (data?.utr) { updates.payment_ref = data.utr; filled.add("payment_ref"); }
+            if (data?.payment_date) { updates.payment_date = data.payment_date; filled.add("payment_date"); }
+            if (Object.keys(updates).length > 0) setFormState(prev => ({ ...prev, ...updates }));
+            setAutofilledFields(filled);
+
+            toast(
+                filled.size > 0
+                    ? { title: "Auto-filled from receipt", description: `Filled ${filled.size} field${filled.size > 1 ? "s" : ""}. Please verify.`, variant: "success" }
+                    : { title: "Couldn't auto-fill", description: "Please enter the payment details manually." }
+            );
+        } catch (e: any) {
+            if (session !== extractionSessionRef.current) return;
+            toast({ title: "Auto-fill failed", description: e?.message || "Please enter details manually.", variant: "destructive" });
+        } finally {
+            if (session === extractionSessionRef.current) {
+                setIsAutofilling(false);
+                setPaymentStage("form"); // reveal the fields (filled) after upload — success or not
+            }
+        }
+    }, [upload, extractPaymentFields, toast, expense.name]);
 
     useEffect(() => {
         if (isOpen && expense) {
             setFormState({
                 payment_date: expense.payment_date ? formatDateFns(new Date(expense.payment_date), "yyyy-MM-dd") : formatDateFns(new Date(), "yyyy-MM-dd"),
                 payment_ref: expense.payment_ref || "",
+                invoice_date: expense.invoice_date ? formatDateFns(new Date(expense.invoice_date), "yyyy-MM-dd") : "",
+                invoice_ref: expense.invoice_ref || "",
             });
             setExistingAttachmentUrl(expense.payment_attachment);
             setNewAttachmentFile(null);
+            setNewInvoiceFile(null);
             setAttachmentAction(expense.payment_attachment ? "keep" : "remove"); // If no existing, default to allow new upload (effectively 'remove' existing null)
             setFormErrors({});
+            setUploadedPaymentUrl(null);
+            setAutofilledFields(new Set());
+            setIsAutofilling(false);
+            // Start on the upload step unless the expense already has a payment receipt.
+            setPaymentStage(expense.payment_attachment ? "form" : "upload");
         }
     }, [isOpen, expense]);
 
@@ -68,11 +139,27 @@ export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProp
         if (formErrors[name as keyof PaymentFormState]) {
             setFormErrors(prev => ({ ...prev, [name]: undefined }));
         }
-    }, [formErrors]);
+        // If the user edits an auto-filled field, drop its amber tint.
+        if (autofilledFields.has(name)) {
+            setAutofilledFields(prev => { const next = new Set(prev); next.delete(name); return next; });
+        }
+    }, [formErrors, autofilledFields]);
 
     const handleNewFileSelected = (file: File | null) => {
         setNewAttachmentFile(file);
+        setUploadedPaymentUrl(null);
+        setAutofilledFields(new Set());
         setAttachmentAction(file ? "replace" : (existingAttachmentUrl ? "keep" : "remove"));
+        if (file) {
+            if (isSupportedForAutofill(file)) {
+                runPaymentAutofill(file); // uploads + extracts, then advances to "form"
+            } else {
+                setPaymentStage("form"); // unsupported for AI — go straight to manual entry
+            }
+        } else {
+            // Removed the staged file — back to the upload step (unless a saved file remains).
+            setPaymentStage(existingAttachmentUrl && attachmentAction !== "remove" ? "form" : "upload");
+        }
     };
 
     const handleRemoveExistingAttachment = () => {
@@ -84,10 +171,22 @@ export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProp
         toast({ title: "Attachment Error", description: message, variant: "destructive" });
     }, [toast]);
 
+    const hasPaymentAttachment = !!newAttachmentFile || !!uploadedPaymentUrl || (attachmentAction !== "remove" && !!existingAttachmentUrl);
+
     const validate = () => {
         const errors: Partial<PaymentFormState> = {};
         if (!formState.payment_date) errors.payment_date = "Payment date is required.";
+        // Mark as Paid requires a payment reference.
+        if (markAsPaid && !formState.payment_ref.trim()) errors.payment_ref = "Payment reference is required.";
+        // An invoice attachment (existing or newly staged) requires an Invoice Ref.
+        const hasInvoiceAttachment = !!newInvoiceFile || !!expense.invoice_attachment;
+        if (hasInvoiceAttachment && !formState.invoice_ref.trim()) errors.invoice_ref = "Invoice reference is required when an invoice is attached.";
         setFormErrors(errors);
+        // Mark as Paid requires a payment receipt (attachment).
+        if (markAsPaid && !hasPaymentAttachment) {
+            toast({ title: "Payment receipt required", description: "Please upload the payment receipt before marking as Paid.", variant: "destructive" });
+            return false;
+        }
         return Object.keys(errors).length === 0;
     };
 
@@ -100,22 +199,41 @@ export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProp
         const dataToUpdate: Partial<NonProjectExpenses> = {
             payment_date: formState.payment_date,
             payment_ref: formState.payment_ref.trim() || null,
+            invoice_date: formState.invoice_date || null,
+            invoice_ref: formState.invoice_ref.trim() || null,
         };
+        if (markAsPaid) {
+            dataToUpdate.status = "Paid";
+        }
 
         try {
             if (attachmentAction === "replace" && newAttachmentFile) {
-                const uploadedFile = await upload(newAttachmentFile, {
-                    doctype: "Non Project Expenses", docname: expense.name,
-                    fieldname: "payment_attachment", isPrivate: true,
-                });
-                dataToUpdate.payment_attachment = uploadedFile.file_url;
+                // Reuse the upload done during auto-fill if available (avoids re-uploading).
+                if (uploadedPaymentUrl) {
+                    dataToUpdate.payment_attachment = uploadedPaymentUrl;
+                } else {
+                    const uploadedFile = await upload(newAttachmentFile, {
+                        doctype: "Non Project Expenses", docname: expense.name,
+                        fieldname: "payment_attachment", isPrivate: true,
+                    });
+                    dataToUpdate.payment_attachment = uploadedFile.file_url;
+                }
             } else if (attachmentAction === "remove") {
                 dataToUpdate.payment_attachment = null;
             }
             // If action is "keep", payment_attachment is not added to dataToUpdate, so Frappe retains current value.
 
+            // Invoice attachment: upload the new / replacement file if the accountant added one.
+            if (newInvoiceFile) {
+                const uploadedInvoice = await upload(newInvoiceFile, {
+                    doctype: "Non Project Expenses", docname: expense.name,
+                    fieldname: "invoice_attachment", isPrivate: true,
+                });
+                dataToUpdate.invoice_attachment = uploadedInvoice.file_url;
+            }
+
             await updateDoc("Non Project Expenses", expense.name, dataToUpdate);
-            toast({ title: "Success", description: "Payment details updated.", variant: "success" });
+            toast({ title: "Success", description: markAsPaid ? "Expense marked Paid." : "Payment details updated.", variant: "success" });
             onSuccess?.();
             setIsOpen(false);
         } catch (error: any) {
@@ -123,99 +241,171 @@ export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProp
         }
     };
 
-    const isLoadingOverall = updateLoading || uploadLoading;
+    const isLoadingOverall = updateLoading || uploadLoading || isAutofilling;
 
-    // Determine what to display for current attachment
-    let currentAttachmentDisplay: React.ReactNode = null;
-    const effectiveExistingUrl = (attachmentAction === "keep" || attachmentAction === "replace") && existingAttachmentUrl;
+    // Existing saved attachment (shown unless a new file is staged or it's marked for removal).
+    const effectiveExistingUrl = (attachmentAction === "keep" || attachmentAction === "replace") ? existingAttachmentUrl : undefined;
 
-    if (newAttachmentFile) { // New file is staged
-        currentAttachmentDisplay = (
-            <div className="flex items-center justify-between p-2 bg-blue-50 dark:bg-blue-900/30 rounded-md text-sm border border-blue-200 dark:border-blue-700">
-                <div className="flex items-center gap-2 min-w-0">
-                    <Paperclip className="h-4 w-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
-                    <span className="truncate" title={newAttachmentFile.name}>{newAttachmentFile.name}</span>
-                    <span className="text-xs text-blue-500 dark:text-blue-500 ml-1 whitespace-nowrap">(New)</span>
-                </div>
-                {/* CustomAttachment handles its own X button for the new file */}
-            </div>
-        );
-    } else if (effectiveExistingUrl) { // Existing file is kept
-        currentAttachmentDisplay = (
-            <div className="flex items-center justify-between p-2 bg-muted/60 rounded-md text-sm">
-                <div className="flex items-center gap-2 min-w-0">
-                    <Download className="h-4 w-4 text-primary flex-shrink-0" />
-                    <a
-                        href={SITEURL + effectiveExistingUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="truncate hover:underline"
-                        title={`View ${effectiveExistingUrl.split('/').pop()}`}
-                    >
-                        {effectiveExistingUrl.split('/').pop()}
-                    </a>
-                </div>
-                <Button variant="ghost" size="icon" onClick={handleRemoveExistingAttachment} className="h-7 w-7 text-destructive hover:bg-destructive/10">
-                    <X className="h-4 w-4" />
-                    <span className="sr-only">Remove existing attachment</span>
-                </Button>
-            </div>
-        );
-    } else if (attachmentAction === "remove" && existingAttachmentUrl) { // Marked for removal (was existing)
-        currentAttachmentDisplay = (
-            <div className="flex items-center gap-2 p-2 bg-amber-50 dark:bg-amber-900/30 rounded-md text-sm text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-700">
-                <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-                <span>Attachment will be removed.</span>
-            </div>
-        );
-    }
+    const hasInvoiceAttachmentNow = !!newInvoiceFile || !!expense.invoice_attachment;
+    const isSubmitDisabled =
+        isLoadingOverall ||
+        paymentStage === "upload" ||
+        !formState.payment_date ||
+        (markAsPaid && !formState.payment_ref.trim()) ||
+        (markAsPaid && !hasPaymentAttachment) ||
+        (hasInvoiceAttachmentNow && !formState.invoice_ref.trim());
 
 
     return (
         <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Update Payment Details</AlertDialogTitle>
+                    <AlertDialogTitle>{markAsPaid ? "Record Payment & Mark as Paid" : "Update Payment Details"}</AlertDialogTitle>
                     <AlertDialogDescription>Expense ID: {expense.name}</AlertDialogDescription>
                     <Separator className="my-2" />
                 </AlertDialogHeader>
-                <div className="space-y-4 py-2">
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_date_update_pd" className="text-right col-span-1">Payment Date <sup className="text-destructive">*</sup></Label>
-                        <Input id="payment_date_update_pd" name="payment_date" type="date" value={formState.payment_date} onChange={handleInputChange} className="col-span-3" />
-                        {formErrors.payment_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
+
+                {/* Expense details, so the accountant has full context before paying */}
+                <div className="rounded-md border bg-muted/40 p-3 text-sm space-y-1.5">
+                    <div className="flex items-start justify-between gap-4">
+                        <span className="text-muted-foreground">Expense Type</span>
+                        <span className="font-medium text-right">{expense.type || "--"}</span>
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_ref_update_pd" className="text-right col-span-1">Payment Ref</Label>
-                        <Input id="payment_ref_update_pd" name="payment_ref" value={formState.payment_ref} onChange={handleInputChange} className="col-span-3" />
+                    <div className="flex items-start justify-between gap-4">
+                        <span className="text-muted-foreground">Amount</span>
+                        <span className="font-semibold text-right">{formatToRoundedIndianRupee(expense.amount)}</span>
+                    </div>
+                    <div className="flex items-start justify-between gap-4">
+                        <span className="text-muted-foreground">Description</span>
+                        <span className="font-medium text-right">{expense.description || "--"}</span>
+                    </div>
+                    {expense.comment && (
+                        <div className="flex items-start justify-between gap-4">
+                            <span className="text-muted-foreground">Comment</span>
+                            <span className="text-right">{expense.comment}</span>
+                        </div>
+                    )}
+                </div>
+
+                <div className="space-y-4 py-2">
+                    <p className="text-sm font-medium">Record Payment Details</p>
+                    {paymentStage === "form" && (
+                        <>
+                            <div className="grid grid-cols-4 items-center gap-4">
+                                <Label htmlFor="payment_date_update_pd" className="text-right col-span-1">Payment Date <sup className="text-destructive">*</sup></Label>
+                                <Input id="payment_date_update_pd" name="payment_date" type="date" value={formState.payment_date} onChange={handleInputChange} className={cn("col-span-3", autofilledFields.has("payment_date") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400")} />
+                                {formErrors.payment_date && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
+                            </div>
+                            <div className="grid grid-cols-4 items-center gap-4">
+                                <Label htmlFor="payment_ref_update_pd" className="text-right col-span-1">Payment Ref{markAsPaid && <sup className="text-destructive"> *</sup>}</Label>
+                                <Input id="payment_ref_update_pd" name="payment_ref" value={formState.payment_ref} onChange={handleInputChange} className={cn("col-span-3", autofilledFields.has("payment_ref") && "bg-amber-50 border-amber-300 focus-visible:ring-amber-400", ((markAsPaid && !formState.payment_ref.trim()) || formErrors.payment_ref) && "border-destructive")} />
+                                {((markAsPaid && !formState.payment_ref.trim()) || formErrors.payment_ref) && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.payment_ref || "Payment reference is required."}</p>}
+                            </div>
+                        </>
+                    )}
+
+                    <div className="space-y-2">
+                            {/* Existing saved receipt (hidden once a new file is staged) */}
+                            {effectiveExistingUrl && !newAttachmentFile && (
+                                <div className="flex items-center justify-between p-2 bg-muted/60 rounded-md text-sm">
+                                    <div className="flex items-center gap-2 min-w-0">
+                                        <Download className="h-4 w-4 text-primary flex-shrink-0" />
+                                        <a href={SITEURL + effectiveExistingUrl} target="_blank" rel="noopener noreferrer" className="truncate hover:underline" title={`View ${effectiveExistingUrl.split('/').pop()}`}>{effectiveExistingUrl.split('/').pop()}</a>
+                                    </div>
+                                    <Button variant="ghost" size="icon" onClick={handleRemoveExistingAttachment} className="h-7 w-7 text-destructive hover:bg-destructive/10" disabled={isLoadingOverall}><X className="h-4 w-4" /><span className="sr-only">Remove existing attachment</span></Button>
+                                </div>
+                            )}
+                            {attachmentAction === "remove" && existingAttachmentUrl && !newAttachmentFile && (
+                                <div className="flex items-center gap-2 p-2 bg-amber-50 dark:bg-amber-900/30 rounded-md text-sm text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-700">
+                                    <AlertTriangle className="h-4 w-4 flex-shrink-0" /><span>Attachment will be removed.</span>
+                                </div>
+                            )}
+                            {!isAutofilling && autofilledFields.size > 0 && (
+                                <div className="flex items-center gap-1.5 text-xs text-amber-800">
+                                    <Sparkles className="h-3.5 w-3.5" /> Auto-filled from receipt — please verify.
+                                </div>
+                            )}
+                            {paymentStage === "upload" ? (
+                                /* Stage 1 — big "Upload Payment Receipt" card (auto-fill), like the create dialog */
+                                <div className="rounded-lg border border-dashed p-3 space-y-2">
+                                    {isAutofilling ? (
+                                        <div className="flex flex-col items-center gap-3 py-6">
+                                            <Loader2 className="h-8 w-8 text-amber-600 animate-spin" />
+                                            <div className="text-center space-y-1">
+                                                <p className="text-sm font-medium text-slate-900 dark:text-slate-100">Reading your receipt…</p>
+                                                <p className="text-xs text-muted-foreground">AI is extracting payment details. This usually takes a few seconds.</p>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <>
+                                            <div className="text-center space-y-1">
+                                                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{effectiveExistingUrl ? "Replace Payment Receipt" : "Upload Payment Receipt"}</h3>
+                                                <p className="text-xs text-muted-foreground">We'll read the receipt and fill in Payment Ref and Payment Date for you.</p>
+                                            </div>
+                                            <CustomAttachment
+                                                label="Choose Receipt (PDF or image)"
+                                                selectedFile={newAttachmentFile}
+                                                onFileSelect={handleNewFileSelected}
+                                                onError={handleAttachmentError}
+                                                maxFileSize={5 * 1024 * 1024}
+                                                acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                                                disabled={isLoadingOverall}
+                                            />
+                                            <p className="text-[11px] text-center text-muted-foreground">Supported for auto-fill: PDF, PNG, JPG · max 5 MB</p>
+                                        </>
+                                    )}
+                                </div>
+                            ) : (
+                                /* Stage 2 — plain attachment control to view / replace the processed receipt */
+                                <CustomAttachment
+                                    label="Upload Payment Proof"
+                                    selectedFile={newAttachmentFile}
+                                    onFileSelect={handleNewFileSelected}
+                                    onError={handleAttachmentError}
+                                    maxFileSize={5 * 1024 * 1024}
+                                    acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                                    disabled={isLoadingOverall}
+                                />
+                            )}
                     </div>
 
+                    {/* Invoice Details — always shown (invoice can be recorded while paying). */}
+                    <Separator className="my-1" />
+                    <p className="text-sm font-medium">Invoice Details</p>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="invoice_date_pd" className="text-right col-span-1">Invoice Date</Label>
+                        <Input id="invoice_date_pd" name="invoice_date" type="date" value={formState.invoice_date} onChange={handleInputChange} max={formatDateFns(new Date(), "yyyy-MM-dd")} className="col-span-3" />
+                    </div>
+                    <div className="grid grid-cols-4 items-center gap-4">
+                        <Label htmlFor="invoice_ref_pd" className="text-right col-span-1">Invoice Ref</Label>
+                        <Input id="invoice_ref_pd" name="invoice_ref" value={formState.invoice_ref} onChange={handleInputChange} className={cn("col-span-3", formErrors.invoice_ref && "border-destructive")} />
+                        {formErrors.invoice_ref && <p className="col-span-3 col-start-2 text-xs text-destructive mt-1">{formErrors.invoice_ref}</p>}
+                    </div>
                     <div className="grid grid-cols-4 items-start gap-3">
-                        <Label className="text-right col-span-1 pt-2">Payment Attachment</Label>
+                        <Label className="text-right col-span-1 pt-2">Invoice Attachment</Label>
                         <div className="col-span-3 space-y-2">
-                            {currentAttachmentDisplay}
-                            {/* Show uploader if no new file is staged AND (either no existing file OR existing file is marked for removal) */}
-                            {(!newAttachmentFile && (attachmentAction === "remove" || !existingAttachmentUrl)) && (
-                                <CustomAttachment
-                                    label="Upload New Attachment"
-                                    selectedFile={newAttachmentFile} // Will be null here
-                                    onFileSelect={handleNewFileSelected}
-                                    onError={handleAttachmentError}
-                                    maxFileSize={5 * 1024 * 1024}
-                                    acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
-                                />
+                            {expense.invoice_attachment && !newInvoiceFile && (
+                                <div className="flex items-center gap-2 p-2 bg-muted/60 rounded-md text-sm">
+                                    <Download className="h-4 w-4 text-primary flex-shrink-0" />
+                                    <a
+                                        href={SITEURL + expense.invoice_attachment}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="truncate hover:underline"
+                                        title={`View ${expense.invoice_attachment.split('/').pop()}`}
+                                    >
+                                        {expense.invoice_attachment.split('/').pop()}
+                                    </a>
+                                </div>
                             )}
-                            {/* Show uploader to replace if an existing file is present and not marked for removal, and no new file is staged */}
-                            {!newAttachmentFile && existingAttachmentUrl && attachmentAction === "keep" && (
-                                <CustomAttachment
-                                    label="Replace Attachment"
-                                    selectedFile={null} // Pass null to indicate it's for replacement
-                                    onFileSelect={handleNewFileSelected}
-                                    onError={handleAttachmentError}
-                                    maxFileSize={5 * 1024 * 1024}
-                                    acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
-                                />
-                            )}
+                            <CustomAttachment
+                                label={expense.invoice_attachment ? "Replace Invoice Attachment" : "Upload Invoice Attachment"}
+                                selectedFile={newInvoiceFile}
+                                onFileSelect={setNewInvoiceFile}
+                                onError={handleAttachmentError}
+                                maxFileSize={5 * 1024 * 1024}
+                                acceptedTypes={ATTACHMENT_ACCEPTED_TYPES}
+                            />
                         </div>
                     </div>
                 </div>
@@ -223,7 +413,7 @@ export const UpdatePaymentDetailsDialog: React.FC<UpdatePaymentDetailsDialogProp
                     {isLoadingOverall ? <div className="flex justify-center w-full"><TailSpin color="#4f46e5" height={24} width={24} /></div> : (
                         <>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
-                            <AlertDialogAction onClick={handleSubmit}>Save Changes</AlertDialogAction>
+                            <AlertDialogAction onClick={handleSubmit} disabled={isSubmitDisabled}>{markAsPaid ? "Mark as Paid" : "Save Changes"}</AlertDialogAction>
                         </>
                     )}
                 </AlertDialogFooter>

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
@@ -431,7 +431,9 @@ export const getNonProjectExpenseColumns = ({
 
   return [
     typeColumn,
-    ...(statusTab === "All" ? [statusColumn] : []),
+    // Status column only on the standalone All tab; report mode (disableActions)
+    // is Paid-only, so the column would be redundant.
+    ...(statusTab === "All" && !disableActions ? [statusColumn] : []),
     descriptionColumn,
     commentColumn,
     amountColumn,

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
@@ -1,0 +1,449 @@
+// src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+//
+// Column definitions for the Non Project Expenses table, consumed by
+// NonProjectExpensesPage.tsx via `getNonProjectExpenseColumns(...)`.
+//
+// Mirrors the Project Expenses workflow (Requested -> Approved -> Paid) with an
+// invoice/payment role split:
+//   - Requested -> creator records Invoice Details, Admin approves
+//   - Approved  -> Accountant records Payment Details + marks Paid
+//   - Paid      -> settled
+//
+// Column visibility is driven by the active status tab:
+//   - "Status"                     -> only on the "All" tab
+//   - "Payment Date" / "Payment Ref" -> only on the "Paid" and "All" tabs
+// Row actions are derived from each row's own status (so the mixed-status "All"
+// tab renders correct actions per row).
+
+import { ColumnDef } from "@tanstack/react-table";
+import {
+  FileText,
+  CheckCircle2,
+  IndianRupee,
+  Pencil,
+  Trash2,
+  Download,
+  MoreHorizontal,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { formatDate } from "@/utils/FormatDate";
+import {
+  formatForReport,
+  formatToRoundedIndianRupee,
+} from "@/utils/FormatPrice";
+import { cn } from "@/lib/utils";
+import SITEURL from "@/constants/siteURL";
+import { NonProjectExpenses } from "@/types/NirmaanStack/NonProjectExpenses";
+
+export interface GetNonProjectExpenseColumnsOptions {
+  statusTab: string;
+  role?: string;
+  getUserName: (id?: string) => string;
+  /** Report/embedded mode: hide the Actions column entirely. */
+  disableActions?: boolean;
+  onEdit: (expense: NonProjectExpenses) => void;
+  onApprove: (expense: NonProjectExpenses) => void;
+  onRecordInvoice: (expense: NonProjectExpenses) => void;
+  onMarkPaid: (expense: NonProjectExpenses) => void;
+  onDelete: (expense: NonProjectExpenses) => void;
+}
+
+const STATUS_BADGE_STYLES: Record<string, string> = {
+  Requested: "bg-amber-100 text-amber-700",
+  Approved: "bg-sky-100 text-sky-700",
+  Paid: "bg-green-100 text-green-700",
+};
+
+export const getNonProjectExpenseColumns = ({
+  statusTab,
+  role,
+  getUserName,
+  disableActions = false,
+  onEdit,
+  onApprove,
+  onRecordInvoice,
+  onMarkPaid,
+  onDelete,
+}: GetNonProjectExpenseColumnsOptions): ColumnDef<NonProjectExpenses>[] => {
+  // --- Role gating (frontend-only enforcement, mirrors Project Expenses) ---
+  const isAdmin = role === "Nirmaan Admin Profile";
+  const isPMO = role === "Nirmaan PMO Executive Profile";
+  // Accountant Lead mirrors Accountant for role checks (parity by design).
+  const isAccountant =
+    role === "Nirmaan Accountant Profile" ||
+    role === "Nirmaan Accountant Lead Profile";
+  const isProcurement = role === "Nirmaan Procurement Executive Profile";
+  const isHR = role === "Nirmaan HR Executive Profile";
+
+  // Action-level permissions
+  // Requested-stage work (Record Invoice + Edit) is open to the broader creation set
+  // (Admin, PMO, Accountant/Lead, Procurement, HR) — mirrors Project Expenses.
+  const canRecordInvoice =
+    isAdmin || isPMO || isAccountant || isProcurement || isHR;
+  const canApprove = isAdmin; // Requested -> Approved (Admin only)
+  const canMarkPaid = isAdmin || isAccountant; // Approved -> Paid (records payment)
+  const canEdit = isAdmin || isPMO || isProcurement || isHR; // Requested-row edit
+  const canDelete = isAdmin; // Delete is Admin only
+
+  // Actions column visibility: shown only to users who can act on the tab's rows.
+  // Requested/Approved show it to everyone (gated per button); Paid/All -> Admin only.
+  // In report/embedded mode the Actions column is hidden entirely.
+  const canSeeActionsColumn = disableActions
+    ? false
+    : statusTab === "Paid" || statusTab === "All"
+      ? isAdmin
+      : true;
+
+  // Invoice Ref opens the invoice attachment — only on the Paid and All tabs.
+  const invoiceRefClickable = statusTab === "Paid" || statusTab === "All";
+
+  const statusColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "status",
+    header: "Status",
+    size: 130,
+    enableColumnFilter: true,
+    cell: ({ row }) => {
+      const status = row.original.status || "Requested";
+      return (
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+            STATUS_BADGE_STYLES[status] || "bg-gray-100 text-gray-700"
+          )}
+        >
+          {status}
+        </span>
+      );
+    },
+    meta: {
+      exportHeaderName: "Status",
+      exportValue: (row: NonProjectExpenses) => row.status || "Requested",
+    },
+  };
+
+  const typeColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "type",
+    size: 150,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Expense Type" />
+    ),
+    cell: ({ row }) => (
+      <div className="truncate font-medium" title={row.original.type}>
+        {row.original.type || "--"}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: {
+      exportHeaderName: "Expense Type",
+      exportValue: (row: NonProjectExpenses) => row.type,
+    },
+  };
+
+  const descriptionColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "description",
+    size: 200,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Description" />
+    ),
+    cell: ({ row }) => (
+      <div className="truncate" title={row.original.description}>
+        {row.original.description || "--"}
+      </div>
+    ),
+    meta: {
+      exportHeaderName: "Description",
+      exportValue: (row: NonProjectExpenses) => row.description || "--",
+    },
+  };
+
+  const commentColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "comment",
+    size: 180,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Comment" />
+    ),
+    cell: ({ row }) => (
+      <div className="truncate" title={row.original.comment}>
+        {row.original.comment || "--"}
+      </div>
+    ),
+    meta: {
+      exportHeaderName: "Comment",
+      exportValue: (row: NonProjectExpenses) => row.comment || "--",
+    },
+  };
+
+  const amountColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "amount",
+    size: 130,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Amount"
+        className="justify-end"
+      />
+    ),
+    cell: ({ row }) => {
+      const amount = row.original.amount;
+      return (
+        <div
+          className={cn(
+            "font-medium pr-2",
+            amount < 0 && "text-green-600 dark:text-green-400"
+          )}
+        >
+          {formatToRoundedIndianRupee(amount)}
+        </div>
+      );
+    },
+    meta: {
+      exportHeaderName: "Amount",
+      exportValue: (row: NonProjectExpenses) => formatForReport(row.amount),
+    },
+  };
+
+  const invoiceDateColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "invoice_date",
+    size: 140,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Invoice Date" />
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium">
+        {row.original.invoice_date ? formatDate(row.original.invoice_date) : "--"}
+      </div>
+    ),
+    meta: {
+      exportHeaderName: "Invoice Date",
+      exportValue: (row: NonProjectExpenses) =>
+        row.invoice_date ? formatDate(row.invoice_date) : "--",
+    },
+  };
+
+  const invoiceRefColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "invoice_ref",
+    size: 150,
+    header: "Invoice Ref",
+    cell: ({ row }) => {
+      const ref = row.original.invoice_ref;
+      const attachment = row.original.invoice_attachment;
+      // On the Paid/All tabs, link the ref to the invoice attachment (opens in a new tab).
+      if (invoiceRefClickable && attachment && ref) {
+        return (
+          <a
+            href={SITEURL + attachment}
+            target="_blank"
+            rel="noreferrer"
+            title={`Open invoice ${ref}`}
+            className="block truncate font-medium text-blue-600 underline hover:text-blue-800"
+          >
+            {ref}
+          </a>
+        );
+      }
+      return (
+        <div className="font-medium truncate" title={ref}>
+          {ref || "--"}
+        </div>
+      );
+    },
+    meta: {
+      exportHeaderName: "Invoice Ref",
+      exportValue: (row: NonProjectExpenses) => row.invoice_ref || "--",
+    },
+  };
+
+  const paymentDateColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "payment_date",
+    size: 140,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Payment Date" />
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium">
+        {row.original.payment_date ? formatDate(row.original.payment_date) : "--"}
+      </div>
+    ),
+    meta: {
+      exportHeaderName: "Payment Date",
+      exportValue: (row: NonProjectExpenses) =>
+        row.payment_date ? formatDate(row.payment_date) : "--",
+    },
+  };
+
+  const paymentRefColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "payment_ref",
+    size: 150,
+    header: "Payment Ref",
+    cell: ({ row }) => (
+      <div className="font-medium truncate" title={row.original.payment_ref}>
+        {row.original.payment_ref || "--"}
+      </div>
+    ),
+    meta: {
+      exportHeaderName: "Payment Ref",
+      exportValue: (row: NonProjectExpenses) => row.payment_ref || "--",
+    },
+  };
+
+  const createdByColumn: ColumnDef<NonProjectExpenses> = {
+    accessorKey: "owner",
+    header: "Created By",
+    size: 160,
+    cell: ({ row }) => (
+      <div className="truncate" title={getUserName(row.original.owner)}>
+        {getUserName(row.original.owner)}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: {
+      exportHeaderName: "Created By",
+      exportValue: (row: NonProjectExpenses) => getUserName(row.owner),
+    },
+  };
+
+  const invoiceAttachColumn: ColumnDef<NonProjectExpenses> = {
+    id: "invoice_attach",
+    header: "Inv. Attach",
+    size: 110,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const url = row.original.invoice_attachment;
+      return url ? (
+        <a
+          href={SITEURL + url}
+          target="_blank"
+          rel="noreferrer"
+          title="Invoice Document"
+          className="inline-flex items-center gap-1 rounded bg-green-50 px-1.5 py-0.5 text-xs font-medium text-green-700 hover:underline"
+        >
+          <FileText className="h-3.5 w-3.5" /> View
+        </a>
+      ) : (
+        <span className="text-xs text-muted-foreground">--</span>
+      );
+    },
+    meta: { excludeFromExport: true },
+  };
+
+  const paymentAttachColumn: ColumnDef<NonProjectExpenses> = {
+    id: "payment_attach",
+    header: "Pay. Attach",
+    size: 110,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const url = row.original.payment_attachment;
+      return url ? (
+        <a
+          href={SITEURL + url}
+          target="_blank"
+          rel="noreferrer"
+          title="Payment Proof"
+          className="inline-flex items-center gap-1 rounded bg-blue-50 px-1.5 py-0.5 text-xs font-medium text-blue-700 hover:underline"
+        >
+          <Download className="h-3.5 w-3.5" /> View
+        </a>
+      ) : (
+        <span className="text-xs text-muted-foreground">--</span>
+      );
+    },
+    meta: { excludeFromExport: true },
+  };
+
+  const actionsColumn: ColumnDef<NonProjectExpenses> = {
+    id: "actions",
+    size: 90,
+    enableSorting: false,
+    header: () => <div className="text-right">Actions</div>,
+    cell: ({ row }) => {
+      const expense = row.original;
+      const status = expense.status || "Requested";
+      return (
+        <div className="text-right">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0">
+                <span className="sr-only">Open menu</span>
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {status === "Requested" && (
+                <>
+                  {canRecordInvoice && (
+                    <DropdownMenuItem onClick={() => onRecordInvoice(expense)}>
+                      <FileText className="mr-2 h-4 w-4" /> Record Invoice
+                    </DropdownMenuItem>
+                  )}
+                  {canApprove && (
+                    <DropdownMenuItem onClick={() => onApprove(expense)}>
+                      <CheckCircle2 className="mr-2 h-4 w-4" /> Approve
+                    </DropdownMenuItem>
+                  )}
+                  {canEdit && (
+                    <DropdownMenuItem onClick={() => onEdit(expense)}>
+                      <Pencil className="mr-2 h-4 w-4" /> Edit
+                    </DropdownMenuItem>
+                  )}
+                </>
+              )}
+
+              {status === "Approved" && canMarkPaid && (
+                <DropdownMenuItem onClick={() => onMarkPaid(expense)}>
+                  <IndianRupee className="mr-2 h-4 w-4" /> Mark as Paid
+                </DropdownMenuItem>
+              )}
+
+              {/* A Paid expense can only be edited by an Admin */}
+              {status === "Paid" && isAdmin && (
+                <DropdownMenuItem onClick={() => onEdit(expense)}>
+                  <Pencil className="mr-2 h-4 w-4" /> Edit
+                </DropdownMenuItem>
+              )}
+
+              {canDelete && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => onDelete(expense)}
+                    className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" /> Delete
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      );
+    },
+    meta: { excludeFromExport: true },
+  };
+
+  return [
+    typeColumn,
+    ...(statusTab === "All" ? [statusColumn] : []),
+    descriptionColumn,
+    commentColumn,
+    amountColumn,
+    invoiceDateColumn,
+    invoiceRefColumn,
+    // Inv. Attach only on tabs where Invoice Ref is NOT the clickable link (Requested/Approved);
+    // on Paid/All the clickable Invoice Ref already opens the invoice attachment.
+    ...(!invoiceRefClickable ? [invoiceAttachColumn] : []),
+    ...(statusTab === "Paid" || statusTab === "All"
+      ? [paymentDateColumn, paymentRefColumn, paymentAttachColumn]
+      : []),
+    createdByColumn,
+    ...(canSeeActionsColumn ? [actionsColumn] : []),
+  ];
+};

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
@@ -101,7 +101,11 @@ export const getNonProjectExpenseColumns = ({
     ? false
     : statusTab === "Paid" || statusTab === "All"
       ? isAdmin
-      : true;
+      // Approved tab: Procurement/HR have no available action here (Mark-as-Paid
+      // is Admin/Accountant), so hide the empty Actions column for them.
+      : statusTab === "Approved" && (isProcurement || isHR)
+        ? false
+        : true;
 
   // Invoice Ref opens the invoice attachment — only on the Paid and All tabs.
   const invoiceRefClickable = statusTab === "Paid" || statusTab === "All";

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
@@ -35,6 +35,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { facetMeta } from "@/components/data-table/facetConfig";
 import { formatDate } from "@/utils/FormatDate";
 import {
   formatForReport,
@@ -129,6 +130,7 @@ export const getNonProjectExpenseColumns = ({
       );
     },
     meta: {
+      ...facetMeta({ field: "status", title: "Status" }),
       exportHeaderName: "Status",
       exportValue: (row: NonProjectExpenses) => row.status || "Requested",
     },
@@ -147,6 +149,7 @@ export const getNonProjectExpenseColumns = ({
     ),
     enableColumnFilter: true,
     meta: {
+      ...facetMeta({ field: "type", title: "Expense Type" }),
       exportHeaderName: "Expense Type",
       exportValue: (row: NonProjectExpenses) => row.type,
     },
@@ -310,6 +313,7 @@ export const getNonProjectExpenseColumns = ({
     ),
     enableColumnFilter: true,
     meta: {
+      ...facetMeta({ field: "owner", title: "Created By" }),
       exportHeaderName: "Created By",
       exportValue: (row: NonProjectExpenses) => getUserName(row.owner),
     },

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesColumns.tsx
@@ -31,9 +31,14 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { facetMeta } from "@/components/data-table/facetConfig";
 import { formatDate } from "@/utils/FormatDate";
@@ -367,34 +372,105 @@ export const getNonProjectExpenseColumns = ({
     meta: { excludeFromExport: true },
   };
 
+  // Actions layout (per row status): primary actions render inline ("outside"),
+  // secondary actions stay in the "..." overflow menu.
+  //   - Requested -> outside: Approve, Delete;  "...": Record Invoice, Edit
+  //   - Approved  -> outside: Mark as Paid, Delete   (no "..." menu)
+  //   - Paid      -> outside: Edit, Delete           (no "..." menu)
+  // The "All" tab renders these per row off each row's own status.
   const actionsColumn: ColumnDef<NonProjectExpenses> = {
     id: "actions",
-    size: 90,
+    size: 140,
     enableSorting: false,
-    header: () => <div className="text-right">Actions</div>,
+    header: () => <div className="text-center">Actions</div>,
     cell: ({ row }) => {
       const expense = row.original;
       const status = expense.status || "Requested";
+      // Overflow "..." holds the secondary Requested-stage actions only.
+      const hasOverflow =
+        status === "Requested" && (canRecordInvoice || canEdit);
+
       return (
-        <div className="text-right">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
-                <span className="sr-only">Open menu</span>
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {status === "Requested" && (
-                <>
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center justify-center gap-1">
+            {/* Requested -> Approve (outside) */}
+            {status === "Requested" && canApprove && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 w-8 p-0 text-green-600 hover:text-green-700"
+                    onClick={() => onApprove(expense)}
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Approve</TooltipContent>
+              </Tooltip>
+            )}
+
+            {/* Approved -> Mark as Paid (outside, green labeled) */}
+            {status === "Approved" && canMarkPaid && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    className="h-7 px-2 text-xs bg-green-600 text-white hover:bg-green-700"
+                    onClick={() => onMarkPaid(expense)}
+                  >
+                    <IndianRupee className="mr-1 h-3 w-3" />
+                    Mark as Paid
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Mark as Paid</TooltipContent>
+              </Tooltip>
+            )}
+
+            {/* Paid -> Edit (outside, Admin only) */}
+            {status === "Paid" && isAdmin && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 w-8 p-0"
+                    onClick={() => onEdit(expense)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Edit</TooltipContent>
+              </Tooltip>
+            )}
+
+            {/* Delete is an outside button on every status */}
+            {canDelete && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                    onClick={() => onDelete(expense)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Delete</TooltipContent>
+              </Tooltip>
+            )}
+
+            {/* Overflow "..." — Requested rows only: Record Invoice + Edit */}
+            {hasOverflow && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="h-8 w-8 p-0">
+                    <span className="sr-only">Open menu</span>
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
                   {canRecordInvoice && (
                     <DropdownMenuItem onClick={() => onRecordInvoice(expense)}>
                       <FileText className="mr-2 h-4 w-4" /> Record Invoice
-                    </DropdownMenuItem>
-                  )}
-                  {canApprove && (
-                    <DropdownMenuItem onClick={() => onApprove(expense)}>
-                      <CheckCircle2 className="mr-2 h-4 w-4" /> Approve
                     </DropdownMenuItem>
                   )}
                   {canEdit && (
@@ -402,36 +478,11 @@ export const getNonProjectExpenseColumns = ({
                       <Pencil className="mr-2 h-4 w-4" /> Edit
                     </DropdownMenuItem>
                   )}
-                </>
-              )}
-
-              {status === "Approved" && canMarkPaid && (
-                <DropdownMenuItem onClick={() => onMarkPaid(expense)}>
-                  <IndianRupee className="mr-2 h-4 w-4" /> Mark as Paid
-                </DropdownMenuItem>
-              )}
-
-              {/* A Paid expense can only be edited by an Admin */}
-              {status === "Paid" && isAdmin && (
-                <DropdownMenuItem onClick={() => onEdit(expense)}>
-                  <Pencil className="mr-2 h-4 w-4" /> Edit
-                </DropdownMenuItem>
-              )}
-
-              {canDelete && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => onDelete(expense)}
-                    className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" /> Delete
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        </TooltipProvider>
       );
     },
     meta: { excludeFromExport: true },

--- a/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesTable.config.ts
+++ b/frontend/src/pages/NonProjectExpenses/config/nonProjectExpensesTable.config.ts
@@ -8,6 +8,7 @@ export const DEFAULT_NPE_FIELDS_TO_FETCH: (keyof NonProjectExpenses | 'name' | '
     "creation",
     "modified",
     "owner",
+    "status",
     "type",
     "description",
     "comment",

--- a/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
+++ b/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
@@ -14,12 +14,6 @@ import {
   getUrlStringParam,
 } from "@/hooks/useServerDataTable";
 
-import { FacetDeclaration } from "@/components/data-table/facetConfig";
-import { formatDate } from "@/utils/FormatDate";
-import {
-  formatForReport,
-  formatToRoundedIndianRupee,
-} from "@/utils/FormatPrice";
 import { urlStateManager } from "@/utils/urlStateManager";
 import memoize from "lodash/memoize";
 import { cn } from "@/lib/utils";
@@ -324,6 +318,13 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
     return filters;
   }, [projectId, effectiveStatusTab]);
 
+  // --- Project-scoped static filters for facet value lists (tab-independent) ---
+  const staticFilters = useMemo(() => {
+    const filters: any[] = [];
+    if (projectId) filters.push(["projects", "=", projectId]);
+    return filters;
+  }, [projectId]);
+
   // --- Per-status counts for the tab badges (project-scoped) ---
   const { data: requestedCount, mutate: mutateRequested } = useFrappeGetDocCount(
     DOCTYPE,
@@ -361,7 +362,6 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   // --- Data Table Hook (MOVED UP) ---
   const {
     table,
-    data,
     totalCount,
     isLoading,
     error,
@@ -458,6 +458,8 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
           vendor: { additionalFilters: staticFilters },
           payment_by: { additionalFilters: staticFilters },
           type: { additionalFilters: staticFilters },
+          owner: { additionalFilters: staticFilters },
+          status: { additionalFilters: staticFilters },
         }}
         showExportButton={true}
         onExport="default"

--- a/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
+++ b/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
@@ -1,9 +1,8 @@
 // src/pages/ProjectExpenses/ProjectExpensesList.tsx
 
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useMemo, useState, useCallback, useEffect } from "react";
 import { ColumnDef, Row } from "@tanstack/react-table";
-import { Link } from "react-router-dom";
-import { useFrappeDeleteDoc, useFrappeGetDocList } from "frappe-react-sdk";
+import { useFrappeDeleteDoc, useFrappeGetDocCount, useFrappeGetDocList, useFrappeUpdateDoc } from "frappe-react-sdk";
 import { useToast } from "@/components/ui/use-toast";
 import { useDialogStore } from "@/zustand/useDialogStore";
 import { useUserData } from "@/hooks/useUserData";
@@ -12,13 +11,16 @@ import {
   useServerDataTable,
   AggregationConfig,
   GroupByConfig,
+  getUrlStringParam,
 } from "@/hooks/useServerDataTable";
+
 import { FacetDeclaration } from "@/components/data-table/facetConfig";
 import { formatDate } from "@/utils/FormatDate";
 import {
   formatForReport,
   formatToRoundedIndianRupee,
 } from "@/utils/FormatPrice";
+import { urlStateManager } from "@/utils/urlStateManager";
 import memoize from "lodash/memoize";
 import { cn } from "@/lib/utils";
 import { CEO_HOLD_ROW_CLASSES } from "@/utils/ceoHoldRowStyles";
@@ -37,14 +39,13 @@ import {
   PE_DATE_COLUMNS,
   DOCTYPE,
 } from "./config/projectExpensesTable.config";
+import { getProjectExpenseColumns } from "./config/projectExpensesColumns";
 import { NewProjectExpenseDialog } from "./components/NewProjectExpenseDialog";
 import { EditProjectExpenseDialog } from "./components/EditProjectExpenseDialog";
 import { ProjectExpenseSummaryCard } from "./components/ProjectExpenseSummaryCard";
 
 // UI Components
 import { DataTable } from "@/components/data-table/new-data-table";
-import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { Button } from "@/components/ui/button";
 import { AlertDestructive } from "@/components/layout/alert-banner/error-alert";
 import {
   AlertDialog,
@@ -56,13 +57,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Edit2, MoreHorizontal, PlusCircle, Trash2 } from "lucide-react";
 
 interface ProjectExpensesListProps {
   projectId?: string; // Optional: To filter by a specific project
@@ -81,14 +75,19 @@ const PE_GROUP_BY_CONFIG: GroupByConfig = {
   limit: 5,
 };
 
+// URL param key for the active status workflow tab. Namespaced ("pe_status") so
+// it never collides with the project page's own ?tab=/?page= params when this
+// list is embedded as a project tab.
+const PE_STATUS_TAB_PARAM = "pe_status";
+
 export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   projectId,
 }) => {
-  const { toggleNewProjectExpenseDialog, setEditProjectExpenseDialog } =
-    useDialogStore();
+  const { setEditProjectExpenseDialog } = useDialogStore();
   const { toast } = useToast();
   const { role } = useUserData();
   const { deleteDoc, loading: deleteLoading } = useFrappeDeleteDoc();
+  const { updateDoc, loading: updateLoading } = useFrappeUpdateDoc();
   const { ceoHoldProjectIds } = useCEOHoldProjects();
 
   // CEO Hold row highlighting
@@ -109,6 +108,39 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   const [expenseToDelete, setExpenseToDelete] =
     useState<ProjectExpenses | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  // Default tab is role-based: Accountant (and Lead) land on "Approved", everyone
+  // else (Admin included) on "Requested". A URL param (deep link / reload) overrides it.
+  const isAccountantUser =
+    role === "Nirmaan Accountant Profile" ||
+    role === "Nirmaan Accountant Lead Profile";
+  const defaultStatusTab = isAccountantUser ? "Approved" : "Requested";
+  const [statusTab, setStatusTab] = useState<string>(() =>
+    getUrlStringParam(PE_STATUS_TAB_PARAM, defaultStatusTab)
+  );
+  const [statusAction, setStatusAction] = useState<{
+    expense: ProjectExpenses;
+    next: "Approved" | "Paid";
+  } | null>(null);
+  const [markPaidMode, setMarkPaidMode] = useState(false);
+
+  // --- Keep the active status tab in sync with the URL (deep-link + back/forward) ---
+  // Persist tab -> URL (replaceState, so it doesn't pollute browser history).
+  useEffect(() => {
+    if (urlStateManager.getParam(PE_STATUS_TAB_PARAM) !== statusTab) {
+      urlStateManager.updateParam(PE_STATUS_TAB_PARAM, statusTab);
+    }
+  }, [statusTab]);
+  // React to URL -> tab changes (back/forward navigation, external deep links).
+  useEffect(() => {
+    const unsubscribe = urlStateManager.subscribe(
+      PE_STATUS_TAB_PARAM,
+      (_, value) => {
+        const next = value || defaultStatusTab;
+        setStatusTab((prev) => (prev !== next ? next : prev));
+      }
+    );
+    return unsubscribe;
+  }, [defaultStatusTab]);
 
   // --- Supporting Data for Lookups ---
   const { data: projects, isLoading: projectsLoading } =
@@ -172,6 +204,7 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   const handleOpenEditDialog = useCallback(
     (expense: ProjectExpenses) => {
       setExpenseToEdit(expense);
+      setMarkPaidMode(false);
       setEditProjectExpenseDialog(true);
     },
     [setEditProjectExpenseDialog]
@@ -180,6 +213,20 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
     setExpenseToDelete(expense);
     setIsDeleteDialogOpen(true);
   }, []);
+  const handleOpenStatusDialog = useCallback(
+    (expense: ProjectExpenses, next: "Approved" | "Paid") => {
+      setStatusAction({ expense, next });
+    },
+    []
+  );
+  const handleOpenMarkPaid = useCallback(
+    (expense: ProjectExpenses) => {
+      setExpenseToEdit(expense);
+      setMarkPaidMode(true);
+      setEditProjectExpenseDialog(true);
+    },
+    [setEditProjectExpenseDialog]
+  );
 
   const confirmDelete = async () => {
     if (!expenseToDelete) return;
@@ -203,178 +250,100 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
     }
   };
 
-  const columns = useMemo<ColumnDef<ProjectExpenses>[]>(
-    () => [
-      // --- (Indicator) MODIFIED: Project column is now conditional ---
-      ...(!projectId
-        ? [
-          {
-            accessorKey: "projects",
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title="Project" />
-            ),
-            cell: ({ row }) => (
-              <Link
-                to={`/projects/${row.original.projects}`}
-                className="text-blue-600 hover:underline"
-              >
-                {getProjectName(row.original.projects)}
-              </Link>
-            ),
-            enableColumnFilter: true,
-            meta: {
-              facet: { field: "projects", title: "Project" } satisfies FacetDeclaration,
-              exportValue: (row) => getProjectName(row.projects),
-            },
-          } as ColumnDef<ProjectExpenses>,
-        ]
-        : []),
-      {
-        accessorKey: "payment_date",
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Payment Date" />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium">
-            {formatDate(row.original.payment_date)}
-          </div>
-        ),
-      },
-      {
-        accessorKey: "type",
-        header: "Expense Type",
-        cell: ({ row }) => (
-          <div
-            className="truncate"
-            title={row.original.expense_type_name || row.original.type}
-          >
-            {row.original.expense_type_name || row.original.type}
-          </div>
-        ),
-        meta: {
-          facet: { field: "type", title: "Expense Type" } satisfies FacetDeclaration,
-          exportValue: (row) => row.expense_type_name || row.type,
-        },
-        enableColumnFilter: true,
-      },
-      {
-        accessorKey: "description",
-        header: "Description",
-        cell: ({ row }) => (
-          <div className="truncate max-w-xs" title={row.original.description}>
-            {row.original.description}
-          </div>
-        ),
-      },
-      {
-        accessorKey: "comment",
-        header: "Comment",
-        cell: ({ row }) => (
-          <div className="truncate max-w-xs" title={row.original.comment}>
-            {row.original.comment}
-          </div>
-        ),
-      },
-      {
-        accessorKey: "vendor",
-        header: "Vendor",
-        cell: ({ row }) => (
-          <div className="truncate" title={getVendorName(row.original.vendor)}>
-            {getVendorName(row.original.vendor)}
-          </div>
-        ),
-        meta: {
-          facet: { field: "vendor", title: "Vendor" } satisfies FacetDeclaration,
-          exportValue: (row) => getVendorName(row.vendor),
-        },
-        enableColumnFilter: true,
-      },
-      {
-        accessorKey: "amount",
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title="Amount"
-            className="justify-center"
-          />
-        ),
-        cell: ({ row }) => (
-          <div className="font-medium pr-2">
-            {formatToRoundedIndianRupee(row.original.amount)}
-          </div>
-        ),
-        meta: { exportValue: (row) => formatForReport(row.amount) },
-      },
-      {
-        accessorKey: "payment_by",
-        header: "Payment By",
-        cell: ({ row }) => (
-          <div
-            className="truncate"
-            title={getUserName(row.original.payment_by)}
-          >
-            {getUserName(row.original.payment_by)}
-          </div>
-        ),
-        meta: {
-          facet: { field: "payment_by", title: "Requested By" } satisfies FacetDeclaration,
-          exportValue: (row) => getUserName(row.payment_by),
-        },
-        enableColumnFilter: true,
-      },
+  const confirmStatusChange = async () => {
+    if (!statusAction) return;
+    try {
+      await updateDoc(DOCTYPE, statusAction.expense.name, {
+        status: statusAction.next,
+      });
+      toast({
+        title: "Success",
+        description: `Expense marked ${statusAction.next}.`,
+        variant: "success",
+      });
+      refetch();
+      mutateRequested();
+      mutateApproved();
+      mutatePaid();
+    } catch (error: any) {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to update status.",
+        variant: "destructive",
+      });
+    } finally {
+      setStatusAction(null);
+    }
+  };
 
-      {
-        id: "actions",
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title="Actions"
-            className="text-center"
-          />
-        ),
-        cell: ({ row }) => (
-          <div className="">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="h-8 w-8 p-0">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => handleOpenEditDialog(row.original)}
-                >
-                  <Edit2 className="mr-2 h-4 w-4" />
-                  Edit
-                </DropdownMenuItem>
-                {(role === "Nirmaan Admin Profile" ||
-                  role === "Nirmaan PMO Executive Profile") && (
-                    <DropdownMenuItem
-                      onClick={() => handleOpenDeleteDialog(row.original)}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Delete
-                    </DropdownMenuItem>
-                  )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        ),
-        meta: {
-          excludeFromExport: true, // Exclude actions column from export
-        },
-      },
-    ],
+  const columns = useMemo<ColumnDef<ProjectExpenses>[]>(
+    () =>
+      getProjectExpenseColumns({
+        statusTab,
+        projectId,
+        role,
+        getProjectName,
+        getVendorName,
+        getUserName,
+        onEdit: handleOpenEditDialog,
+        onApprove: (expense) => handleOpenStatusDialog(expense, "Approved"),
+        onMarkPaid: handleOpenMarkPaid,
+        onDelete: handleOpenDeleteDialog,
+      }),
     [
+      statusTab,
       projectId,
+      role,
       getProjectName,
       getVendorName,
       getUserName,
-      getExpenseTypeName,
       handleOpenEditDialog,
+      handleOpenStatusDialog,
+      handleOpenMarkPaid,
       handleOpenDeleteDialog,
     ]
+  );
+
+  // --- Status workflow tab → base filters (project scope + active status tab) ---
+  const baseFilters = useMemo(() => {
+    const filters: any[] = [];
+    if (projectId) filters.push(["projects", "=", projectId]);
+    if (statusTab !== "All") filters.push(["status", "=", statusTab]);
+    return filters;
+  }, [projectId, statusTab]);
+
+  // --- Per-status counts for the tab badges (project-scoped) ---
+  const { data: requestedCount, mutate: mutateRequested } = useFrappeGetDocCount(
+    DOCTYPE,
+    projectId
+      ? [["projects", "=", projectId], ["status", "=", "Requested"]]
+      : [["status", "=", "Requested"]]
+  );
+  const { data: approvedCount, mutate: mutateApproved } = useFrappeGetDocCount(
+    DOCTYPE,
+    projectId
+      ? [["projects", "=", projectId], ["status", "=", "Approved"]]
+      : [["status", "=", "Approved"]]
+  );
+  const { data: paidCount, mutate: mutatePaid } = useFrappeGetDocCount(
+    DOCTYPE,
+    projectId
+      ? [["projects", "=", projectId], ["status", "=", "Paid"]]
+      : [["status", "=", "Paid"]]
+  );
+  const { data: allCount } = useFrappeGetDocCount(
+    DOCTYPE,
+    projectId ? [["projects", "=", projectId]] : undefined
+  );
+
+  const statusTabs = useMemo(
+    () => [
+      { label: "Requested", value: "Requested", count: requestedCount ?? 0 },
+      { label: "Approved", value: "Approved", count: approvedCount ?? 0 },
+      { label: "Paid", value: "Paid", count: paidCount ?? 0 },
+      { label: "All", value: "All", count: allCount ?? 0 },
+    ],
+    [requestedCount, approvedCount, paidCount, allCount]
   );
 
   // --- Data Table Hook (MOVED UP) ---
@@ -403,18 +372,13 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
       "type.expense_name as expense_type_name",
     ], // Ensure display name is fetched
     searchableFields: PE_SEARCHABLE_FIELDS,
-    urlSyncKey: `project_expenses_list_${projectId || "all"}`,
-    // --- (Indicator) Static filter is now conditional ---
-    additionalFilters: projectId ? [["projects", "=", projectId]] : [],
+    urlSyncKey: `project_expenses_list_${projectId || "all"}_${statusTab.toLowerCase()}`,
+    // Project scope + active status tab
+    additionalFilters: baseFilters,
     aggregatesConfig: PE_AGGREGATES_CONFIG, // NEW: Pass the aggregation config
     groupByConfig: PE_GROUP_BY_CONFIG, // NEW: Pass the group by config
   });
 
-  // --- Dynamic Facet Values ---
-  const staticFilters = useMemo(
-    () => (projectId ? [["projects", "=", projectId]] : []),
-    [projectId]
-  );
 
   // --- Data Table Hook ---
 
@@ -436,6 +400,34 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
             : ""
       )}
     >
+      <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 scrollbar-thin">
+        <div className="flex gap-1.5 sm:flex-wrap pb-1 sm:pb-0">
+          {statusTabs.map((sTab) => {
+            const isActive = statusTab === sTab.value;
+            return (
+              <button
+                key={sTab.value}
+                type="button"
+                onClick={() => setStatusTab(sTab.value)}
+                className={`px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm rounded transition-colors flex items-center gap-1.5 whitespace-nowrap ${
+                  isActive
+                    ? "bg-sky-500 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+              >
+                {sTab.label}
+                <span
+                  className={`text-xs font-bold ${
+                    isActive ? "opacity-90" : "opacity-70"
+                  }`}
+                >
+                  {sTab.count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
       <DataTable
         table={table}
         columns={columns}
@@ -457,16 +449,6 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
         isExporting={isExporting}
         exportFileName={`Project_Expenses_${projectId ? getProjectName(projectId) : "All"}`}
         getRowClassName={getRowClassName}
-        toolbarActions={
-          (role === "Nirmaan Admin Profile" ||
-            role === "Nirmaan PMO Executive Profile" ||
-            role === "Nirmaan Accountant Profile" || role === "Nirmaan Accountant Lead Profile") && (
-            <Button onClick={toggleNewProjectExpenseDialog} size="sm">
-              <PlusCircle className="mr-2 h-4 w-4" />
-              Add Project Expense
-            </Button>
-          )
-        }
         // --- (Indicator) FIX: Explicitly pass the required props with the correct names ---
         searchTerm={searchTerm}
         onSearchTermChange={setSearchTerm}
@@ -489,8 +471,12 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
       {expenseToEdit && (
         <EditProjectExpenseDialog
           expenseToEdit={expenseToEdit}
+          markAsPaid={markPaidMode}
           onSuccess={() => {
             refetch();
+            mutateRequested();
+            mutateApproved();
+            mutatePaid();
             setEditProjectExpenseDialog(false);
           }}
         />
@@ -521,6 +507,41 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
                 className="bg-destructive hover:bg-destructive/90"
               >
                 {deleteLoading ? "Deleting..." : "Confirm"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+      {statusAction && (
+        <AlertDialog
+          open={!!statusAction}
+          onOpenChange={(open) => !open && setStatusAction(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {statusAction.next === "Approved"
+                  ? "Approve this expense?"
+                  : "Mark this expense as Paid?"}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {statusAction.next === "Approved"
+                  ? "This moves the expense from Requested to Approved."
+                  : "This moves the expense from Approved to Paid."}{" "}
+                <span className="font-semibold">
+                  {statusAction.expense.description}
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={() => setStatusAction(null)}>
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmStatusChange}
+                disabled={updateLoading}
+              >
+                {updateLoading ? "Updating..." : "Confirm"}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
+++ b/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
@@ -127,13 +127,19 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   } | null>(null);
   const [markPaidMode, setMarkPaidMode] = useState(false);
 
+  // Embedded in a project (projectId present) = Paid-only view with NO status tabs;
+  // the standalone list keeps the full tabbed Requested/Approved/Paid/All workflow.
+  const isEmbedded = !!projectId;
+  const effectiveStatusTab = isEmbedded ? "Paid" : statusTab;
+
   // --- Keep the active status tab in sync with the URL (deep-link + back/forward) ---
   // Persist tab -> URL (replaceState, so it doesn't pollute browser history).
   useEffect(() => {
+    if (isEmbedded) return; // embedded view is fixed to Paid; don't sync to the URL
     if (urlStateManager.getParam(PE_STATUS_TAB_PARAM) !== statusTab) {
       urlStateManager.updateParam(PE_STATUS_TAB_PARAM, statusTab);
     }
-  }, [statusTab]);
+  }, [statusTab, isEmbedded]);
   // React to URL -> tab changes (back/forward navigation, external deep links).
   useEffect(() => {
     const unsubscribe = urlStateManager.subscribe(
@@ -283,9 +289,10 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   const columns = useMemo<ColumnDef<ProjectExpenses>[]>(
     () =>
       getProjectExpenseColumns({
-        statusTab,
+        statusTab: effectiveStatusTab,
         projectId,
         role,
+        disableActions: isEmbedded,
         getProjectName,
         getVendorName,
         getUserName,
@@ -295,8 +302,9 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
         onDelete: handleOpenDeleteDialog,
       }),
     [
-      statusTab,
+      effectiveStatusTab,
       projectId,
+      isEmbedded,
       role,
       getProjectName,
       getVendorName,
@@ -312,9 +320,9 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   const baseFilters = useMemo(() => {
     const filters: any[] = [];
     if (projectId) filters.push(["projects", "=", projectId]);
-    if (statusTab !== "All") filters.push(["status", "=", statusTab]);
+    if (effectiveStatusTab !== "All") filters.push(["status", "=", effectiveStatusTab]);
     return filters;
-  }, [projectId, statusTab]);
+  }, [projectId, effectiveStatusTab]);
 
   // --- Per-status counts for the tab badges (project-scoped) ---
   const { data: requestedCount, mutate: mutateRequested } = useFrappeGetDocCount(
@@ -376,7 +384,7 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
       "type.expense_name as expense_type_name",
     ], // Ensure display name is fetched
     searchableFields: PE_SEARCHABLE_FIELDS,
-    urlSyncKey: `project_expenses_list_${projectId || "all"}_${statusTab.toLowerCase()}`,
+    urlSyncKey: `project_expenses_list_${projectId || "all"}_${effectiveStatusTab.toLowerCase()}`,
     // Project scope + active status tab
     additionalFilters: baseFilters,
     aggregatesConfig: PE_AGGREGATES_CONFIG, // NEW: Pass the aggregation config
@@ -406,6 +414,7 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
               : ""
       )}
     >
+      {!isEmbedded && (
       <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 scrollbar-thin">
         <div className="flex gap-1.5 sm:flex-wrap pb-1 sm:pb-0">
           {statusTabs.map((sTab) => {
@@ -434,6 +443,7 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
           })}
         </div>
       </div>
+      )}
       <DataTable
         table={table}
         columns={columns}

--- a/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
+++ b/frontend/src/pages/ProjectExpenses/ProjectExpensesList.tsx
@@ -83,6 +83,10 @@ const PE_STATUS_TAB_PARAM = "pe_status";
 export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
   projectId,
 }) => {
+  // Standalone list (no projectId) grows to natural height for a single page
+  // scroll; the embedded project tab (projectId set) keeps the fixed-height
+  // internal table scroll.
+  const autoHeight = !projectId;
   const { setEditProjectExpenseDialog } = useDialogStore();
   const { toast } = useToast();
   const { role } = useUserData();
@@ -393,11 +397,13 @@ export const ProjectExpensesList: React.FC<ProjectExpensesListProps> = ({
     <div
       className={cn(
         "flex flex-col gap-2 overflow-hidden",
-        totalCount > 10
-          ? "h-[calc(100vh-80px)]"
-          : totalCount > 0
-            ? "h-auto"
-            : ""
+        autoHeight
+          ? "h-auto"
+          : totalCount > 10
+            ? "h-[calc(100vh-80px)]"
+            : totalCount > 0
+              ? "h-auto"
+              : ""
       )}
     >
       <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 scrollbar-thin">

--- a/frontend/src/pages/ProjectExpenses/components/EditProjectExpenseDialog.tsx
+++ b/frontend/src/pages/ProjectExpenses/components/EditProjectExpenseDialog.tsx
@@ -24,7 +24,6 @@ import { cn } from "@/lib/utils";
 // --- Types ---
 import { ProjectExpenses } from "@/types/NirmaanStack/ProjectExpenses";
 import { Vendors } from "@/types/NirmaanStack/Vendors";
-import { NirmaanUsers } from "@/types/NirmaanStack/NirmaanUsers";
 import { ExpenseType } from "@/types/NirmaanStack/ExpenseType";
 
 // --- Utils & State ---
@@ -33,9 +32,11 @@ import { useDialogStore } from "@/zustand/useDialogStore";
 import { queryKeys, getProjectExpenseTypeListOptions } from "@/config/queryKeys";
 import { formatToRoundedIndianRupee } from "@/utils/FormatPrice";
 import { useCEOHoldGuard } from "@/hooks/useCEOHoldGuard";
+import { useUserData } from "@/hooks/useUserData";
 
 interface EditProjectExpenseDialogProps {
     expenseToEdit: ProjectExpenses;
+    markAsPaid?: boolean;
     onSuccess?: () => void;
 }
 
@@ -52,21 +53,24 @@ interface FormState {
 const AMOUNT_LIMIT = 15000;
 const OTHERS_VENDOR_VALUE = "OTHERS_EMPTY_SELECTION";
 
-export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> = ({ expenseToEdit, onSuccess }) => {
+export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> = ({ expenseToEdit, markAsPaid = false, onSuccess }) => {
     const { editProjectExpenseDialog, setEditProjectExpenseDialog } = useDialogStore();
     const { toast } = useToast();
+    const { user_id } = useUserData();
     const [formState, setFormState] = useState<FormState>({ type: "", vendor: "", description: "", comment: "", amount: "", payment_date: "", payment_by: "" });
     const [formErrors, setFormErrors] = useState<Partial<FormState>>({});
 
     // CEO Hold guard - get project from the expense being edited
     const { isCEOHold, showBlockedToast } = useCEOHoldGuard(expenseToEdit?.projects);
 
+    // Payment Date / Paid By are only relevant once the expense leaves the Requested stage
+    const isRequested = (expenseToEdit?.status || "Requested") === "Requested";
+
     const [expenseTypePopoverOpen, setExpenseTypePopoverOpen] = useState(false);
     const commandListRef = useRef<HTMLDivElement>(null);
 
     const { updateDoc, loading } = useFrappeUpdateDoc();
     const { data: vendorsData, isLoading: vendorsLoading } = useFrappeGetDocList<Vendors>("Vendors", { fields: ["name", "vendor_name"], limit: 0 });
-    const { data: users, isLoading: usersLoading } = useFrappeGetDocList<NirmaanUsers>("Nirmaan Users", { fields: ["name", "full_name"], limit: 0 });
     const expenseTypeFetchOptions = useMemo(() => getProjectExpenseTypeListOptions(), []);
     const { data: expenseTypesData, isLoading: expenseTypesLoading } = useFrappeGetDocList<ExpenseType>("Expense Type", expenseTypeFetchOptions as any, queryKeys.expenseTypes.list(expenseTypeFetchOptions));
 
@@ -86,12 +90,12 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
                 comment: expenseToEdit.comment || "",
                 amount: expenseToEdit.amount?.toString() || "",
                 payment_date: expenseToEdit.payment_date ? formatDateFns(new Date(expenseToEdit.payment_date), 'yyyy-MM-dd') : "",
-                payment_by: expenseToEdit.payment_by || "",
+                payment_by: expenseToEdit.payment_by || (markAsPaid ? user_id : ""),
             });
             setFormErrors({});
             setExpenseTypePopoverOpen(false);
         }
-    }, [editProjectExpenseDialog, expenseToEdit]);
+    }, [editProjectExpenseDialog, expenseToEdit, markAsPaid, user_id]);
 
     useEffect(() => {
         const commandListElement = commandListRef.current;
@@ -107,8 +111,10 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
         if (!formState.type) errors.type = "Expense Type is required.";
         if (!formState.description.trim()) errors.description = "Description is required.";
         if (formState.vendor === "") errors.vendor = "Please select a vendor or 'Others'.";
-        if (!formState.payment_by) errors.payment_by = "Paid By user is required.";
-        if (!formState.payment_date) errors.payment_date = "Payment date is required.";
+        // Paid By is auto/read-only; only Payment Date is user-entered once past Requested
+        if (!isRequested && !formState.payment_date) {
+            errors.payment_date = "Payment date is required.";
+        }
 
         const amountValue = parseNumber(formState.amount);
         if (!formState.amount.trim() || isNaN(amountValue)) {
@@ -119,7 +125,7 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
 
         setFormErrors(errors);
         return Object.keys(errors).length === 0;
-    }, [formState]);
+    }, [formState, isRequested]);
 
     const handleSubmit = async () => {
         if (isCEOHold) {
@@ -135,9 +141,10 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
             await updateDoc("Project Expenses", expenseToEdit.name, {
                 ...formState,
                 vendor: finalVendor,
-                amount: parseNumber(formState.amount)
+                amount: parseNumber(formState.amount),
+                ...(markAsPaid ? { status: "Paid" } : {})
             });
-            toast({ title: "Success", description: "Expense updated successfully.", variant: "success" });
+            toast({ title: "Success", description: markAsPaid ? "Expense marked Paid." : "Expense updated successfully.", variant: "success" });
             onSuccess?.();
             handleDialogClose();
         } catch (error: any) {
@@ -152,15 +159,15 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
         }
     }, [formErrors]);
 
-    const isLoadingOverall = loading || vendorsLoading || usersLoading || expenseTypesLoading;
-    const isSubmitDisabled = isLoadingOverall || Object.values(formErrors).some(Boolean);
+    const isLoadingOverall = loading || vendorsLoading || expenseTypesLoading;
+    const isSubmitDisabled = isLoadingOverall || Object.values(formErrors).some(Boolean) || (markAsPaid && !formState.payment_date);
     const selectedExpenseTypeLabel = expenseTypeOptions.find(option => option.value === formState.type)?.label || "Select an expense type...";
 
     return (
         <AlertDialog open={editProjectExpenseDialog} onOpenChange={(isOpen) => !isOpen && handleDialogClose()}>
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Edit Project Expense</AlertDialogTitle>
+                    <AlertDialogTitle>{markAsPaid ? "Mark as Paid" : "Edit Project Expense"}</AlertDialogTitle>
                     <AlertDialogDescription>ID: {expenseToEdit.name}</AlertDialogDescription>
                 </AlertDialogHeader>
                 <div className="space-y-4 py-2 max-h-[70vh] overflow-y-auto pr-2">
@@ -205,23 +212,17 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
                             {formErrors.vendor && <p className="text-xs text-destructive mt-1">{formErrors.vendor}</p>}
                         </div>
                     </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_date_edit" className="text-right">Payment Date <sup className="text-destructive">*</sup></Label>
-                        <div className="col-span-3">
-                            <Input id="payment_date_edit" type="date" value={formState.payment_date} onChange={(e) => handleInputChange('payment_date', e.target.value)} className={formErrors.payment_date ? "border-destructive" : ""} max={formatDateFns(new Date(), 'yyyy-MM-dd')} disabled={isLoadingOverall} />
-                            {formErrors.payment_date && <p className="text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
-                        </div>
-                    </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_by_edit" className="text-right">Paid By <sup className="text-destructive">*</sup></Label>
-                        <div className="col-span-3">
-                            <Select value={formState.payment_by} onValueChange={(val) => handleInputChange('payment_by', val)} disabled={isLoadingOverall}>
-                                <SelectTrigger id="payment_by_edit" className={formErrors.payment_by ? "border-destructive" : ""}><SelectValue placeholder="Select user..." /></SelectTrigger>
-                                <SelectContent>{users?.map(u => <SelectItem key={u.name} value={u.name}>{u.full_name}</SelectItem>)}</SelectContent>
-                            </Select>
-                            {formErrors.payment_by && <p className="text-xs text-destructive mt-1">{formErrors.payment_by}</p>}
-                        </div>
-                    </div>
+                    {!isRequested && (
+                        <>
+                            <div className="grid grid-cols-4 items-center gap-4">
+                                <Label htmlFor="payment_date_edit" className="text-right">Payment Date <sup className="text-destructive">*</sup></Label>
+                                <div className="col-span-3">
+                                    <Input id="payment_date_edit" type="date" value={formState.payment_date} onChange={(e) => handleInputChange('payment_date', e.target.value)} className={formErrors.payment_date ? "border-destructive" : ""} max={formatDateFns(new Date(), 'yyyy-MM-dd')} disabled={isLoadingOverall} />
+                                    {formErrors.payment_date && <p className="text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
+                                </div>
+                            </div>
+                        </>
+                    )}
                     <div className="grid grid-cols-4 items-center gap-4">
                         <Label htmlFor="comment_edit" className="text-right">Comment</Label>
                         <Textarea id="comment_edit" value={formState.comment} onChange={(e) => handleInputChange('comment', e.target.value)} className="col-span-3" disabled={isLoadingOverall} />
@@ -230,7 +231,7 @@ export const EditProjectExpenseDialog: React.FC<EditProjectExpenseDialogProps> =
                 <AlertDialogFooter>
                     {isLoadingOverall ? <div className="flex justify-end w-full"><TailSpin color="#4f46e5" height={28} width={28} /></div> : <>
                         <AlertDialogCancel asChild><Button variant="outline" type="button" onClick={handleDialogClose}>Cancel</Button></AlertDialogCancel>
-                        <AlertDialogAction onClick={handleSubmit} disabled={isSubmitDisabled}>Save Changes</AlertDialogAction>
+                        <AlertDialogAction onClick={(e) => { e.preventDefault(); handleSubmit(); }} disabled={isSubmitDisabled}>{markAsPaid ? "Mark as Paid" : "Save Changes"}</AlertDialogAction>
                     </>}
                 </AlertDialogFooter>
             </AlertDialogContent>

--- a/frontend/src/pages/ProjectExpenses/components/NewProjectExpenseDialog.tsx
+++ b/frontend/src/pages/ProjectExpenses/components/NewProjectExpenseDialog.tsx
@@ -3,7 +3,6 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { useFrappeCreateDoc, useFrappeGetDocList, GetDocListArgs, FrappeDoc } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
-import { formatDate as formatDateFns } from "date-fns";
 import { Check, ChevronsUpDown } from "lucide-react";
 
 // --- UI Components ---
@@ -25,7 +24,6 @@ import ProjectSelect from "@/components/custom-select/project-select"; // Assumi
 // --- Types ---
 import { ProjectExpenses } from "@/types/NirmaanStack/ProjectExpenses";
 import { Vendors } from "@/types/NirmaanStack/Vendors";
-import { NirmaanUsers } from "@/types/NirmaanStack/NirmaanUsers";
 import { ExpenseType } from "@/types/NirmaanStack/ExpenseType";
 
 // --- Utils & State ---
@@ -47,8 +45,6 @@ interface FormState {
     description: string;
     comment: string;
     amount: string;
-    payment_date: string;
-    payment_by: string;
 }
 
 const AMOUNT_LIMIT = 15000;
@@ -61,8 +57,6 @@ const INITIAL_STATE: FormState = {
     description: "",
     comment: "",
     amount: "",
-    payment_date: formatDateFns(new Date(), 'yyyy-MM-dd'),
-    payment_by: ""
 };
 
 export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = ({ projectId, onSuccess }) => {
@@ -78,7 +72,6 @@ export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = (
     const commandListRef = useRef<HTMLDivElement>(null);
 
     const { data: vendorsData, isLoading: vendorsLoading } = useFrappeGetDocList<Vendors>("Vendors", { fields: ["name", "vendor_name"], limit: 0 });
-    const { data: users, isLoading: usersLoading } = useFrappeGetDocList<NirmaanUsers>("Nirmaan Users", { fields: ["name", "full_name"], limit: 0 });
     const expenseTypeFetchOptions = useMemo(() => getProjectExpenseTypeListOptions(), []);
     const { data: expenseTypesData, isLoading: expenseTypesLoading } = useFrappeGetDocList<ExpenseType>("Expense Type", expenseTypeFetchOptions as any, queryKeys.expenseTypes.list(expenseTypeFetchOptions));
 
@@ -100,8 +93,6 @@ export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = (
         if (!formState.projects) errors.projects = "Project is required.";
         if (!formState.type) errors.type = "Expense Type is required.";
         if (!formState.description.trim()) errors.description = "Description is required.";
-        if (!formState.payment_by) errors.payment_by = "Paid By user is required.";
-        if (!formState.payment_date) errors.payment_date = "Payment date is required.";
         if (formState.vendor === "") errors.vendor = "Please select a vendor or choose 'Others'.";
 
         const amountValue = parseNumber(formState.amount);
@@ -172,7 +163,7 @@ export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = (
         }
     }, [formErrors]);
 
-    const isLoadingOverall = loading || vendorsLoading || usersLoading || expenseTypesLoading;
+    const isLoadingOverall = loading || vendorsLoading || expenseTypesLoading;
     const isSubmitDisabled = isLoadingOverall || Object.values(formErrors).some(Boolean);
     const selectedExpenseTypeLabel = expenseTypeOptions.find(option => option.value === formState.type)?.label || "Select an expense type...";
 
@@ -244,23 +235,6 @@ export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = (
                                 <SelectContent>{vendorOptions.map(v => <SelectItem key={v.value} value={v.value}>{v.label}</SelectItem>)}</SelectContent>
                             </Select>
                             {formErrors.vendor && <p className="text-xs text-destructive mt-1">{formErrors.vendor}</p>}
-                        </div>
-                    </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_date" className="text-right">Payment Date <sup className="text-destructive">*</sup></Label>
-                        <div className="col-span-3">
-                            <Input id="payment_date" type="date" value={formState.payment_date} onChange={(e) => handleInputChange('payment_date', e.target.value)} className={formErrors.payment_date ? "border-destructive" : ""} max={formatDateFns(new Date(), 'yyyy-MM-dd')} disabled={isLoadingOverall} />
-                            {formErrors.payment_date && <p className="text-xs text-destructive mt-1">{formErrors.payment_date}</p>}
-                        </div>
-                    </div>
-                    <div className="grid grid-cols-4 items-center gap-4">
-                        <Label htmlFor="payment_by" className="text-right">Requested By <sup className="text-destructive">*</sup></Label>
-                        <div className="col-span-3">
-                            <Select value={formState.payment_by} onValueChange={(val) => handleInputChange('payment_by', val)} disabled={isLoadingOverall}>
-                                <SelectTrigger className={formErrors.payment_by ? "border-destructive" : ""}><SelectValue placeholder="Select user..." /></SelectTrigger>
-                                <SelectContent>{users?.map(u => <SelectItem key={u.name} value={u.name}>{u.full_name}</SelectItem>)}</SelectContent>
-                            </Select>
-                            {formErrors.payment_by && <p className="text-xs text-destructive mt-1">{formErrors.payment_by}</p>}
                         </div>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">

--- a/frontend/src/pages/ProjectExpenses/components/NewProjectExpenseDialog.tsx
+++ b/frontend/src/pages/ProjectExpenses/components/NewProjectExpenseDialog.tsx
@@ -1,7 +1,7 @@
 // src/pages/ProjectExpenses/components/NewProjectExpenseDialog.tsx
 
 import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
-import { useFrappeCreateDoc, useFrappeGetDocList, GetDocListArgs, FrappeDoc } from "frappe-react-sdk";
+import { useFrappeCreateDoc, useFrappeGetDocList } from "frappe-react-sdk";
 import { TailSpin } from "react-loader-spinner";
 import { Check, ChevronsUpDown } from "lucide-react";
 
@@ -22,7 +22,6 @@ import { cn } from "@/lib/utils";
 import ProjectSelect from "@/components/custom-select/project-select"; // Assuming this is your project selector
 
 // --- Types ---
-import { ProjectExpenses } from "@/types/NirmaanStack/ProjectExpenses";
 import { Vendors } from "@/types/NirmaanStack/Vendors";
 import { ExpenseType } from "@/types/NirmaanStack/ExpenseType";
 
@@ -225,6 +224,7 @@ export const NewProjectExpenseDialog: React.FC<NewProjectExpenseDialogProps> = (
                         <div className="col-span-3">
                             <Input id="amount" type="number" value={formState.amount} onChange={(e) => handleInputChange('amount', e.target.value)} className={formErrors.amount ? "border-destructive" : ""} disabled={isLoadingOverall} />
                             {formErrors.amount && <p className="text-xs text-destructive mt-1">{formErrors.amount}</p>}
+                            <p className="text-xs text-muted-foreground mt-1">Expenses under ₹5,000 are auto-approved; ₹5,000 and above require approval.</p>
                         </div>
                     </div>
                     <div className="grid grid-cols-4 items-center gap-4">

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
@@ -102,7 +102,11 @@ export const getProjectExpenseColumns = ({
       ? isAdmin
       : statusTab === "All"
         ? isAdmin
-        : true;
+        // Approved tab: Procurement/HR have no available action here (Mark-as-Paid
+        // is Admin/Accountant), so hide the empty Actions column for them.
+        : statusTab === "Approved" && (isProcurement || isHR)
+          ? false
+          : true;
 
   const projectColumn: ColumnDef<ProjectExpenses> = {
     accessorKey: "projects",

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
@@ -1,0 +1,373 @@
+// src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+//
+// Column definitions for the Project Expenses table, consumed by
+// ProjectExpensesList.tsx via `getProjectExpenseColumns(...)`.
+//
+// Column visibility is driven by the active status tab:
+//   - "Project"  -> only on the global list (no projectId)
+//   - "Created By" (owner)      -> all tabs EXCEPT "Paid"
+//   - "Payment By" + "Payment Date" -> only on the "Paid" tab
+//   - "Status"   -> only on the "All" tab (other tabs are already status-scoped)
+// The faceted-filter / date-filter wiring in ProjectExpensesList keys off these
+// column ids (projects, type, vendor, owner, payment_by, status, payment_date).
+//
+// Row actions are derived from each row's own status (so the mixed-status "All"
+// tab renders correct actions per row):
+//   - Requested -> Edit, Approve, Delete
+//   - Approved  -> Mark as Paid, Delete
+//   - Paid      -> Delete
+
+import { ColumnDef } from "@tanstack/react-table";
+import { Link } from "react-router-dom";
+import { Pencil, CheckCircle2, IndianRupee, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { formatDate } from "@/utils/FormatDate";
+import {
+  formatForReport,
+  formatToRoundedIndianRupee,
+} from "@/utils/FormatPrice";
+import { cn } from "@/lib/utils";
+import { ProjectExpenses } from "@/types/NirmaanStack/ProjectExpenses";
+
+export interface GetProjectExpenseColumnsOptions {
+  statusTab: string;
+  projectId?: string;
+  role?: string;
+  getProjectName: (id?: string) => string;
+  getVendorName: (id?: string) => string;
+  getUserName: (id?: string) => string;
+  onEdit: (expense: ProjectExpenses) => void;
+  onApprove: (expense: ProjectExpenses) => void;
+  onMarkPaid: (expense: ProjectExpenses) => void;
+  onDelete: (expense: ProjectExpenses) => void;
+}
+
+const STATUS_BADGE_STYLES: Record<string, string> = {
+  Requested: "bg-amber-100 text-amber-700",
+  Approved: "bg-sky-100 text-sky-700",
+  Paid: "bg-green-100 text-green-700",
+};
+
+export const getProjectExpenseColumns = ({
+  statusTab,
+  projectId,
+  role,
+  getProjectName,
+  getVendorName,
+  getUserName,
+  onEdit,
+  onApprove,
+  onMarkPaid,
+  onDelete,
+}: GetProjectExpenseColumnsOptions): ColumnDef<ProjectExpenses>[] => {
+  // --- Role gating (frontend-only enforcement, mirrors the existing flow) ---
+  const isAdmin = role === "Nirmaan Admin Profile";
+  const isPMO = role === "Nirmaan PMO Executive Profile";
+  // Accountant Lead mirrors Accountant for role checks (parity by design).
+  const isAccountant =
+    role === "Nirmaan Accountant Profile" ||
+    role === "Nirmaan Accountant Lead Profile";
+  const isProcurement = role === "Nirmaan Procurement Executive Profile";
+  const isHR = role === "Nirmaan HR Executive Profile";
+
+  // Action-level permissions
+  // Editing a *Requested* expense is allowed for the broader managing set
+  // (Admin, PMO, Accountant/Lead, Procurement, HR). Paid-row edit stays Admin-only.
+  const canEditRequested =
+    isAdmin || isPMO || isAccountant || isProcurement || isHR;
+  const canApprove = isAdmin; // Requested -> Approved (Admin only)
+  const canMarkPaid = isAdmin || isAccountant; // Approved -> Paid (Accountant now allowed)
+  const canDelete = isAdmin; // Delete is Admin only (PMO removed)
+
+  // --- Actions column visibility (scoped to the Paid and All tabs) ---
+  // The column shows only for users who can actually act on the tab's rows:
+  //   - Paid tab: Edit/Delete are Admin-only, so only Admin sees it.
+  //   - All tab:  Admin, plus Accountant (who can Mark as Paid the Approved rows).
+  // Requested/Approved tabs are left unchanged (column always present).
+  const canSeeActionsColumn =
+    statusTab === "Paid"
+      ? isAdmin
+      : statusTab === "All"
+        ? isAdmin
+        : true;
+
+  const projectColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "projects",
+    size: 180,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Project" />
+    ),
+    cell: ({ row }) => (
+      <Link
+        to={`/projects/${row.original.projects}`}
+        className="text-blue-600 hover:underline"
+      >
+        {getProjectName(row.original.projects)}
+      </Link>
+    ),
+    enableColumnFilter: true,
+    meta: { exportValue: (row: ProjectExpenses) => getProjectName(row.projects) },
+  };
+
+  const expenseTypeColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "type",
+    header: "Expense Type",
+    size: 150,
+    cell: ({ row }) => (
+      <div
+        className="truncate"
+        title={row.original.expense_type_name || row.original.type}
+      >
+        {row.original.expense_type_name || row.original.type || "--"}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: {
+      exportValue: (row: ProjectExpenses) =>
+        row.expense_type_name || row.type || "--",
+    },
+  };
+
+  const descriptionColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "description",
+    header: "Description",
+    size: 200,
+    cell: ({ row }) => (
+      <div className="truncate" title={row.original.description}>
+        {row.original.description || "--"}
+      </div>
+    ),
+  };
+
+  const commentColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "comment",
+    header: "Comment",
+    size: 200,
+    cell: ({ row }) => (
+      <div className="truncate" title={row.original.comment}>
+        {row.original.comment || "--"}
+      </div>
+    ),
+  };
+
+  const vendorColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "vendor",
+    header: "Vendor",
+    size: 170,
+    cell: ({ row }) => (
+      <div className="truncate" title={getVendorName(row.original.vendor)}>
+        {getVendorName(row.original.vendor)}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: { exportValue: (row: ProjectExpenses) => getVendorName(row.vendor) },
+  };
+
+  const amountColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "amount",
+    size: 130,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Amount"
+        className="justify-center"
+      />
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium pr-2">
+        {formatToRoundedIndianRupee(row.original.amount)}
+      </div>
+    ),
+    meta: { exportValue: (row: ProjectExpenses) => formatForReport(row.amount) },
+  };
+
+  const createdByColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "owner",
+    header: "Created By",
+    size: 160,
+    cell: ({ row }) => (
+      <div className="truncate" title={getUserName(row.original.owner)}>
+        {getUserName(row.original.owner)}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: { exportValue: (row: ProjectExpenses) => getUserName(row.owner) },
+  };
+
+  const paymentByColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "payment_by",
+    header: "Payment By",
+    size: 160,
+    cell: ({ row }) => (
+      <div className="truncate" title={getUserName(row.original.payment_by)}>
+        {getUserName(row.original.payment_by)}
+      </div>
+    ),
+    enableColumnFilter: true,
+    meta: { exportValue: (row: ProjectExpenses) => getUserName(row.payment_by) },
+  };
+
+  const paymentDateColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "payment_date",
+    size: 150,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Payment Date" />
+    ),
+    cell: ({ row }) => (
+      <div className="font-medium">
+        {row.original.payment_date ? formatDate(row.original.payment_date) : "--"}
+      </div>
+    ),
+    meta: {
+      exportValue: (row: ProjectExpenses) =>
+        row.payment_date ? formatDate(row.payment_date) : "--",
+    },
+  };
+
+  const statusColumn: ColumnDef<ProjectExpenses> = {
+    accessorKey: "status",
+    header: "Status",
+    size: 140,
+    enableColumnFilter: true,
+    cell: ({ row }) => {
+      const status = row.original.status || "Requested";
+      return (
+        <span
+          className={cn(
+            "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+            STATUS_BADGE_STYLES[status] || "bg-gray-100 text-gray-700"
+          )}
+        >
+          {status}
+        </span>
+      );
+    },
+    meta: { exportValue: (row: ProjectExpenses) => row.status || "Requested" },
+  };
+
+  const actionsColumn: ColumnDef<ProjectExpenses> = {
+    id: "actions",
+    size: 150,
+    enableSorting: false,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Actions"
+        className="text-center"
+      />
+    ),
+    cell: ({ row }) => {
+      const expense = row.original;
+      const status = expense.status || "Requested";
+      return (
+        <TooltipProvider delayDuration={300}>
+          <div className="flex items-center gap-1">
+            {status === "Requested" && (
+              <>
+                {canEditRequested && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="h-8 w-8 p-0"
+                        onClick={() => onEdit(expense)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Edit</TooltipContent>
+                  </Tooltip>
+                )}
+                {canApprove && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="h-8 w-8 p-0 text-green-600 hover:text-green-700"
+                        onClick={() => onApprove(expense)}
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Approve</TooltipContent>
+                  </Tooltip>
+                )}
+              </>
+            )}
+
+            {status === "Approved" && canMarkPaid && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    className="h-8 bg-green-600 text-white hover:bg-green-700"
+                    onClick={() => onMarkPaid(expense)}
+                  >
+                    <IndianRupee className="mr-1 h-3.5 w-3.5" />
+                    Mark as Paid
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Mark as Paid</TooltipContent>
+              </Tooltip>
+            )}
+
+            {/* A Paid expense can only be edited by an Admin */}
+            {status === "Paid" && isAdmin && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 w-8 p-0"
+                    onClick={() => onEdit(expense)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Edit</TooltipContent>
+              </Tooltip>
+            )}
+
+            {canDelete && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+                    onClick={() => onDelete(expense)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="bg-white text-gray-900 border shadow-lg">Delete</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </TooltipProvider>
+      );
+    },
+    meta: { excludeFromExport: true },
+  };
+
+  return [
+    ...(!projectId ? [projectColumn] : []),
+    expenseTypeColumn,
+    descriptionColumn,
+    commentColumn,
+    vendorColumn,
+    amountColumn,
+    ...(statusTab !== "Paid" ? [createdByColumn] : []),
+    // "All" tab also shows Payment By (right after Created By); blank for non-paid rows
+    ...(statusTab === "All" ? [paymentByColumn] : []),
+    ...(statusTab === "Paid" ? [paymentByColumn, paymentDateColumn] : []),
+    ...(statusTab === "All" ? [statusColumn] : []),
+    ...(canSeeActionsColumn ? [actionsColumn] : []),
+  ];
+};

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
@@ -41,6 +41,9 @@ export interface GetProjectExpenseColumnsOptions {
   statusTab: string;
   projectId?: string;
   role?: string;
+  // When true, never render the Actions column (used by the read-only embedded
+  // project view).
+  disableActions?: boolean;
   getProjectName: (id?: string) => string;
   getVendorName: (id?: string) => string;
   getUserName: (id?: string) => string;
@@ -60,6 +63,7 @@ export const getProjectExpenseColumns = ({
   statusTab,
   projectId,
   role,
+  disableActions = false,
   getProjectName,
   getVendorName,
   getUserName,
@@ -92,8 +96,9 @@ export const getProjectExpenseColumns = ({
   //   - Paid tab: Edit/Delete are Admin-only, so only Admin sees it.
   //   - All tab:  Admin, plus Accountant (who can Mark as Paid the Approved rows).
   // Requested/Approved tabs are left unchanged (column always present).
-  const canSeeActionsColumn =
-    statusTab === "Paid"
+  const canSeeActionsColumn = disableActions
+    ? false
+    : statusTab === "Paid"
       ? isAdmin
       : statusTab === "All"
         ? isAdmin

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
@@ -29,6 +29,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
+import { facetMeta } from "@/components/data-table/facetConfig";
 import { formatDate } from "@/utils/FormatDate";
 import {
   formatForReport,
@@ -123,7 +124,10 @@ export const getProjectExpenseColumns = ({
       </Link>
     ),
     enableColumnFilter: true,
-    meta: { exportValue: (row: ProjectExpenses) => getProjectName(row.projects) },
+    meta: {
+      ...facetMeta({ field: "projects", title: "Project" }),
+      exportValue: (row: ProjectExpenses) => getProjectName(row.projects),
+    },
   };
 
   const expenseTypeColumn: ColumnDef<ProjectExpenses> = {
@@ -140,6 +144,7 @@ export const getProjectExpenseColumns = ({
     ),
     enableColumnFilter: true,
     meta: {
+      ...facetMeta({ field: "type", title: "Expense Type" }),
       exportValue: (row: ProjectExpenses) =>
         row.expense_type_name || row.type || "--",
     },
@@ -177,7 +182,10 @@ export const getProjectExpenseColumns = ({
       </div>
     ),
     enableColumnFilter: true,
-    meta: { exportValue: (row: ProjectExpenses) => getVendorName(row.vendor) },
+    meta: {
+      ...facetMeta({ field: "vendor", title: "Vendor" }),
+      exportValue: (row: ProjectExpenses) => getVendorName(row.vendor),
+    },
   };
 
   const amountColumn: ColumnDef<ProjectExpenses> = {
@@ -208,7 +216,10 @@ export const getProjectExpenseColumns = ({
       </div>
     ),
     enableColumnFilter: true,
-    meta: { exportValue: (row: ProjectExpenses) => getUserName(row.owner) },
+    meta: {
+      ...facetMeta({ field: "owner", title: "Created By" }),
+      exportValue: (row: ProjectExpenses) => getUserName(row.owner),
+    },
   };
 
   const paymentByColumn: ColumnDef<ProjectExpenses> = {
@@ -221,7 +232,10 @@ export const getProjectExpenseColumns = ({
       </div>
     ),
     enableColumnFilter: true,
-    meta: { exportValue: (row: ProjectExpenses) => getUserName(row.payment_by) },
+    meta: {
+      ...facetMeta({ field: "payment_by", title: "Payment By" }),
+      exportValue: (row: ProjectExpenses) => getUserName(row.payment_by),
+    },
   };
 
   const paymentDateColumn: ColumnDef<ProjectExpenses> = {
@@ -259,7 +273,10 @@ export const getProjectExpenseColumns = ({
         </span>
       );
     },
-    meta: { exportValue: (row: ProjectExpenses) => row.status || "Requested" },
+    meta: {
+      ...facetMeta({ field: "status", title: "Status" }),
+      exportValue: (row: ProjectExpenses) => row.status || "Requested",
+    },
   };
 
   const actionsColumn: ColumnDef<ProjectExpenses> = {

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesColumns.tsx
@@ -334,10 +334,10 @@ export const getProjectExpenseColumns = ({
                 <TooltipTrigger asChild>
                   <Button
                     size="sm"
-                    className="h-8 bg-green-600 text-white hover:bg-green-700"
+                    className="h-7 px-2 text-xs bg-green-600 text-white hover:bg-green-700"
                     onClick={() => onMarkPaid(expense)}
                   >
-                    <IndianRupee className="mr-1 h-3.5 w-3.5" />
+                    <IndianRupee className="mr-1 h-3 w-3" />
                     Mark as Paid
                   </Button>
                 </TooltipTrigger>

--- a/frontend/src/pages/ProjectExpenses/config/projectExpensesTable.config.ts
+++ b/frontend/src/pages/ProjectExpenses/config/projectExpensesTable.config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_PE_FIELDS_TO_FETCH: (keyof ProjectExpenses | 'name' | 'owne
     "name",
     "creation",
     "owner",
+    "status",
     "projects",
     "type",
     "vendor",

--- a/frontend/src/pages/projects/data/root/useProjectRootApi.ts
+++ b/frontend/src/pages/projects/data/root/useProjectRootApi.ts
@@ -201,7 +201,8 @@ export const useProjectsListPayments = () => {
 export const useProjectsListExpenses = () => {
   const response = useFrappeGetDocList<ProjectExpenses>(
     "Project Expenses",
-    { fields: ["projects", "amount"], limit: 100000 },
+    // Only Paid expenses count toward project financial totals.
+    { fields: ["projects", "amount"], filters: [["status", "=", "Paid"]], limit: 100000 },
     projectRootKeys.projectsListExpenses()
   );
 
@@ -470,7 +471,9 @@ export const useProjectViewFinancialData = (projectId: string) => {
     "Project Expenses",
     {
       fields: ["name", "amount"],
-      filters: [["projects", "=", projectId]],
+      // Only Paid expenses count toward the project's financial total (mirrors the
+      // Paid-only Project Payments filter above).
+      filters: [["projects", "=", projectId], ["status", "=", "Paid"]],
       limit: 0,
     },
     projectId ? projectRootKeys.projectExpenses(projectId) : null

--- a/frontend/src/pages/reports/hooks/useOutflowReportData.ts
+++ b/frontend/src/pages/reports/hooks/useOutflowReportData.ts
@@ -57,8 +57,8 @@ export const useOutflowReportData = ({ startDate, endDate }: UseOutflowReportDat
     }, []);
 
     const expenseFilters = useMemo(() => {
-        const filters: any[] = [];
-        // Removed date filters from database query - will filter client-side instead
+        // Only Paid expenses count toward outflow. Date filtering is applied client-side.
+        const filters: any[] = [["status", "=", "Paid"]];
         return filters;
     }, []);
 

--- a/frontend/src/pages/reports/hooks/useProjectReportCalculations.ts
+++ b/frontend/src/pages/reports/hooks/useProjectReportCalculations.ts
@@ -108,6 +108,7 @@ export const useProjectReportCalculations = (params: ProjectReportParams = {}): 
     const { data: projectExpensesData, isLoading: isLoadingProjectExpenses, error: errorProjectExpenses, mutate: mutateProjectExpenses } =
         useFrappeGetDocList<ProjectExpenses>('Project Expenses', {
             fields: ['projects', 'amount', 'payment_date'], // Only fields needed for this calculation
+            filters: [["status", "=", "Paid"]], // Only Paid expenses count toward the per-project outflow.
             limit: 0,
         }, 'AllProjectExpensesForReports');
 

--- a/frontend/src/types/NirmaanStack/NonProjectExpenses.ts
+++ b/frontend/src/types/NirmaanStack/NonProjectExpenses.ts
@@ -12,6 +12,8 @@ export interface NonProjectExpenses {
     comment?: string
     amount: number;
 
+    status?: "Requested" | "Approved" | "Paid"; // Approval workflow status (default "Requested")
+
     // Payment Details (conditionally entered)
     payment_date?: string; // YYYY-MM-DD
     payment_ref?: string;

--- a/frontend/src/types/NirmaanStack/ProjectExpenses.ts
+++ b/frontend/src/types/NirmaanStack/ProjectExpenses.ts
@@ -12,6 +12,7 @@ export interface ProjectExpenses {
     parenttype?: string
     idx?: number
 
+    status?: "Requested" | "Approved" | "Paid"; // Approval workflow status (default "Requested")
     projects: string; // This is the link to the Projects doctype
     vendor?: string; // Optional link to Vendors
     type?: string; // --- (Indicator) NEW: Link to Expense Type DocType ---

--- a/nirmaan_stack/api/data_table/constants.py
+++ b/nirmaan_stack/api/data_table/constants.py
@@ -66,4 +66,5 @@ LINK_FIELD_MAP = {
     "assigned_to": {"doctype": "User", "label_field": "full_name"},
     "created_by": {"doctype": "User", "label_field": "full_name"},
     "modified_by": {"doctype": "User", "label_field": "full_name"},
+    "payment_by": {"doctype": "User", "label_field": "full_name"},
 }

--- a/nirmaan_stack/api/payments/get_project_payment_summary.py
+++ b/nirmaan_stack/api/payments/get_project_payment_summary.py
@@ -177,7 +177,7 @@ def get_payment_dashboard_stats():
         # means PO + WO + Project Expenses (matches the Cash Sheet report).
         project_expenses = frappe.get_all(
             "Project Expenses",
-            filters={"payment_date": ["between", [thirty_days_ago, today_date]]},
+            filters={"payment_date": ["between", [thirty_days_ago, today_date]], "status": "Paid"},
             fields=["amount"],
             limit_page_length=None,
         )
@@ -199,7 +199,7 @@ def get_payment_dashboard_stats():
         # --- 2g. Non-project outflow (Non Project Expenses) — last 30 days ---
         non_project_expenses = frappe.get_all(
             "Non Project Expenses",
-            filters={"payment_date": ["between", [thirty_days_ago, today_date]]},
+            filters={"payment_date": ["between", [thirty_days_ago, today_date]], "status": "Paid"},
             fields=["amount"],
             limit_page_length=None,
         )

--- a/nirmaan_stack/api/po_adjustments/adjustment_logic.py
+++ b/nirmaan_stack/api/po_adjustments/adjustment_logic.py
@@ -151,6 +151,9 @@ def execute_adjustment(po_id, adjustments_json):
                     expense.amount = amount
                     expense.payment_date = nowdate()
                     expense.payment_by = frappe.session.user
+                    # The adjustment already moves money (paired payment is created
+                    # status="Paid"), so the expense is a completed payment -> Paid.
+                    expense.status = "Paid"
                     comment_text = entry.get("comment", "").strip()
                     expense.comment = f"{comment_text}" if comment_text else po_id
                     expense.save(ignore_permissions=True)

--- a/nirmaan_stack/fixtures/expense_type.json
+++ b/nirmaan_stack/fixtures/expense_type.json
@@ -295,5 +295,14 @@
   "name": "Fixed Assets",
   "non_project": 1,
   "project": 0
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Expense Type",
+  "expense_name": "Loan",
+  "modified": "2026-07-04 18:40:12.399476",
+  "name": "Loan",
+  "non_project": 1,
+  "project": 0
  }
 ]

--- a/nirmaan_stack/hooks.py
+++ b/nirmaan_stack/hooks.py
@@ -245,10 +245,12 @@ doc_events = {
     "Project Expenses": {
         "after_insert": "nirmaan_stack.integrations.controllers.project_cashflow_hold_update.on_project_expense",
         "on_update": "nirmaan_stack.integrations.controllers.project_cashflow_hold_update.on_project_expense",
-        "on_trash": [
-            "nirmaan_stack.integrations.controllers.delete_doc_versions.generate_versions",
-            "nirmaan_stack.integrations.controllers.project_cashflow_hold_update.on_project_expense",
-        ],
+        # generate_versions needs the pre-delete data, so it stays on on_trash.
+        "on_trash": "nirmaan_stack.integrations.controllers.delete_doc_versions.generate_versions",
+        # Cashflow recompute moved to after_delete so the gap query runs AFTER the
+        # row is gone (on_trash fires before the DB delete) — deleting a Paid
+        # expense now correctly lowers the gap / releases a CEO Hold.
+        "after_delete": "nirmaan_stack.integrations.controllers.project_cashflow_hold_update.on_project_expense",
     },
     "Project Inflows": {
         "validate": "nirmaan_stack.integrations.controllers.project_inflows.validate",

--- a/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
+++ b/nirmaan_stack/integrations/controllers/project_cashflow_hold_update.py
@@ -331,8 +331,25 @@ def on_project_payment(doc, method=None):
 
 
 def on_project_expense(doc, method=None):
-	# Project Expenses uses 'projects' (plural) as the link field.
-	trigger_check(doc.projects)
+	"""
+	Cashflow gap counts only Paid expenses (see _compute_cashflow_gap), so — like
+	on_project_payment — only re-evaluate the CEO Hold when a row enters or leaves
+	Paid. Adding / editing a Requested or Approved expense does NOT touch the gap
+	and is skipped.
+
+	Fires only when:
+	  * a row enters Paid (status flipped to 'Paid', incl. created directly as Paid)
+	  * a row leaves  Paid (status flipped away from 'Paid')
+	  * a Paid row is deleted (wired to after_delete — NOT on_trash — so the gap
+	    query runs after the DB row is gone and reflects the deletion)
+	Project Expenses uses 'projects' (plural) as the link field.
+	"""
+	if not doc.has_value_changed("status"):
+		return
+
+	prev_status = (doc.get_doc_before_save() or {}).get("status") if not doc.is_new() else None
+	if doc.status == "Paid" or prev_status == "Paid":
+		trigger_check(doc.projects)
 
 
 def on_project_inflow(doc, method=None):
@@ -362,7 +379,9 @@ def _compute_cashflow_gap(project_id: str) -> float:
 	)
 	expenses = frappe.get_all(
 		"Project Expenses",
-		filters=[["projects", "=", project_id]],  # 'projects' (plural) is correct
+		# Only Paid expenses count as outflow (mirrors the Paid-only Project Payments
+		# filter above); Requested/Approved-but-unpaid expenses don't affect the gap.
+		filters=[["projects", "=", project_id], ["status", "=", "Paid"]],  # 'projects' (plural) is correct
 		fields=["amount"],
 	)
 	outflow = sum(flt(p.amount) for p in paid_payments) + sum(flt(e.amount) for e in expenses)

--- a/nirmaan_stack/nirmaan_stack/doctype/non_project_expenses/non_project_expenses.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/non_project_expenses/non_project_expenses.json
@@ -8,6 +8,7 @@
  "field_order": [
   "details_section",
   "type",
+  "status",
   "description",
   "comment",
   "amount",
@@ -31,6 +32,15 @@
    "fieldtype": "Link",
    "label": "Type",
    "options": "Expense Type"
+  },
+  {
+   "default": "Requested",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Requested\nApproved\nPaid",
+   "in_list_view": 1,
+   "in_standard_filter": 1
   },
   {
    "fieldname": "amount",

--- a/nirmaan_stack/nirmaan_stack/doctype/non_project_expenses/non_project_expenses.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/non_project_expenses/non_project_expenses.py
@@ -1,9 +1,25 @@
 # Copyright (c) 2025, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
+from frappe.utils import flt
+
+# Positive expenses strictly below this amount skip the Requested step and are
+# created directly as Approved.
+AUTO_APPROVE_LIMIT = 5000
 
 
 class NonProjectExpenses(Document):
-	pass
+	def validate(self):
+		# Auto-approve small positive expenses on creation: a positive amount
+		# below AUTO_APPROVE_LIMIT is created as Approved, skipping Requested.
+		# A refund (negative), zero, or an amount >= the limit follows the normal
+		# Requested -> Approved -> Paid workflow. Create-time only, and only while
+		# the status is still the pre-approval default, so it never overrides an
+		# explicit status or re-flips a row on a later edit.
+		if not self.is_new():
+			return
+		if self.status and self.status != "Requested":
+			return
+		if 0 < flt(self.amount) < AUTO_APPROVE_LIMIT:
+			self.status = "Approved"

--- a/nirmaan_stack/nirmaan_stack/doctype/project_expenses/project_expenses.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/project_expenses/project_expenses.json
@@ -11,6 +11,7 @@
   "vendor",
   "type",
   "details_section",
+  "status",
   "description",
   "comment",
   "amount",
@@ -39,6 +40,15 @@
    "fieldname": "details_section",
    "fieldtype": "Section Break",
    "label": "Details"
+  },
+  {
+   "default": "Requested",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "label": "Status",
+   "options": "Requested\nApproved\nPaid",
+   "in_list_view": 1,
+   "in_standard_filter": 1
   },
   {
    "fieldname": "description",

--- a/nirmaan_stack/nirmaan_stack/doctype/project_expenses/project_expenses.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/project_expenses/project_expenses.py
@@ -1,9 +1,25 @@
 # Copyright (c) 2025, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
 # For license information, please see license.txt
 
-# import frappe
 from frappe.model.document import Document
+from frappe.utils import flt
+
+# Positive expenses strictly below this amount skip the Requested step and are
+# created directly as Approved.
+AUTO_APPROVE_LIMIT = 5000
 
 
 class ProjectExpenses(Document):
-	pass
+	def validate(self):
+		# Auto-approve small positive expenses on creation: a positive amount
+		# below AUTO_APPROVE_LIMIT is created as Approved, skipping Requested.
+		# A refund (negative), zero, or an amount >= the limit follows the normal
+		# Requested -> Approved -> Paid workflow. Create-time only, and only while
+		# the status is still the pre-approval default, so it never overrides an
+		# explicit status or re-flips a row on a later edit.
+		if not self.is_new():
+			return
+		if self.status and self.status != "Requested":
+			return
+		if 0 < flt(self.amount) < AUTO_APPROVE_LIMIT:
+			self.status = "Approved"

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -133,3 +133,4 @@ nirmaan_stack.patches.v3_0.remove_commission_report_zones
 
 nirmaan_stack.patches.v3_0.backfill_project_expenses_status
 nirmaan_stack.patches.v3_0.backfill_non_project_expenses_status #v2
+nirmaan_stack.patches.v3_0.normalize_project_expense_types

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -130,3 +130,5 @@ nirmaan_stack.patches.v3_0.migrate_general_specs_to_child_table
 nirmaan_stack.patches.v3_0.migrate_boq_sheet_draft_status_rename
 
 nirmaan_stack.patches.v3_0.remove_commission_report_zones
+
+nirmaan_stack.patches.v3_0.backfill_project_expenses_status

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -132,3 +132,4 @@ nirmaan_stack.patches.v3_0.migrate_boq_sheet_draft_status_rename
 nirmaan_stack.patches.v3_0.remove_commission_report_zones
 
 nirmaan_stack.patches.v3_0.backfill_project_expenses_status
+nirmaan_stack.patches.v3_0.backfill_non_project_expenses_status #v2

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -132,5 +132,5 @@ nirmaan_stack.patches.v3_0.migrate_boq_sheet_draft_status_rename
 nirmaan_stack.patches.v3_0.remove_commission_report_zones
 
 nirmaan_stack.patches.v3_0.backfill_project_expenses_status
-nirmaan_stack.patches.v3_0.backfill_non_project_expenses_status #v2
+nirmaan_stack.patches.v3_0.backfill_non_project_expenses_status #v3
 nirmaan_stack.patches.v3_0.normalize_project_expense_types

--- a/nirmaan_stack/patches/v3_0/backfill_non_project_expenses_status.py
+++ b/nirmaan_stack/patches/v3_0/backfill_non_project_expenses_status.py
@@ -1,0 +1,46 @@
+import frappe
+
+
+def execute():
+    """
+    Backfill `status` on legacy Non Project Expenses.
+
+    These rows predate the Requested -> Approved -> Paid workflow. When the `status`
+    column was added, Frappe applied the field default ('Requested') to every existing
+    row, so legacy rows read as 'Requested' (NOT blank). This patch therefore treats
+    NULL / '' / 'Requested' as "unclassified legacy" and re-classifies them:
+      - a payment attachment is present  -> Paid
+      - otherwise                        -> Approved
+    Rows already advanced to Approved / Paid are left untouched.
+
+    Raw SQL is used deliberately so the `modified` timestamp is preserved.
+    """
+    # Legacy rows that already have a payment attachment -> Paid.
+    frappe.db.sql(
+        """
+        UPDATE "tabNon Project Expenses"
+        SET status = 'Paid'
+        WHERE (status IS NULL OR status = '' OR status = 'Requested')
+          AND payment_attachment IS NOT NULL
+          AND payment_attachment != ''
+        """
+    )
+    # Everything else still unclassified -> Approved.
+    frappe.db.sql(
+        """
+        UPDATE "tabNon Project Expenses"
+        SET status = 'Approved'
+        WHERE status IS NULL OR status = '' OR status = 'Requested'
+        """
+    )
+
+    frappe.db.commit()
+
+    # Summary so the run is never "blind" (shows in `bench migrate` output).
+    rows = frappe.db.sql(
+        """SELECT COALESCE(NULLIF(status, ''), '(blank)') AS s, COUNT(*) AS n
+           FROM "tabNon Project Expenses" GROUP BY 1 ORDER BY s""",
+        as_dict=True,
+    )
+    dist = {r.s: r.n for r in rows}
+    print(f"[backfill_non_project_expenses_status] done — status distribution now: {dist}")

--- a/nirmaan_stack/patches/v3_0/backfill_non_project_expenses_status.py
+++ b/nirmaan_stack/patches/v3_0/backfill_non_project_expenses_status.py
@@ -3,34 +3,28 @@ import frappe
 
 def execute():
     """
-    Backfill `status` on legacy Non Project Expenses.
+    Settle legacy Non Project Expenses -> `Paid` (attachment check removed).
 
-    These rows predate the Requested -> Approved -> Paid workflow. When the `status`
-    column was added, Frappe applied the field default ('Requested') to every existing
-    row, so legacy rows read as 'Requested' (NOT blank). This patch therefore treats
-    NULL / '' / 'Requested' as "unclassified legacy" and re-classifies them:
-      - a payment attachment is present  -> Paid
-      - otherwise                        -> Approved
-    Rows already advanced to Approved / Paid are left untouched.
+    Originally this patch split legacy rows by payment attachment (attachment ->
+    Paid, none -> Approved). Per the owner's decision the attachment distinction
+    is dropped and every non-`Paid` row is settled: any row in `Approved`,
+    `Requested`, or unclassified (NULL/blank) is moved straight to `Paid`. In
+    effect every Non Project Expense ends up `Paid`.
+
+    This patch has only ever run on the local/dev site, so it is edited in place
+    and its version tag bumped (#v2 -> #v3) to force a re-run instead of shipping
+    a separate patch.
 
     Raw SQL is used deliberately so the `modified` timestamp is preserved.
     """
-    # Legacy rows that already have a payment attachment -> Paid.
     frappe.db.sql(
         """
         UPDATE "tabNon Project Expenses"
         SET status = 'Paid'
-        WHERE (status IS NULL OR status = '' OR status = 'Requested')
-          AND payment_attachment IS NOT NULL
-          AND payment_attachment != ''
-        """
-    )
-    # Everything else still unclassified -> Approved.
-    frappe.db.sql(
-        """
-        UPDATE "tabNon Project Expenses"
-        SET status = 'Approved'
-        WHERE status IS NULL OR status = '' OR status = 'Requested'
+        WHERE status = 'Approved'
+           OR status IS NULL
+           OR status = ''
+           OR status = 'Requested'
         """
     )
 
@@ -43,4 +37,7 @@ def execute():
         as_dict=True,
     )
     dist = {r.s: r.n for r in rows}
-    print(f"[backfill_non_project_expenses_status] done — status distribution now: {dist}")
+    print(
+        "[backfill_non_project_expenses_status] done — "
+        f"status distribution now: {dist}"
+    )

--- a/nirmaan_stack/patches/v3_0/backfill_project_expenses_status.py
+++ b/nirmaan_stack/patches/v3_0/backfill_project_expenses_status.py
@@ -1,0 +1,36 @@
+import frappe
+
+
+def execute():
+    """
+    Backfill `status` on legacy Project Expenses.
+
+    Older Project Expenses rows predate the Requested -> Approved -> Paid workflow,
+    so their `status` is blank (NULL / '') — and a few legacy rows still carry the
+    old 'Pending' value. Treat all of these as already settled: set them to 'Paid'.
+
+    Rows already in Requested / Approved / Paid are left untouched.
+
+    `modified` is intentionally NOT updated (raw SQL leaves the timestamp as-is),
+    so the historical audit trail on these rows is preserved.
+
+    Idempotent — safe to re-run.
+    """
+    frappe.db.sql(
+        """
+        UPDATE "tabProject Expenses"
+        SET status = 'Paid'
+        WHERE status IS NULL OR status = '' OR status = 'Requested'
+        """
+    )
+
+    frappe.db.commit()
+
+    # Summary so the run is never "blind" (shows in `bench migrate` output).
+    rows = frappe.db.sql(
+        """SELECT COALESCE(NULLIF(status, ''), '(blank)') AS s, COUNT(*) AS n
+           FROM "tabProject Expenses" GROUP BY 1 ORDER BY s""",
+        as_dict=True,
+    )
+    dist = {r.s: r.n for r in rows}
+    print(f"[backfill_project_expenses_status] done — status distribution now: {dist}")

--- a/nirmaan_stack/patches/v3_0/normalize_project_expense_types.py
+++ b/nirmaan_stack/patches/v3_0/normalize_project_expense_types.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+import frappe
+
+# Non-project-flagged expense types that were mistakenly used on Project Expenses.
+# They are consolidated into a single standardized project expense type.
+SOURCE_EXPENSE_NAMES = [
+	"Printing & Stationery",
+	"Staff Welfare Expenses",
+	"Hotel Expenses",
+	"Postage & Courier",
+	"Pooja Expenses",
+	"Travel Expenses (Flight)",
+]
+TARGET_EXPENSE_NAME = "Other Project Related Charges"
+
+
+def execute():
+	# Raw UPDATE -> only `type` changes; everything else (incl. modified) is preserved.
+	# Idempotent: once run, no row carries a source type, so a re-run matches nothing.
+	frappe.db.sql(
+		"""
+		UPDATE "tabProject Expenses"
+		SET type = %(target)s
+		WHERE type IN %(sources)s
+		""",
+		{"target": TARGET_EXPENSE_NAME, "sources": tuple(SOURCE_EXPENSE_NAMES)},
+	)
+	frappe.db.commit()
+
+	frappe.logger("patches").info(
+		f"normalize_project_expense_types: repointed Project Expenses "
+		f"{SOURCE_EXPENSE_NAMES} -> '{TARGET_EXPENSE_NAME}'."
+	)


### PR DESCRIPTION

Non-Project Expenses (nonProjectExpensesColumns.tsx):
- Rework the row Actions column: primary actions render inline ("outside"), only Requested rows keep a "..." overflow menu. Requested -> inline: Approve, Delete;  overflow: Record Invoice, Edit Approved  -> inline: Mark as Paid, Delete
    Paid      -> inline: Edit, Delete
    All       -> per row, by row status
  Role gating + column-visibility rules unchanged; only button placement moved.
- Center the Actions column (header + cells) — was right-aligned.
- Compact "Mark as Paid" button (h-7, px-2, text-xs, smaller icon).

Project Expenses (projectExpensesColumns.tsx):
- Shrink the "Mark as Paid" button to match the Non-Project sizing.

Data patch (backfill_non_project_expenses_status.py, patches.txt):
- Drop the payment-attachment check; sweep every non-Paid legacy row (Approved / Requested / NULL / blank) -> Paid.
- Edited in place + tag bumped #v2 -> #v3 to force a local re-run (local-only).

Docs (expenses.md):
- Fix the #v3 patch description and expand role gating into a full per-tab / per-profile permission matrix (module visibility, create, Non-Project + Project actions, known asymmetries).
