### PR TITLE
refactor: read attachments through frappe_gcp_attachment

### DIFF
--- a/nirmaan_stack/api/boq/wizard/parse_run.py
+++ b/nirmaan_stack/api/boq/wizard/parse_run.py
@@ -957,16 +957,16 @@ def _fetch_boq_file_to_tempfile(source_file_url: str) -> str:
     Caller must os.unlink the returned path in a finally block.
 
     Routing:
-      - If 'frappe_s3_attachment' is not in the URL: treat as local/dev path (tests, dev env).
+      - If 'frappe_gcp_attachment' is not in the URL: treat as local/dev path (tests, dev env).
         /private/... and /files/... are resolved via frappe.get_site_path(); bare absolute
         paths (e.g. test fixture paths) are used as-is.  File is copied to a tempfile so the
         caller can safely unlink it without destroying the source.
       - Otherwise: download from S3 via S3Operations.read_file_from_s3.
-        Real extension is derived from the 'file_name' query param (set by frappe_s3_attachment).
+        Real extension is derived from the 'file_name' query param (set by frappe_gcp_attachment).
         Unlike sheet_preview._fetch_boq_file_to_tempfile (which hardcodes '.xlsx'), this
         version correctly handles '.xlsm' workbooks.
     """
-    if "frappe_s3_attachment" not in source_file_url:
+    if "frappe_gcp_attachment" not in source_file_url:
         # Local path (dev / test)
         if source_file_url.startswith("/private/") or source_file_url.startswith("/files/"):
             local_path = frappe.get_site_path(source_file_url.lstrip("/"))
@@ -986,12 +986,12 @@ def _fetch_boq_file_to_tempfile(source_file_url: str) -> str:
         return tmp.name
 
     # S3 path
-    from frappe_s3_attachment.controller import S3Operations  # noqa: PLC0415
+    from frappe_gcp_attachment.controller import S3Operations  # noqa: PLC0415
 
     parsed_url = urllib.parse.urlparse(source_file_url)
     params = urllib.parse.parse_qs(parsed_url.query)
 
-    # Derive real extension from file_name query param (frappe_s3_attachment sets this)
+    # Derive real extension from file_name query param (frappe_gcp_attachment sets this)
     ext = ".xlsx"
     file_name_list = params.get("file_name")
     if file_name_list:

--- a/nirmaan_stack/api/boq/wizard/sheet_preview.py
+++ b/nirmaan_stack/api/boq/wizard/sheet_preview.py
@@ -59,7 +59,7 @@ def _fetch_boq_file_to_tempfile(source_file_url: str) -> str:
     The tempfile is only created after bytes are successfully downloaded, so a
     failed fetch never leaves an orphaned file.
     """
-    from frappe_s3_attachment.controller import S3Operations  # noqa: PLC0415
+    from frappe_gcp_attachment.controller import S3Operations  # noqa: PLC0415
 
     key = _derive_s3_key(source_file_url)
 

--- a/nirmaan_stack/api/frappe_s3_attachment.py
+++ b/nirmaan_stack/api/frappe_s3_attachment.py
@@ -1,6 +1,6 @@
 import frappe
 import urllib.parse
-from frappe_s3_attachment.controller import S3Operations
+from frappe_gcp_attachment.controller import S3Operations
 
 @frappe.whitelist()
 def get_s3_temp_url(file_url):
@@ -12,7 +12,7 @@ def get_s3_temp_url(file_url):
         return ""
     
     # Check if it's our specific S3 proxy URL
-    if "frappe_s3_attachment.controller.generate_file" in file_url:
+    if "frappe_gcp_attachment.controller.generate_file" in file_url:
         try:
             parsed = urllib.parse.urlparse(file_url)
             params = urllib.parse.parse_qs(parsed.query)

--- a/nirmaan_stack/services/extraction/files.py
+++ b/nirmaan_stack/services/extraction/files.py
@@ -25,12 +25,12 @@ SETTINGS_DOCTYPE = "Document AI Settings"
 
 def fetch_file_content(file_doc, file_name=None):
     """Return raw bytes for a File doc — S3 presigned URL or local bench file."""
-    if file_doc.file_url and "/api/method/frappe_s3_attachment" in file_doc.file_url:
+    if file_doc.file_url and ("/api/method/frappe_gcp_attachment" in file_doc.file_url):
         try:
             import urllib.parse
 
             import requests
-            from frappe_s3_attachment.controller import S3Operations
+            from frappe_gcp_attachment.controller import S3Operations
 
             s3 = S3Operations()
             s3_key = file_doc.content_hash


### PR DESCRIPTION
Point every live attachment read path at the GCP app, matching the stored file URLs which now name frappe_gcp_attachment.controller.

parse_run._fetch_boq_file_to_tempfile routes local-vs-cloud on the module name in BOQs.source_file_url. Left on the old string it would have sent all 105 BoQs down the local branch and copy2'd an /api/method/... URL as a path, failing every parse with fetch_failed.

api/frappe_s3_attachment.get_s3_temp_url is the shared helper behind po_print, pdf_merger_api and bulk_download; its URL check missing meant returning the raw proxy URL, which those callers fall back to fetching over unauthenticated HTTP -- silently dropping attachments from merged PDFs rather than erroring. The module keeps its filename; only its internals move to GCP.

sheet_preview and services/extraction/files: import + URL check.

S3Operations resolves via the backward-compatible alias in frappe_gcp_attachment.controller; get_url and read_file_from_s3 keep identical signatures, so no call sites change.