### PR TITLE
Uri fix

### DIFF
--- a/frontend/.claude/context/domain/commissioning-report-templates.md
+++ b/frontend/.claude/context/domain/commissioning-report-templates.md
@@ -17,7 +17,7 @@ Each commissioning task type (e.g., "Sprinkler Pressure Test Report") declares a
 - Saves the structured response into the child row's `response_data` Long Text field.
 - Stores a **frozen snapshot** of the template used (in a content-addressed pool) so older filled reports always render correctly even after the master template changes.
 
-**Decoupling rule (updated):** Filling/saving the wizard does **not** directly set `task_status` — status is driven by the per-row action buttons (Submit for Approval, Approve, Upload Signed, …; see workflow below). **One exception:** saving the wizard for a **Rejected** task resolves it back to **Pending** (`update_task_response` flips it). The backend `validate_report_evidence_for_completed` hook still accepts a meaningfully filled `response_data` as evidence on the Completed transition.
+**Decoupling rule (updated):** Filling/saving the wizard does **not** directly set `task_status` — status is driven by the per-row action buttons (Submit for Approval, Approve, Upload Signed, …; see workflow below). **One exception:** saving the wizard for a **Rejected** task resolves it back to **Pending** (`update_task_response` flips it). The backend `validate_report_evidence_for_completed` hook (name unchanged) still accepts a meaningfully filled `response_data` as evidence on the terminal **`Client Accepted`** transition.
 
 ---
 
@@ -29,57 +29,61 @@ Each commissioning task type (e.g., "Sprinkler Pressure Test Report") declares a
 Every task carries a **`report_type`** (`Field` | `Vendor`, default `Field`), stored on both the master (`Commission Report Tasks.report_type`) and the instance (`Commission Report Task Child Table.report_type`). The master value seeds new project tasks; per-project it's editable (via the row's **Configure** modal) only while the task is `Pending` or `Not Applicable`.
 
 - **Field** → internal team fills the wizard, then goes through approval + client-signature.
-- **Vendor** → external vendor; the team just **uploads a PDF**, which **completes the task directly** (no approval, no signature).
+- **Vendor** → external vendor; the team **uploads a PDF** and **sends it for approval** (two-step, mirrors Field's approval gate but with **no wizard and no client-signature step**). Approve completes it directly.
 
 Missing/empty `report_type` is treated as `Field` for back-compat.
 
 ### Status set
 `task_status` is a plain `Data` field; the option list lives in frontend code (`useCommissionMasters.TASK_STATUS_OPTIONS`). Values:
 
-`Not Applicable` · `Pending` · `Pending Approval` · `Approved` · `Rejected` · `Completed`
+`Not Applicable` · `Pending` · `Pending Approval` · `Submitted` · `Rejected` · `Client Accepted`
 
-Badge colors (`utils.getUnifiedStatusStyle`): Pending=amber, Pending Approval=indigo, Approved=teal, **Rejected=red**, Completed=green, N/A=gray. ("In Progress" was removed.)
+> **Terminology (renamed in code 2026-06):** `Approved → Submitted`, `Completed → Client Accepted`. Older text/UX may say "approved"/"completed" — these are the **same states** as `Submitted`/`Client Accepted`. The "**Approved Reports**" dialog label is the business word for the `Submitted` state (admin-approved, awaiting client signature), **not** a separate status.
+
+Badge colors (`utils.getUnifiedStatusStyle`): Pending=amber, Pending Approval=indigo, Submitted=teal, **Rejected=red**, Client Accepted=green, N/A=gray. ("In Progress" was removed.)
 
 ### State machine
-```
-                       ┌─ Vendor: Upload PDF (approval_proof) ─────────────► Completed   (direct; last_submitted stamped)
-Pending ─ report_type? ┤
-                       └─ Field: Fill wizard (response_data)
-                                     │  Submit for Approval (needs response_data)
-                                     ▼
-                              Pending Approval
-                          ┌──────────┴──────────┐
-                   Approve (Admin/PMO)     Reject (Admin/PMO)
-                          ▼                       ▼
-                       Approved                Rejected
-                          │                       │ Resolve (edit wizard) → SAVE
-   download report (blank client-sig)            ▼
-   → client signs offline                     Pending  ─ Submit for Approval ─► Pending Approval …
-   → Upload Signed (approval_proof)
-                          ▼
-                       Completed   (last_submitted stamped)
+Both report types now share the **same approval gate** (Pending Approval → Submitted / Rejected). They differ only in how the artifact is produced and finished: Field fills a wizard + gets a client signature; Vendor uploads a PDF and skips the signature (approve completes it directly).
 
-Pending / Rejected → Mark as Not Applicable → Not Applicable → Re-activate → Pending
+```
+FIELD:
+  Pending ─ Fill wizard (response_data) ─ Submit for Approval ─► Pending Approval
+     ▲                                              Approve (Admin) │  Reject (Admin)
+     │ Resolve (edit) → SAVE                                    ▼       ▼
+  Rejected ◄────────────────────────────────────────────  Submitted  Rejected
+                                                                │ download (blank client-sig)
+                                                                │ → client signs → Upload Signed (approval_proof)
+                                                                ▼
+                                                         Client Accepted   (last_submitted stamped)
+
+VENDOR (no wizard, no signature):
+  Pending ─ Upload PDF (approval_proof; stays Pending) ─ Send for Approval ─► Pending Approval
+     ▲                                                      Approve (Admin) │  Reject (Admin)
+     │ View / Replace file → Send for Approval                          ▼       ▼
+  Rejected ◄──────────────────────────────────────────────  Client Accepted  Rejected
+                                                             (approve completes directly; last_submitted stamped)
+
+BOTH: Pending / Rejected → Mark as Not Applicable → Not Applicable → Re-activate → Pending
 ```
 
 Key transitions and where they fire:
-- **Submit for Approval** (Field, `response_data` present): `updateTaskChild({task_status:'Pending Approval'})`.
-- **Approve / Reject**: `ApprovalActionDialog` (confirm-only) → `Approved` / `Rejected`. Approve no longer shows a sign step — that lives on the Approved row's own actions.
-- **Resolve** (Rejected): opens the wizard in `edit` mode; **saving** flips `Rejected → Pending` server-side (`update_task_response`, see Decoupling rule). The row then shows **Submit for Approval** again.
-- **Upload Signed** (Approved, Field) / **Upload Report** (Vendor): uploads the PDF to `approval_proof`, sets `task_status:'Completed'`, stamps `last_submitted`.
-- **Send back to Pending** (Admin only): reopens a `Pending Approval` / `Approved` / `Completed` Field task to `Pending`.
+- **Submit for Approval** (Field, `response_data` present) / **Send for Approval** (Vendor, `approval_proof` present): `updateTaskChild({task_status:'Pending Approval'})`. A Vendor upload while `Pending`/`Rejected` only **attaches the file** (stays in place) — the separate Send step moves it to Pending Approval (`ReportActionCell.onFileChosen`).
+- **Approve / Reject**: `ApprovalActionDialog` (confirm-only). Approve → **`Submitted`** for Field, **`Client Accepted`** for Vendor (`report_type === 'Vendor' ? 'Client Accepted' : 'Submitted'`). Reject → `Rejected` (both).
+- **Resolve** (Field, Rejected): opens the wizard in `edit` mode; **saving** flips `Rejected → Pending` server-side (`update_task_response`). **Vendor, Rejected**: View / **Replace file** then **Send for Approval** again.
+- **Upload Signed** (Field, Submitted): uploads the signed PDF to `approval_proof`, sets `task_status:'Client Accepted'`, stamps `last_submitted`.
+- **Send back to Pending** (Admin only, Field): reopens a `Pending Approval` / `Submitted` / `Client Accepted` Field task to `Pending`.
 
 ### Per-row action UI — `ReportActionCell`
 Each tracker/Task-Wise row renders one **primary button** per status + a **⋮ More** menu (pinned to the cell's right edge). The primary by status:
 
 | Status | Field (editor) | Vendor (editor) | View-only |
 |---|---|---|---|
-| Pending (empty) | **Fill Report** | **Upload Report** | View |
-| Pending (draft) | **Submit for Approval** (More: Edit) | — | View |
-| Pending Approval | **View Submission** | View | View |
-| Approved | **Download Report** + **Upload Signed** | — | View |
-| Rejected | **Resolve** (More: Mark N/A) | Upload Report | "Rejected" |
-| Completed | **View Signed Report** | **View Vendor Report** | View |
+| Pending (empty / no file) | **Fill Report** | **Upload Report** | View |
+| Pending (draft / has file) | **Submit for Approval** (More: Edit) | **View** + **Send for Approval** (More: Replace report) | View |
+| Pending Approval | **View Submission** | **View Vendor Report** | View |
+| Submitted | **Download Report** + **Upload Signed** | _n/a — Vendor approve → Client Accepted_ | View |
+| Rejected | **Resolve** (More: Mark N/A) | **View** + **Send for Approval** (More: Replace report) | "Rejected" |
+| Client Accepted | **View Signed Report** | **View Vendor Report** | View |
 | Not Applicable | muted + Re-activate (More) | — | — |
 
 More menu also offers **View Review (answers)** (filled reports), **Configure** (Report Type / Deadline / Comments), **Mark as Not Applicable** (Pending/Rejected), and **Send back to Pending** (Admin only).
@@ -88,22 +92,30 @@ More menu also offers **View Review (answers)** (filled reports), **Configure** 
 - **List page** "Pending Approval" tab → cross-project queue (server-fetched via `get_task_wise_list`, filtered to `task_status='Pending Approval'`).
 - **Details page** "Pending Approval" view → scoped to the tracker; rendered from the already-loaded tasks.
 - Approve/Reject use icon-only triggers → `ApprovalActionDialog`. After any action, refresh updates **both** the table and the tracker list/doc so status-tab counts react immediately.
+- **Vendor** rows now appear here too (Vendor goes through the gate). Their Report column shows **View Vendor Report**, previewing the uploaded file with **`directSrc`** — the file is a GCS `generate_file` **redirect to a signed URL served inline**, so an `<iframe>` (which follows the redirect) renders it, but a cross-origin blob `fetch` would CORS-fail. (Field rows still preview the generated print format via the blob path.)
 
 ### Roles & permissions
+The `Administrator` **user** matches every **Admin** cell below. Every gate is **frontend-only** EXCEPT the wizard edit gate (²), which the backend enforces. Profile strings: Admin = `Nirmaan Admin Profile`, PMO = `Nirmaan PMO Executive Profile`, PM = `Nirmaan Project Manager Profile`, Design Lead = `Nirmaan Design Lead Profile`, Design Exec = `Nirmaan Design Executive Profile`.
+
 | Capability | Admin | PMO | Project Manager | Design Lead | Design Exec |
 |---|:--:|:--:|:--:|:--:|:--:|
-| **Nav: Commission Report Tracker** | ✅ | ✅ | ✅ | ❌ | ❌ |
-| Full editor (any task in project) | ✅ | ✅ | ✅ | ✅ | assigned only |
-| Approve / Reject | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Send back to Pending (reopen) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Add Category/Zone, Create Task, Rename, Bulk Assign | ✅ | ✅ | ❌ | ✅ | ❌ |
+| **Nav: Commission Report Tracker** (sidebar) | ✅ | ✅ | ✅ | ❌ | ❌ |
+| See **Pending Approval** queue (tab) — `isApprover` | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **Approve / Reject** ¹ | ✅ | view-only | ❌ | ❌ | ❌ |
+| **Send back to Pending** (reopen) — `ReportActionCell.isAdmin` | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Bulk Approved Reports** export — `canExportApprovedReports` | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Fill / Submit / Upload report (wizard edit) ² | ✅ | ✅ | ✅ | ✅ | assigned only |
+| **Add Category** / Configure / structure edits ³ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Row-select checkboxes on the task table | ✅ | ✅ | ❌ | ✅ | ❌ |
 
-- **Nav gate** (`NewSidebar.tsx`): Administrator + Admin + PMO + Project Manager only.
-- **Edit gate is role-based, not assignment-based.** Backend `update_task_response._FULL_EDIT_ROLES` = `{System Manager, Nirmaan Admin, Nirmaan PMO Executive, Nirmaan Design Lead, Nirmaan Project Manager}`; only `Nirmaan Design Executive` is in `_RESTRICTED_EDIT_ROLES` (assigned tasks only). Frontend mirrors this (`isReportEditRestricted = isDesignExecutive`).
-- **Approvers** (`isApprover`): Admin, PMO, Administrator.
+- **Nav gate** (`NewSidebar.tsx`, the `/commission-tracker` entry): `Administrator + Admin + PMO + Project Manager` only — so **Design Lead / Design Exec have NO sidebar entry**. Their ✅s above apply only if they reach a tracker via deep link / assignment.
+- **¹ Approve / Reject** = **`Nirmaan Admin Profile` + `Administrator` ONLY** (`GlobalApprovalsTable` renders the action column only when `isAdmin = role === "Nirmaan Admin Profile" || user_id === "Administrator"`). **PMO** opens the Pending Approval queue but sees it **read-only** (no buttons). Frontend-only — writes go through the generic `updateTaskChild`, no server-side role check.
+- **² Wizard edit gate — the ONLY server-enforced permission:** backend `update_task_response._FULL_EDIT_ROLES` = `{System Manager, Nirmaan Admin, Nirmaan PMO Executive, Nirmaan Design Lead, Nirmaan Project Manager}`; `Nirmaan Design Executive` ∈ `_RESTRICTED_EDIT_ROLES` (its **assigned tasks only**). The per-row Fill/Submit/Upload buttons render for anyone with table access (`canEdit = true` is hardcoded in `TaskWiseTable` / `commissionTableColumns`) — the wizard/backend is the real gate; frontend mirrors via `isReportEditRestricted = isDesignExecutive`.
+- **³ Structure edits** (Add Category, Configure, Mark N/A, rename) = `hasEditStructureAccess && !isRestrictedAssigneeRole`, i.e. **Admin / PMO / Design Lead** — PM and Design Exec are excluded (`isRestrictedAssigneeRole = isDesignExecutive || isProjectManager`).
+- **Gate variables** (`project-commission-report-details.tsx`): `hasEditStructureAccess` = Design Lead·Admin·PMO·Administrator · `isApprover` = Admin·PMO·Administrator · `canExportApprovedReports` = Administrator + Admin·PMO·PM·Design Lead · `isRestrictedAssigneeRole` = Design Exec·PM.
 
 ### Counts
-- Task Wise **status tabs** (All / Pending / Pending Approval / Approved / Rejected / Completed) show task counts summed from the tracker list's `status_counts` (excludes N/A).
+- Task Wise **status tabs** (All / Pending / Pending Approval / Submitted / Rejected / Client Accepted) show task counts summed from the tracker list's `status_counts` (excludes N/A).
 - Any approve/reject or status change refreshes **both** the table and the tracker list/doc, so the status-tab counts update immediately.
 
 ### CSV Export
@@ -113,11 +125,20 @@ Both the Task Wise table and the per-zone details table use `onExport="default"`
 - **Values:** `meta.exportValue(row)` overrides where the raw `accessorKey` is wrong/missing — Report Type (details column uses `accessorFn`, so it needs `exportValue`), Deadline (formatted `dd-MMM-yyyy`), and Project (exports `project_name`, not the `project` id).
 - **Scope (current limitation):** `onExportAll` is **not** wired, so the export only covers the **current page** of a server-paginated table; on the details page `showRowSelection` makes it export **selected rows** (or nothing if none selected). Wire `onExportAll={serverDataTable.exportAllRows}` to export the full filtered set.
 
+### Bulk Approved Reports export (async, one merged PDF)
+A **"Bulk Approved Reports"** header button (Download icon, after Add Category) on the tracker details page opens **`ApprovedReportsDialog`**. Visibility is gated by `canExportApprovedReports` = **`Administrator` user + Admin + PMO + Project Manager + Design Lead** (the tracker-access roles plus Design Lead — broader than `hasEditStructureAccess`, which excludes PM). It lists the tracker's **`report_type = Field` AND `task_status = Submitted`** reports ("approved" = the Submitted state — see Terminology), with **Category** filter chips (`All (n)` + one per `commission_category`; select-all is scoped to the filtered view, selection persists across chips by report name), and **Export** merges the selected reports into **one PDF**.
+
+- **Async by design (never blocks other users):** `Export` POSTs `enqueue_commission_reports(tracker, tasks)` (`api/commission_report/bulk_download_reports.py`), which takes a **per-user atomic NX lock**, enqueues `_run_commission_bulk_job` on the **`long` queue**, and returns `{status:"enqueued", job_id}` in ms — no web worker is held. The worker re-gates Field+Submitted, renders each task, merges with `pypdf`, writes a temp file, and streams **user-targeted** realtime events, each stamped with the **`job_id`**: `commission_bulk_progress {job_id,done,total}` / `commission_bulk_ready {job_id,token,filename,rendered,failed,total}` / `commission_bulk_failed {job_id,message}`; the `finally` releases the lock. Download is via the shared **`bulk_download.fetch_temp_file?token=…`** (streams + deletes). Mirrors `api/pdf_helper/bulk_download.py`.
+- **Hardening (review):** the dialog remembers its own `job_id` and **ignores events from any other export** (a second open dialog won't react); if `frappe.enqueue` raises, the **lock is released** (not stranded for the TTL); the `ready` event's **`failed` count** is surfaced ("N of M downloaded; K could not be generated") so a partial merge is never silent; the client safety-timeout is **unmount-safe** and re-armed on each progress tick.
+- **No selection cap** (a full tracker must export); `LOCK_TTL_SECONDS = 300` (5-min job/lock ceiling). Measured ~1.2 s/report → ~60 reports ≈ 1.3 min. The frontend re-arms a "stuck" timeout on each progress tick, so large jobs never falsely time out.
+- **Rendering gotcha (LOAD-BEARING):** the print format selects the child row via `frappe.form_dict.task_row`, which **`frappe.get_print` DROPS** (every task then renders byte-identical). Render each task with **`frappe.render_template(print_format.html, {"doc": tracker_doc})`** (sees the live form_dict) → **`frappe.utils.pdf.get_pdf`** (still reads the format's `@page` margins + `#header-html`/`#footer-html`). Verified per-task-correct.
+- **Deploy note (ops):** the job runs on `long`; ensure a worker processes it. `background_workers: 1` shares one worker with emails/notifications — a dedicated `bench worker --queue long` fully isolates PDF rendering.
+
 ### Bulk Assign — currently disabled
 The "Bulk Assign" toolbar button on the details zone table is **commented out** (`toolbarActions` renders `null`). Row selection, the handler, and `BulkAssignDialog` are left intact — un-comment the block to re-enable.
 
 ### Print format — client signature
-The `render_signatures` macro in `commission-printformat.html` / `ls-commission-printformat.html` renders a **blank signature line** above each role label (incl. CLIENT) so the downloaded Approved report can be physically signed before the signed copy is uploaded. (Per project memory: edit the `.html` source + deliver paste-ready HTML for the Frappe UI; do **not** edit `print_format.json`.)
+The `render_signatures` macro in `commission-printformat.html` / `ls-commission-printformat.html` renders a **blank signature line** above each role label (incl. CLIENT) so the downloaded report (at `Submitted`) can be physically signed before the signed copy is uploaded. (Per project memory: edit the `.html` source + deliver paste-ready HTML for the Frappe UI; do **not** edit `print_format.json`.)
 
 ---
 
@@ -589,7 +610,7 @@ Files are uploaded immediately when the user picks them (so previews work). To a
 | **Per-step Next** | `form.trigger(stepFieldKeys)` against the per-step Zod schema built from the template. |
 | **Submit** | Full schema validation across all steps + 1MB size cap + image-slot required check. |
 | **Backend Save** | Server re-parses + re-runs shape check. Snapshot upsert. Optimistic-concurrency check on parent.modified. |
-| **Status → Completed (existing hook)** | `validate_report_evidence_for_completed` accepts: `file_link` set OR `approval_proof` set OR (`response_data` is a parseable JSON with non-empty `responses` AND `response_snapshot_id` is set). |
+| **Status → Client Accepted (existing hook)** | `validate_report_evidence_for_completed` (name unchanged) accepts: `file_link` set OR `approval_proof` set OR (`response_data` is a parseable JSON with non-empty `responses` AND `response_snapshot_id` is set). |
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "NODE_OPTIONS=--max-http-header-size=8192 vite --host",
     "build": "vite build --base=/assets/nirmaan_stack/frontend/ && yarn run copy-html-entry && yarn run copy-sw",
     "preview": "vite preview",
     "test": "vitest run",

--- a/frontend/src/components/custom-select/project-select.tsx
+++ b/frontend/src/components/custom-select/project-select.tsx
@@ -55,7 +55,12 @@ export default function ProjectSelect({
         filters: all ? undefined : projectFilters,
         limit: 1000,
         orderBy: { field: 'creation', order: 'desc' },
-    });
+    },
+        // Stable SWR key so every ProjectSelect across the app shares one cache
+        // entry (deduped) instead of refetching the whole Projects list per mount.
+        // Keyed by `all` because the two variants fetch different filter sets.
+        all ? "ProjectSelect Projects All" : "ProjectSelect Projects Won"
+    );
 
     const [selectedOption, setSelectedOption] = useState<SelectOptions | null>(null);
 

--- a/frontend/src/components/procurement-request/list-pr.tsx
+++ b/frontend/src/components/procurement-request/list-pr.tsx
@@ -31,46 +31,35 @@ export default function ListPR() {
 
   const { notifications, mark_seen_notification } = useNotificationStore();
 
+  // Single enriched call: the PR list AND each PR's tag headers come back in ONE
+  // round trip. get_pr_summary_list embeds `pr_tag_list` on every row (empty array
+  // when a PR has no tags), so there is no separate get_pr_tags call and no PR-name
+  // list on the URL. Replaces the old load-PRs-then-fetch-tags-by-project pair.
   const {
-    data: procurement_request_list,
+    data: prSummaryResponse,
     isLoading: procurement_request_list_loading,
     error: procurement_request_list_error,
     mutate: prListMutate,
-  } = useFrappeGetDocList<ProcurementRequest>(
-    "Procurement Requests",
+  } = useFrappeGetCall<{ message: { data: ProcurementRequest[] } }>(
+    "nirmaan_stack.api.projects.pr_summary.get_pr_summary_list",
     {
-      fields: ["*"],
-      filters: [["project", "=", selectedProject!]],
-      orderBy: { field: "modified", order: "desc" },
-      limit: 0,
+      doctype: "Procurement Requests",
+      fields: JSON.stringify(["*"]),
+      filters: JSON.stringify([["project", "=", selectedProject]]),
+      order_by: "modified desc",
+      limit_page_length: 0,
     },
-    selectedProject ? `Procurement Requests ${selectedProject}` : null
+    selectedProject ? `PR Summary ${selectedProject}` : null
+  );
+
+  const procurement_request_list = useMemo(
+    () => prSummaryResponse?.message?.data ?? [],
+    [prSummaryResponse]
   );
 
   useFrappeDocTypeEventListener("Procurement Requests", async () => {
     await prListMutate();
-    await prTagsMutate();
   });
-
-  const prNames = useMemo(
-    () => (procurement_request_list || []).map((p) => p.name),
-    [procurement_request_list]
-  );
-
-  const { data: prTagsResponse, mutate: prTagsMutate } = useFrappeGetCall<{
-    message: Record<string, { tag_header: string; tag_package: string }[]>;
-  }>(
-    "nirmaan_stack.api.projects.pr_summary.get_pr_tags_by_names",
-    { pr_names: JSON.stringify(prNames) },
-    selectedProject && prNames.length > 0
-      ? `PR Tags ${selectedProject} ${prNames.length}`
-      : null
-  );
-
-  const tagsByPR = useMemo(
-    () => prTagsResponse?.message ?? {},
-    [prTagsResponse]
-  );
 
 
   const handleChange = (selectedItem: { label: string, value: string } | null) => {
@@ -143,7 +132,7 @@ export default function ListPR() {
                           </Link>
                         </TableCell>
                         <TableCell className="text-sm text-center">
-                          <PRHeadersCell item={item} tags={tagsByPR[item.name]} />
+                          <PRHeadersCell item={item} tags={item.pr_tag_list} />
                         </TableCell>
                         <TableCell className="text-sm text-center">
                           <RenderStatusBadge item={item} selectedProject={selectedProject} />
@@ -203,7 +192,7 @@ export default function ListPR() {
                           </Link>
                         </TableCell>
                         <TableCell className="text-sm text-center">
-                          <PRHeadersCell item={item} tags={tagsByPR[item.name]} />
+                          <PRHeadersCell item={item} tags={item.pr_tag_list} />
                         </TableCell>
                         <TableCell className="text-sm text-center">
                           <RenderStatusBadge item={item} selectedProject={selectedProject} />

--- a/frontend/src/pages/CommissionReport/components/ApprovalActionDialog.tsx
+++ b/frontend/src/pages/CommissionReport/components/ApprovalActionDialog.tsx
@@ -1,6 +1,6 @@
 // Approve / Reject confirmation dialog for the commission approval queue.
-//   Approve: confirm → status Submitted (team handles download → sign → upload later).
-//   Reject:  confirm → status Rejected (team Resolves + resubmits).
+//   Approve: Field → Submitted (team downloads → signs → uploads later); Vendor → Client Accepted (done).
+//   Reject:  confirm → status Rejected (Field: Resolve/edit; Vendor: view/replace the file) + resubmit.
 
 import React, { useEffect, useState } from 'react';
 import { Check, X, Loader2, AlertTriangle } from 'lucide-react';
@@ -18,6 +18,7 @@ export interface ApprovalTaskRef {
     task_name: string;
     hasTemplate?: boolean;
     isLandscape?: boolean;
+    report_type?: string;
 }
 
 interface Props {
@@ -48,8 +49,9 @@ export const ApprovalActionDialog: React.FC<Props> = ({ open, onOpenChange, mode
     const doApprove = async () => {
         setBusy(true);
         try {
-            await updateTaskChild(task.name, { task_status: 'Submitted' });
-            toast({ title: 'Submitted', variant: 'success' });
+            const nextStatus = task.report_type === 'Vendor' ? 'Client Accepted' : 'Submitted';
+            await updateTaskChild(task.name, { task_status: nextStatus });
+            toast({ title: nextStatus === 'Client Accepted' ? 'Approved & Completed' : 'Submitted', variant: 'success' });
             refresh?.();
             close();
         } catch {
@@ -84,8 +86,9 @@ export const ApprovalActionDialog: React.FC<Props> = ({ open, onOpenChange, mode
                         </DialogTitle>
                         <DialogDescription className="text-sm">
                             <span className="font-medium text-gray-700">{task.task_name}</span> will be marked
-                            <strong> Rejected</strong>. The team can <strong>Resolve</strong> it (edit the
-                            submission) and submit for approval again.
+                            <strong> Rejected</strong>. {task.report_type === 'Vendor'
+                                ? <>The team can <strong>view / replace</strong> the uploaded file and send it for approval again.</>
+                                : <>The team can <strong>Resolve</strong> it (edit the submission) and submit for approval again.</>}
                         </DialogDescription>
                     </DialogHeader>
                     {isLockedByOther && (
@@ -123,8 +126,9 @@ export const ApprovalActionDialog: React.FC<Props> = ({ open, onOpenChange, mode
                         <Check className="h-4 w-4 text-green-600" /> Submit report?
                     </DialogTitle>
                     <DialogDescription className="text-sm">
-                        Submit <span className="font-medium text-gray-700">{task.task_name}</span>? The team can
-                        then download the report, get the client signature, and upload the signed copy to mark it Client Accepted.
+                        Submit <span className="font-medium text-gray-700">{task.task_name}</span>? {task.report_type === 'Vendor' 
+                            ? "The vendor report will be approved and marked as Client Accepted." 
+                            : "The team can then download the report, get the client signature, and upload the signed copy to mark it Client Accepted."}
                     </DialogDescription>
                 </DialogHeader>
                 {isLockedByOther && (

--- a/frontend/src/pages/CommissionReport/components/ApprovedReportsDialog.tsx
+++ b/frontend/src/pages/CommissionReport/components/ApprovedReportsDialog.tsx
@@ -1,0 +1,324 @@
+// Dialog opened from the "Bulk Approved Reports" header button on the tracker details page.
+// Lists the Submitted (approved, awaiting client-signature) Field reports, lets the user pick
+// any subset, and exports them as ONE merged PDF.
+//
+// ASYNC by design (does NOT block the site for other users): Export enqueues a background job
+// (nirmaan_stack.api.commission_report.bulk_download_reports.enqueue_commission_reports) that
+// renders + merges on the `long` queue, streams progress over Socket.IO, and hands back a
+// temp-file token we download via the shared bulk_download.fetch_temp_file endpoint.
+// (Vendor reports and non-Submitted tasks are intentionally out of scope.)
+
+import React, { useContext, useMemo, useRef, useState } from 'react';
+import { FrappeContext, FrappeConfig } from 'frappe-react-sdk';
+import { Loader2, Download } from 'lucide-react';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { toast } from '@/components/ui/use-toast';
+
+import type { CommissionReportTask } from '../types';
+import { masterMapKey, type MasterTaskInfo } from './FillReportButton';
+
+interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    trackerId: string;
+    projectName?: string;
+    /** Submitted + Field reports available to export (already scoped by the page). */
+    reports: CommissionReportTask[];
+    masterMap: Map<string, MasterTaskInfo>;
+}
+
+// Safety net: if the job never emits a terminal event (worker died before publish),
+// stop showing the spinner after this long. The server-side lock has its own TTL.
+const EXPORT_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const ApprovedReportsDialog: React.FC<Props> = ({
+    open, onOpenChange, trackerId, projectName, reports, masterMap,
+}) => {
+    const { socket } = useContext(FrappeContext) as FrappeConfig;
+
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+    const [categoryFilter, setCategoryFilter] = useState<string>('all');
+    const [exporting, setExporting] = useState(false);
+    const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // The job_id of the export THIS dialog started; events not matching it are ignored so a
+    // second open dialog never reacts to our progress/ready (F4).
+    const activeJobRef = useRef<string | null>(null);
+
+    const clearSafetyTimeout = () => {
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = null;
+        }
+    };
+
+    const resetRun = () => {
+        clearSafetyTimeout();
+        activeJobRef.current = null;
+        setExporting(false);
+        setProgress(null);
+    };
+
+    // Clear a pending safety timer if the dialog unmounts mid-export (F3) — otherwise it
+    // fires ~5 min later and calls setState/toast on an unmounted component.
+    React.useEffect(() => () => clearSafetyTimeout(), []);
+
+    // (Re)arm the "no events at all" safety net. Re-armed on every progress tick, so a large
+    // job (60, 100, … reports) that keeps reporting progress NEVER falsely times out — only a
+    // genuinely stuck job (no event for EXPORT_TIMEOUT_MS) trips it.
+    const armSafetyTimeout = () => {
+        clearSafetyTimeout();
+        timeoutRef.current = setTimeout(() => {
+            toast({ title: 'Still working…', description: 'This is taking longer than expected. Please try again.', variant: 'destructive' });
+            resetRun();
+        }, EXPORT_TIMEOUT_MS);
+    };
+
+    const triggerDownload = (token: string, filename: string) => {
+        const url = `/api/method/nirmaan_stack.api.pdf_helper.bulk_download.fetch_temp_file?token=${token}&filename=${encodeURIComponent(filename)}`;
+        const link = document.createElement('a');
+        link.href = url;
+        link.setAttribute('download', filename);
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+    };
+
+    // Fresh state each time the dialog opens.
+    React.useEffect(() => {
+        if (open) {
+            setSelected(new Set());
+            setCategoryFilter('all');
+            resetRun();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open]);
+
+    // Socket listeners live while the dialog is open. The job is user-targeted server-side,
+    // so we only ever receive our own events.
+    React.useEffect(() => {
+        if (!socket || !open) return;
+
+        // Ignore events from an export this dialog didn't start (F4). If job_id is absent
+        // (older payload), fall through and handle it.
+        const isMine = (d: { job_id?: string }) => !d.job_id || d.job_id === activeJobRef.current;
+
+        const onProgress = (d: { job_id?: string; done: number; total: number }) => {
+            if (!isMine(d)) return;
+            setProgress({ done: d.done, total: d.total });
+            armSafetyTimeout(); // keep-alive: a progress tick means the job is running
+        };
+
+        const onReady = (d: { job_id?: string; token: string; filename: string; rendered?: number; failed?: number; total?: number }) => {
+            if (!isMine(d)) return;
+            triggerDownload(d.token, d.filename);
+            const failed = d.failed ?? 0;
+            toast(
+                failed > 0
+                    ? { title: 'Exported with issues', description: `${d.rendered ?? '?'} of ${d.total ?? '?'} report(s) downloaded; ${failed} could not be generated.`, variant: 'destructive' }
+                    : { title: 'Exported', description: 'Your merged PDF is downloading.', variant: 'success' },
+            );
+            resetRun();
+            onOpenChange(false);
+        };
+
+        const onFailed = (d: { job_id?: string; message?: string }) => {
+            if (!isMine(d)) return;
+            toast({ title: 'Failed', description: d?.message || 'Could not generate the reports.', variant: 'destructive' });
+            resetRun();
+        };
+
+        socket.on('commission_bulk_progress', onProgress);
+        socket.on('commission_bulk_ready', onReady);
+        socket.on('commission_bulk_failed', onFailed);
+        return () => {
+            socket.off('commission_bulk_progress', onProgress);
+            socket.off('commission_bulk_ready', onReady);
+            socket.off('commission_bulk_failed', onFailed);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [socket, open]);
+
+    // Distinct categories present (for the filter chips), with counts.
+    const categories = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const r of reports) counts.set(r.commission_category, (counts.get(r.commission_category) || 0) + 1);
+        return Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+    }, [reports]);
+
+    const visibleReports = categoryFilter === 'all'
+        ? reports
+        : reports.filter((r) => r.commission_category === categoryFilter);
+
+    // Select-all is scoped to the CURRENT filter view; selection itself persists across filters
+    // (by report name), so Export always sends every ticked report whatever category chip is active.
+    const allVisibleSelected = visibleReports.length > 0 && visibleReports.every((r) => selected.has(r.name));
+
+    const toggle = (name: string) =>
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(name)) next.delete(name);
+            else next.add(name);
+            return next;
+        });
+
+    const toggleAllVisible = () =>
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (allVisibleSelected) visibleReports.forEach((r) => next.delete(r.name));
+            else visibleReports.forEach((r) => next.add(r.name));
+            return next;
+        });
+
+    const handleExport = async () => {
+        if (selected.size === 0) return;
+        setExporting(true);
+        // Don't seed progress with selected.size — the backend re-gates and streams the
+        // authoritative total on the first tick (F5); the button shows a spinner until then.
+        try {
+            const tasks = reports
+                .filter((r) => selected.has(r.name))
+                .map((r) => {
+                    const info = masterMap.get(masterMapKey(r.commission_category, r.task_name));
+                    return { name: r.name, landscape: !!info?.isLandscape };
+                });
+
+            const res = await fetch(
+                '/api/method/nirmaan_stack.api.commission_report.bulk_download_reports.enqueue_commission_reports',
+                {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-Frappe-CSRF-Token': (window as any).csrf_token || '',
+                    },
+                    body: JSON.stringify({ tracker: trackerId, tasks }),
+                },
+            );
+            if (!res.ok) {
+                // Surface the server message (e.g. "already in progress", size cap).
+                let msg = 'Failed to start the export.';
+                try {
+                    const j = await res.json();
+                    if (j?._server_messages) msg = JSON.parse(JSON.parse(j._server_messages)[0]).message || msg;
+                } catch { /* keep default */ }
+                throw new Error(msg);
+            }
+            // Remember which job is ours so we only react to its events (F4).
+            const j = await res.json();
+            activeJobRef.current = j?.message?.job_id ?? null;
+            // Enqueued: wait for the commission_bulk_* events (re-armed on each progress tick).
+            armSafetyTimeout();
+        } catch (e: any) {
+            toast({ title: 'Error', description: e?.message || 'Failed to start the export.', variant: 'destructive' });
+            resetRun();
+        }
+    };
+
+    // Block closing while a job is in flight (keeps the socket listener alive for the download).
+    const handleOpenChange = (o: boolean) => {
+        if (!o && exporting) return;
+        onOpenChange(o);
+    };
+
+    const pct = progress && progress.total ? Math.round((progress.done / progress.total) * 100) : 0;
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Approved Reports</DialogTitle>
+                </DialogHeader>
+
+                {reports.length === 0 ? (
+                    <div className="py-10 text-center text-sm text-gray-500">
+                        No approved reports yet. A report appears here once its Field task is{' '}
+                        <span className="font-medium text-gray-700">Submitted</span> (approved, awaiting client signature).
+                    </div>
+                ) : (
+                    <div className="space-y-2">
+                        {/* Category filter chips (mirrors the reference dialog's package filters) */}
+                        {categories.length > 1 && (
+                            <div className="flex items-center gap-2">
+                                <span className="shrink-0 text-[11px] font-medium text-gray-500">Category:</span>
+                                <div className="flex items-center gap-1.5 overflow-x-auto pb-1">
+                                <button
+                                    type="button"
+                                    onClick={() => setCategoryFilter('all')}
+                                    disabled={exporting}
+                                    className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium whitespace-nowrap transition-colors cursor-pointer ${categoryFilter === 'all' ? 'bg-red-600 text-white border-red-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}
+                                >
+                                    All ({reports.length})
+                                </button>
+                                {categories.map(([cat, n]) => (
+                                    <button
+                                        key={cat}
+                                        type="button"
+                                        onClick={() => setCategoryFilter(cat)}
+                                        disabled={exporting}
+                                        className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium whitespace-nowrap transition-colors cursor-pointer ${categoryFilter === cat ? 'bg-red-600 text-white border-red-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}
+                                    >
+                                        {cat} ({n})
+                                    </button>
+                                ))}
+                                </div>
+                            </div>
+                        )}
+
+                        <div className="flex items-center justify-between gap-2 px-1 pb-2 border-b">
+                            <span className="text-[11px] text-gray-400">
+                                Admin-approved (Submitted) reports only
+                            </span>
+                            <label htmlFor="approved-all" className="flex items-center gap-2 text-xs font-medium text-gray-600 cursor-pointer">
+                                Select all ({visibleReports.length})
+                                <Checkbox id="approved-all" checked={allVisibleSelected} onCheckedChange={toggleAllVisible} disabled={exporting} />
+                            </label>
+                        </div>
+                        <div className="max-h-[50vh] overflow-y-auto pr-1 space-y-1">
+                            {visibleReports.map((r) => (
+                                <label
+                                    key={r.name}
+                                    className="flex items-center gap-3 rounded-md px-2 py-2 hover:bg-gray-50 cursor-pointer"
+                                >
+                                    <Checkbox
+                                        checked={selected.has(r.name)}
+                                        onCheckedChange={() => toggle(r.name)}
+                                        disabled={exporting}
+                                    />
+                                    <div className="min-w-0">
+                                        <div className="text-sm font-medium truncate">{r.task_name}</div>
+                                        <div className="text-[11px] text-gray-500 truncate">{r.commission_category}</div>
+                                    </div>
+                                </label>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {exporting && progress && (
+                    <div className="px-1 pt-1">
+                        <div className="flex justify-between text-[11px] text-gray-500 mb-1">
+                            <span>Preparing your PDF…</span>
+                            <span className="tabular-nums">{progress.done} / {progress.total}</span>
+                        </div>
+                        <div className="h-1.5 w-full rounded-full bg-gray-100 overflow-hidden">
+                            <div className="h-full bg-blue-600 transition-all duration-300" style={{ width: `${pct}%` }} />
+                        </div>
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <Button variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={exporting}>
+                        Cancel
+                    </Button>
+                    <Button size="sm" className="gap-1" onClick={handleExport} disabled={selected.size === 0 || exporting}>
+                        {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+                        {exporting ? 'Preparing…' : `Export${selected.size > 0 ? ` (${selected.size})` : ''}`}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/frontend/src/pages/CommissionReport/components/GlobalApprovalsTable.tsx
+++ b/frontend/src/pages/CommissionReport/components/GlobalApprovalsTable.tsx
@@ -20,6 +20,7 @@ import { DataTable } from "@/components/data-table/new-data-table";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { useServerDataTable } from "@/hooks/useServerDataTable";
 import { useUserData } from "@/hooks/useUserData";
+import SITEURL from "@/constants/siteURL";
 
 import { useCommissionMasters } from "../hooks/useCommissionMasters";
 import { CommissionReportTask } from "../types";
@@ -64,8 +65,11 @@ export const GlobalApprovalsTable: React.FC<Props> = ({ trackerName, onRefresh }
     // Approve / Reject actions are Admin-only; PMO sees the queue read-only.
     const isAdmin = role === "Nirmaan Admin Profile" || user_id === "Administrator";
 
-    const [preview, setPreview] = useState<{ open: boolean; url: string; title: string }>({ open: false, url: "", title: "" });
-    const openPreview = useCallback((url: string, title: string) => setPreview({ open: true, url, title }), []);
+    const [preview, setPreview] = useState<{ open: boolean; url: string; title: string; direct: boolean }>({ open: false, url: "", title: "", direct: false });
+    // `direct` renders the URL straight in the iframe. Required for the uploaded vendor
+    // file, which is served via a GCS `generate_file` redirect that a cross-origin blob
+    // fetch cannot follow (CORS). Field print-format previews keep the blob path (direct=false).
+    const openPreview = useCallback((url: string, title: string, direct = false) => setPreview({ open: true, url, title, direct }), []);
     const [approval, setApproval] = useState<{ open: boolean; mode: 'approve' | 'reject' | null; task: ApprovalTaskRef | null }>(
         { open: false, mode: null, task: null },
     );
@@ -85,6 +89,7 @@ export const GlobalApprovalsTable: React.FC<Props> = ({ trackerName, onRefresh }
                 task_name: task.task_name,
                 hasTemplate: !!info?.hasTemplate,
                 isLandscape: !!info?.isLandscape,
+                report_type: task.report_type,
             },
         });
     }, [masterMap]);
@@ -151,6 +156,24 @@ export const GlobalApprovalsTable: React.FC<Props> = ({ trackerName, onRefresh }
             cell: ({ row }) => {
                 const t = row.original;
                 const info = masterMap.get(masterMapKey(t.commission_category, t.task_name));
+                
+                if (t.report_type === 'Vendor' && t.approval_proof) {
+                    const uploadedHref = t.approval_proof.startsWith('http') ? t.approval_proof : SITEURL + t.approval_proof;
+                    return (
+                        <div className="flex justify-center">
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 gap-1"
+                                onClick={() => openPreview(uploadedHref, t.task_name, true)}
+                                title="View the submitted vendor report"
+                            >
+                                <Eye className="h-3 w-3" /> <span className="text-[11px] font-medium">View Vendor Report</span>
+                            </Button>
+                        </div>
+                    );
+                }
+
                 if (!info?.hasTemplate) {
                     return <div className="text-center text-[11px] text-gray-400">--</div>;
                 }
@@ -298,6 +321,7 @@ export const GlobalApprovalsTable: React.FC<Props> = ({ trackerName, onRefresh }
                 open={preview.open}
                 onOpenChange={(o) => setPreview((p) => ({ ...p, open: o }))}
                 pdfUrl={preview.url}
+                directSrc={preview.direct}
                 title={preview.title}
                 canDownload={false}
             />

--- a/frontend/src/pages/CommissionReport/components/ReportActionCell.tsx
+++ b/frontend/src/pages/CommissionReport/components/ReportActionCell.tsx
@@ -5,7 +5,9 @@
 // Status → primary:
 //   Pending  (Field, empty)  -> Fill Report
 //   Pending  (Field, draft)  -> Submit for Approval   (More: Edit)
-//   Pending  (Vendor)        -> Upload Report
+//   Pending  (Vendor, no file) -> Upload Report
+//   Pending  (Vendor, file)    -> View Report + Send for Approval  (More: Replace report)
+//   Rejected (Vendor, file)    -> View Report + Send for Approval  (More: Replace report)
 //   Pending Approval         -> View Submission        (+ "awaiting approval")
 //   Submitted                -> Download Report + Upload Signed (helper text)
 //   Client Accepted          -> View Signed Report      (More: Replace)
@@ -137,12 +139,17 @@ export const ReportActionCell: React.FC<Props> = ({ parentName, task, masterMap,
                 fieldname: 'approval_proof',
                 isPrivate: true,
             });
-            await updateTaskChild(task.name, {
-                approval_proof: uploaded.file_url,
-                task_status: 'Client Accepted',
-                last_submitted: todayDate(),
-            });
-            toast({ title: 'Report completed', variant: 'success' });
+            // A vendor upload/replace while Pending or Rejected only ATTACHES the file —
+            // the user then clicks "Send for Approval" (a separate step, mirroring Field's
+            // Fill → Submit). Every other upload (Field signed-copy from Submitted) completes.
+            const isVendorDraftUpload = isVendor && (status === 'Pending' || status === 'Rejected');
+            await updateTaskChild(
+                task.name,
+                isVendorDraftUpload
+                    ? { approval_proof: uploaded.file_url }
+                    : { approval_proof: uploaded.file_url, task_status: 'Client Accepted', last_submitted: todayDate() },
+            );
+            toast({ title: isVendorDraftUpload ? 'File uploaded — send for approval when ready' : 'Report completed', variant: 'success' });
             refresh?.();
         } catch {
             toast({ title: 'Upload failed', variant: 'destructive' });
@@ -185,7 +192,11 @@ export const ReportActionCell: React.FC<Props> = ({ parentName, task, masterMap,
         moreItems.push({ icon: Upload, label: 'Upload Signed Copy', onClick: triggerUpload });
     }
     if (canEdit && status === 'Client Accepted' && hasFile) {
-        moreItems.push({ icon: ReplaceIcon, label: 'Replace Signed Copy', onClick: triggerUpload });
+        moreItems.push({ icon: ReplaceIcon, label: isVendor ? 'Replace report' : 'Replace Signed Copy', onClick: triggerUpload });
+    }
+    // Vendor draft (Pending/Rejected) with a file attached: allow swapping it before resending.
+    if (canEdit && isVendor && (status === 'Pending' || status === 'Rejected') && hasFile) {
+        moreItems.push({ icon: ReplaceIcon, label: 'Replace report', onClick: triggerUpload });
     }
     if (canDownload && hasTemplate) {
         moreItems.push({ icon: Eye, label: 'View generated report', onClick: () => openPreview(genUrl, canDownload, task.task_name) });
@@ -299,7 +310,17 @@ export const ReportActionCell: React.FC<Props> = ({ parentName, task, masterMap,
             return shell(<span className="text-[11px] text-red-600">Rejected</span>);
         }
         if (isVendor) {
-            return shell(primaryBtn(Upload, 'Upload Report', triggerUpload, 'bg-blue-600 hover:bg-blue-700'));
+            if (!hasFile) {
+                return shell(primaryBtn(Upload, 'Upload Report', triggerUpload, 'bg-blue-600 hover:bg-blue-700'));
+            }
+            // Rejected: view the file, replace it if needed (⋮ Replace report), then resend.
+            return shell(
+                <div className="flex flex-col gap-1">
+                    {primaryBtn(Eye, 'View Report', () => openPreview(uploadedHref, false, task.task_name, true))}
+                    {primaryBtn(Send, 'Send for Approval', sendForApproval, 'bg-indigo-600 hover:bg-indigo-700')}
+                </div>,
+                'Rejected — view, replace if needed, then resend',
+            );
         }
         // Resolve = edit the submission; saving it moves the task to Pending, where
         // "Submit for Approval" then appears.
@@ -310,6 +331,12 @@ export const ReportActionCell: React.FC<Props> = ({ parentName, task, masterMap,
     }
 
     if (status === 'Pending Approval') {
+        if (isVendor && uploadedHref) {
+            return shell(
+                primaryBtn(Eye, 'View Vendor Report', () => openPreview(uploadedHref, false, task.task_name, true)),
+                'Awaiting approval'
+            );
+        }
         return shell(
             <>
                 {hasTemplate
@@ -327,7 +354,17 @@ export const ReportActionCell: React.FC<Props> = ({ parentName, task, masterMap,
         );
     }
     if (isVendor) {
-        return shell(primaryBtn(Upload, 'Upload Report', triggerUpload, 'bg-blue-600 hover:bg-blue-700'));
+        if (!hasFile) {
+            return shell(primaryBtn(Upload, 'Upload Report', triggerUpload, 'bg-blue-600 hover:bg-blue-700'));
+        }
+        // File attached — review it, then send for approval (⋮ Replace report to swap it).
+        return shell(
+            <div className="flex flex-col gap-1">
+                {primaryBtn(Eye, 'View Report', () => openPreview(uploadedHref, false, task.task_name, true))}
+                {primaryBtn(Send, 'Send for Approval', sendForApproval, 'bg-indigo-600 hover:bg-indigo-700')}
+            </div>,
+            'Review the file, then send for approval',
+        );
     }
     if (!info?.isActive) {
         return shell(<span className="text-[11px] text-gray-400">Template inactive</span>);

--- a/frontend/src/pages/CommissionReport/project-commission-report-details.tsx
+++ b/frontend/src/pages/CommissionReport/project-commission-report-details.tsx
@@ -44,6 +44,7 @@ import {
 } from "@tanstack/react-table";
 import { getTaskTableColumns, TASK_DATE_COLUMNS } from './config/commissionTableColumns';
 import { useMasterTaskMap } from './report-wizard/data/useMasterTaskMap';
+import { ApprovedReportsDialog } from './components/ApprovedReportsDialog';
 
 const DOCTYPE = 'Project Commission Report';
 
@@ -312,6 +313,14 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
     const hasEditStructureAccess = role === "Nirmaan Design Lead Profile" || role === "Nirmaan Admin Profile" || role === "Nirmaan PMO Executive Profile" || user_id === "Administrator";
     // Approvers (Admin / PMO) get the Approvals queue tab + Approve/Reject actions.
     const isApprover = role === "Nirmaan Admin Profile" || role === "Nirmaan PMO Executive Profile" || user_id === "Administrator";
+    // Who may open the "Bulk Approved Reports" export: Administrator + Admin + PMO + Project Manager
+    // (the tracker-access roles) + Design Lead (kept from the prior hasEditStructureAccess gate).
+    const canExportApprovedReports = user_id === "Administrator" || [
+        "Nirmaan Admin Profile",
+        "Nirmaan PMO Executive Profile",
+        "Nirmaan Project Manager Profile",
+        "Nirmaan Design Lead Profile",
+    ].includes(role);
     // Status-filter tabs above the table. All / per-status filter the task table;
     // 'Pending Approval' (approver-only, last after a divider) opens the approvals queue.
     const [activeStatusTab, setActiveStatusTab] = useState<string>('All');
@@ -334,6 +343,7 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
     const [sorting, setSorting] = useState<SortingState>([{ id: 'deadline', desc: false }]);
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 });
     const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+    const [isApprovedReportsOpen, setIsApprovedReportsOpen] = useState(false);
 
     // --- Progress Calculations for Header (phase-scoped) ---
     // Phase-scoped tasks for progress metrics
@@ -522,48 +532,55 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
         await handleParentDocSave({ commission_report_task: updatedTasks });
     };
 
-    const handleDownloadReport = async (isFullReport: boolean = false) => {
-        const printFormatName = "Project Commission Report";
-        const params = new URLSearchParams({
-            doctype: DOCTYPE,
-            name: trackerId!,
-            format: printFormatName,
-            no_letterhead: "0",
-            _lang: "en",
-            phase: isFullReport ? "All" : activePhase, // Pass 'All' or current phase
-        });
+    // const handleDownloadReport = async (isFullReport: boolean = false) => {
+    //     const printFormatName = "Project Commission Report";
+    //     const params = new URLSearchParams({
+    //         doctype: DOCTYPE,
+    //         name: trackerId!,
+    //         format: printFormatName,
+    //         no_letterhead: "0",
+    //         _lang: "en",
+    //         phase: isFullReport ? "All" : activePhase, // Pass 'All' or current phase
+    //     });
 
-        const downloadUrl = `/api/method/frappe.utils.print_format.download_pdf?${params.toString()}`;
+    //     const downloadUrl = `/api/method/frappe.utils.print_format.download_pdf?${params.toString()}`;
 
-        try {
-            toast({ title: "Generating PDF...", description: "Please wait while we generate your report." });
+    //     try {
+    //         toast({ title: "Generating PDF...", description: "Please wait while we generate your report." });
 
-            const response = await fetch(downloadUrl);
-            if (!response.ok) throw new Error('PDF generation failed.');
+    //         const response = await fetch(downloadUrl);
+    //         if (!response.ok) throw new Error('PDF generation failed.');
 
-            const blob = await response.blob();
+    //         const blob = await response.blob();
 
-            const now = new Date();
-            const dateStr = format(now, "dd_MMM_yyyy");
-            const projectNameClean = (trackerDoc?.project_name || "Project").replace(/[^a-zA-Z0-9-_]/g, "_");
+    //         const now = new Date();
+    //         const dateStr = format(now, "dd_MMM_yyyy");
+    //         const projectNameClean = (trackerDoc?.project_name || "Project").replace(/[^a-zA-Z0-9-_]/g, "_");
 
-            const filename = `${projectNameClean}-${activePhase}-${dateStr}-CommissionReport.pdf`;
+    //         const filename = `${projectNameClean}-${activePhase}-${dateStr}-CommissionReport.pdf`;
 
-            const url = window.URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.href = url;
-            link.setAttribute('download', filename);
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            window.URL.revokeObjectURL(url);
+    //         const url = window.URL.createObjectURL(blob);
+    //         const link = document.createElement('a');
+    //         link.href = url;
+    //         link.setAttribute('download', filename);
+    //         document.body.appendChild(link);
+    //         link.click();
+    //         link.remove();
+    //         window.URL.revokeObjectURL(url);
 
-            toast({ title: "Success", description: "Report downloaded successfully.", variant: "success" });
-        } catch (error) {
-            console.error("Download Error:", error);
-            toast({ title: "Error", description: "Failed to download PDF.", variant: "destructive" });
-        }
-    };
+    //         toast({ title: "Success", description: "Report downloaded successfully.", variant: "success" });
+    //     } catch (error) {
+    //         console.error("Download Error:", error);
+    //         toast({ title: "Error", description: "Failed to download PDF.", variant: "destructive" });
+    //     }
+    // };
+    
+
+    // Approved (Submitted) Field reports available for bulk export in the Approved Reports dialog.
+    const submittedFieldReports = useMemo(
+        () => flattenedTasks.filter((t) => t.report_type === 'Field' && t.task_status === 'Submitted'),
+        [flattenedTasks],
+    );
 
     // --- Inline Task Save Handler ---
     const inlineTaskSaveHandler = async (updatedFields: { [key: string]: any }) => {
@@ -670,14 +687,16 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
                                             <Plus className="h-3 w-3" /> Category
                                         </Button>
                                     )}
-                                    <Button
-                                        variant="default"
-                                        size="sm"
-                                        className="h-7 text-xs gap-1 bg-red-600 hover:bg-red-700 ml-auto"
-                                        onClick={() => handleDownloadReport(true)}
-                                    >
-                                        <Download className="h-3 w-3" /> Download Tracker
-                                    </Button>
+                                    {canExportApprovedReports && (
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            className="h-7 text-xs gap-1 ml-auto"
+                                            onClick={() => setIsApprovedReportsOpen(true)}
+                                        >
+                                            <Download className="h-3 w-3" /> Bulk Approved Reports
+                                        </Button>
+                                    )}
                                     {/* <TooltipProvider>
                                 <Tooltip delayDuration={200}>
                                     <TooltipTrigger asChild>
@@ -722,14 +741,16 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
                                     <Plus className="h-3 w-3" /> Add Category
                                 </Button>
                             )}
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                className="h-8 text-xs gap-1"
-                                onClick={() => handleDownloadReport(true)}
-                            >
-                                <Download className="h-3 w-3" /> Download Tracker
-                            </Button>
+                            {canExportApprovedReports && (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="h-8 text-xs gap-1"
+                                    onClick={() => setIsApprovedReportsOpen(true)}
+                                >
+                                    <Download className="h-3 w-3" /> Bulk Approved Reports
+                                </Button>
+                            )}
                         </div>
                     </div>
 
@@ -856,6 +877,15 @@ export const ProjectCommissionReportDetail: React.FC<ProjectCommissionReportType
                 onOpenChange={setIsAddCategoryModalOpen}
                 availableCategories={availableNewCategories}
                 onAdd={handleAddCategories}
+            />
+
+            <ApprovedReportsDialog
+                open={isApprovedReportsOpen}
+                onOpenChange={setIsApprovedReportsOpen}
+                trackerId={trackerId || ''}
+                projectName={trackerDoc?.project_name}
+                reports={submittedFieldReports}
+                masterMap={masterTaskMap}
             />
 
             {trackerDoc && (

--- a/nirmaan_stack/api/commission_report/bulk_download_reports.py
+++ b/nirmaan_stack/api/commission_report/bulk_download_reports.py
@@ -1,0 +1,201 @@
+"""Bulk-download commission report PDFs — ASYNC (background job).
+
+Renders the per-task print format for each SELECTED commission task on the `long`
+background queue and merges them into ONE PDF, so NO web worker is ever blocked —
+the site stays responsive for every other user even at 55+ reports / many
+concurrent downloads. Mirrors api/pdf_helper/bulk_download.py's
+enqueue -> worker -> socket-progress -> temp-file-token pattern and reuses its
+temp-file helpers + `fetch_temp_file` download endpoint.
+
+Owner scope: only Field-type tasks in Submitted status are rendered; the gate is
+re-checked from the DB in the worker (the client is never trusted for it).
+
+Rendering note: the commission print format selects the child row via
+`frappe.form_dict.task_row`, which `frappe.get_print` DROPS (every task then renders
+identical). So each task is rendered with `frappe.render_template(pf.html, {"doc":
+tracker})` (which sees the live form_dict) then `frappe.utils.pdf.get_pdf`. Verified
+per-task-correct + valid merged PDF.
+"""
+import io
+import json
+
+import frappe
+from frappe import _
+from frappe.utils import today
+from frappe.utils.pdf import get_pdf
+from pypdf import PdfReader, PdfWriter
+
+# Reuse the shared temp-file plumbing (download is via bulk_download.fetch_temp_file).
+from nirmaan_stack.api.pdf_helper.bulk_download import ensure_temp_dir, get_temp_path
+
+PARENT_DOCTYPE = "Project Commission Report"
+CHILD_DOCTYPE = "Commission Report Task Child Table"
+PF_PORTRAIT = "Project Commission Report - Filled Task"
+PF_LANDSCAPE = "LSProject Commission Report - Filled Task"
+
+# No selection cap: the async job has no HTTP timeout, so any number the tracker has
+# (60, 100, …) is handled — we never reject the user. Job/lock window is generous so
+# even a large batch finishes; progress is streamed the whole way.
+LOCK_TTL_SECONDS = 300  # 5 min — auto-releases if a job dies; also the enqueue job timeout
+
+# Realtime events (user-targeted, and carry the job_id so the frontend can ignore
+# events from a different export it didn't start). Consumer: ApprovedReportsDialog.tsx
+EV_PROGRESS = "commission_bulk_progress"
+EV_READY = "commission_bulk_ready"
+EV_FAILED = "commission_bulk_failed"
+
+
+def _lock_key(user):
+    return f"commission_bulk_lock:{user}"
+
+
+@frappe.whitelist()
+def enqueue_commission_reports(tracker=None, tasks=None):
+    """Validate + enqueue a background merge job. Returns immediately.
+
+    Args:
+        tracker: the "Project Commission Report" docname (parent of every selected row).
+        tasks:   JSON list of {"name": <child row name>, "landscape": bool}.
+
+    Returns:
+        {"status": "enqueued", "job_id": <hash>} in ~milliseconds (no render on the web
+        worker). Progress / result / errors arrive via the commission_bulk_* realtime
+        events, each stamped with this job_id.
+    """
+    if isinstance(tasks, str):
+        tasks = json.loads(tasks or "[]")
+
+    if not tracker:
+        frappe.throw(_("Missing tracker."))
+    if not tasks:
+        frappe.throw(_("No tasks selected."))
+
+    if not frappe.has_permission(PARENT_DOCTYPE, "read", doc=tracker):
+        raise frappe.PermissionError(_("Not permitted to read this tracker."))
+
+    user = frappe.session.user
+    # One in-flight bulk job per user, via an ATOMIC set-if-absent (NX) lock with a TTL
+    # (so a dead job can't lock them out forever). NB: a plain get_value-then-set_value on
+    # the same key in one request hits an in-process-cache quirk where the set doesn't
+    # stick — so we use the raw redis SET NX EX instead (make_key = site-namespaced key).
+    cache = frappe.cache()
+    lock_key = cache.make_key(_lock_key(user))
+    if not cache.set(lock_key, "1", ex=LOCK_TTL_SECONDS, nx=True):
+        frappe.throw(_("A report download is already in progress. Please wait for it to finish."))
+
+    job_id = frappe.generate_hash(length=16)
+    try:
+        frappe.enqueue(
+            "nirmaan_stack.api.commission_report.bulk_download_reports._run_commission_bulk_job",
+            queue="long",
+            timeout=LOCK_TTL_SECONDS,
+            user=user,
+            job_id=job_id,
+            tracker=tracker,
+            tasks=tasks,
+        )
+    except Exception:
+        # The job never made it onto the queue — release the lock so the user isn't
+        # stranded for the full TTL, then surface the original error.
+        cache.delete_value(_lock_key(user))
+        raise
+    return {"status": "enqueued", "job_id": job_id}
+
+
+def _run_commission_bulk_job(tracker=None, tasks=None, user=None, job_id=None):
+    """Background worker: render each eligible task, merge, publish the result.
+
+    Runs on the `long` queue (NOT a web worker), so it never blocks page requests.
+    """
+    frappe.set_user(user or "Administrator")
+    try:
+        if isinstance(tasks, str):
+            tasks = json.loads(tasks or "[]")
+
+        # Requested orientation per child row name (appearance only).
+        want_landscape = {}
+        for t in (tasks or []):
+            name = (t or {}).get("name")
+            if name:
+                want_landscape[name] = bool((t or {}).get("landscape"))
+        names = list(want_landscape.keys())
+
+        # Re-fetch + gate (Field + Submitted), scoped to THIS tracker. Authoritative.
+        eligible_rows = frappe.get_all(
+            CHILD_DOCTYPE,
+            filters={
+                "name": ["in", names],
+                "parent": tracker,
+                "parenttype": PARENT_DOCTYPE,
+                "report_type": "Field",
+                "task_status": "Submitted",
+            },
+            fields=["name"],
+        )
+        eligible = {r.name for r in eligible_rows}
+        ordered = [n for n in names if n in eligible]  # preserve client order
+
+        if not ordered:
+            frappe.publish_realtime(
+                EV_FAILED,
+                {"job_id": job_id, "message": "None of the selected tasks are eligible (Field type, Submitted status)."},
+                user=user,
+            )
+            return
+
+        ensure_temp_dir()
+        tracker_doc = frappe.get_doc(PARENT_DOCTYPE, tracker)
+        pf_html_cache = {}
+
+        def _pf_html(landscape):
+            pf_name = PF_LANDSCAPE if landscape else PF_PORTRAIT
+            if pf_name not in pf_html_cache:
+                pf_html_cache[pf_name] = frappe.get_cached_doc("Print Format", pf_name).html or ""
+            return pf_html_cache[pf_name]
+
+        total = len(ordered)
+        merger = PdfWriter()
+        rendered = 0
+        failed = 0
+        for i, name in enumerate(ordered):
+            try:
+                # form_dict.task_row is what the print format reads; render_template sees it live.
+                frappe.local.form_dict["task_row"] = name
+                html = frappe.render_template(_pf_html(want_landscape.get(name)), {"doc": tracker_doc})
+                pdf_content = get_pdf(html)
+                reader = PdfReader(io.BytesIO(pdf_content))
+                for page in reader.pages:
+                    merger.add_page(page)
+                rendered += 1
+            except Exception as e:
+                failed += 1
+                frappe.log_error(message=str(e), title=f"Commission bulk PDF failed for task: {name}")
+            frappe.publish_realtime(EV_PROGRESS, {"job_id": job_id, "done": i + 1, "total": total}, user=user)
+
+        if not rendered:
+            frappe.publish_realtime(EV_FAILED, {"job_id": job_id, "message": "Failed to generate the selected reports."}, user=user)
+            return
+
+        token = frappe.generate_hash(length=32)
+        with open(get_temp_path(token), "wb") as f:
+            merger.write(f)
+        merger.close()
+
+        project_name = frappe.db.get_value(PARENT_DOCTYPE, tracker, "project_name") or "Project"
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in project_name)
+        filename = f"{safe}_Commission_Reports_{today()}.pdf"
+
+        # The temp file exists on disk before this event fires -> no race for the download.
+        # `failed` lets the frontend tell the user some reports were dropped from the merge.
+        frappe.publish_realtime(
+            EV_READY,
+            {"job_id": job_id, "token": token, "filename": filename,
+             "rendered": rendered, "failed": failed, "total": total},
+            user=user,
+        )
+    except Exception as e:
+        frappe.log_error(message=str(e), title="Commission bulk job crashed")
+        frappe.publish_realtime(EV_FAILED, {"job_id": job_id, "message": "The report download failed. Please try again."}, user=user)
+    finally:
+        if user:
+            frappe.cache().delete_value(_lock_key(user))

--- a/nirmaan_stack/api/projects/pr_summary.py
+++ b/nirmaan_stack/api/projects/pr_summary.py
@@ -155,3 +155,25 @@ def get_pr_tags_by_names(pr_names: str | list[str]) -> dict:
             "tag_package": tag.get("tag_package"),
         })
     return tags_by_parent
+
+
+@frappe.whitelist(allow_guest=False)
+def get_pr_tags_by_project(project: str) -> dict:
+    """Return {pr_name: [{tag_header, tag_package}, ...]} for every PR in a project.
+
+    The PR-name list is derived server-side so the caller never ships the whole
+    list of names in the request URL. Passing all names in a GET query string
+    overruns nginx's request-line limit on large projects (the same failure mode
+    that broke the Project-Payments PO-Wise view); passing just the project id
+    keeps the URL O(1) regardless of how many PRs the project has.
+    """
+    if not project:
+        return {}
+    pr_names = frappe.get_all(
+        "Procurement Requests", filters={"project": project}, pluck="name"
+    )
+    if not pr_names:
+        return {}
+    # Reuse the tested name-based path; the IN-list now lives server-side where
+    # there is no URL limit (and well under sqlparse's token cap for one project).
+    return get_pr_tags_by_names(pr_names)


### PR DESCRIPTION
- 1. fix(pr-list): stop tag-fetch URL from overrunning nginx's 8KB limit The PR list's Headers column loaded tags via a GET that put every PR name in the query string.
- 2.chore(dev): cap dev server request-header size to 8KB (match prod nginx) Run Vite dev with NODE_OPTIONS=--max-http-header-size=8192 so an oversized request URL (a large IN-filter or name list on a GET) is rejected locally.
- 3.feat(commission): bulk approved-reports export + vendor approval workflow Bulk export New "Bulk App