### PR TITLE
feat(reports): Monthly WIP & Handover report — Active-days derived fr…

### DIFF
--- a/.claude/plans/monthly-wip-plan.md
+++ b/.claude/plans/monthly-wip-plan.md
@@ -1,0 +1,143 @@
+# Monthly WIP & Handover Report — Full Plan (as-built)
+
+**Feature:** For a selected month, list every project that was **active** (in `WIP` **or** `Handover` status) that month, with — for that month — how many **days it was active** (WIP + Handover combined), the **active start/end** dates, per-project **status chips**, and monthly **counts of DPR, Inventory, DC, DN**. Collapsible per-project rows expand to per-stint sub-rows, each labeled with its status.
+
+**Placement:** it is a **report type inside the Reports hub** — *Reports → Projects tab → Report Type dropdown → "Monthly WIP"* — **not** a sidebar item or standalone route.
+
+**Status (updated 2026-07):**
+- **Plan A — Calculated (live):** ✅ BUILT & verified. Now covers **WIP + Handover**.
+- **Plan B — Document save (persisted):** 📐 DESIGNED, NOT built. Owner deferred; auto monthly cron when built. Needs a new doctype → explicit owner approval.
+
+---
+
+## 1. Context & the core problem
+
+Management wants a monthly oversight view: how long each project was in active execution (`WIP`) or handover (`Handover`), and how much delivery/reporting activity happened.
+
+The hard part: **`Projects.status` is a free-text `Data` field with NO stored status-start date.** When a project entered/left `WIP`/`Handover` exists ONLY in Frappe's built-in `Version` doctype (`Projects` has `track_changes: 1`). So durations are *derived* by replaying status transitions. **No new schema for Plan A** (agreed).
+
+---
+
+## 2. The "Active-days" calculation (WIP + Handover) — validated on live data
+
+Used by both plans (Plan B calls the exact same compute).
+
+**Keyed on the transitions:** a change **`→ WIP`** or **`→ Handover`** starts a period of that status; a change **out of** it ends the period. `WIP` and `Handover` are both "active"; every other status (Won, Halted, CEO Hold, Completed…) is an inactive **gap**.
+
+1. **Reconstruct the status timeline** from `Version` rows → `(status, start, end)` intervals. Status *before the first recorded change* = that change's `old` value, from `[creation → first_change]` (some projects were already active before their first Version row). No Version rows → single `(current status, creation → now)`. Reuses `_extract_status_change_value_pairs` from `api/pmo_dashboard.py`.
+2. **Status-aware merge** (`_merged_active_periods`): merge touching same-status intervals (`next.start <= prev.end` **AND** same status) — this collapses Version-log fragmentation. A **`WIP → Handover`** (or vice-versa) transition is **NOT** merged; it stays **two distinct, adjacent, labeled stints**.
+3. **Intersect each active period with the month**, sum calendar days. Convention: **entry day counts, exit day does not**; the current month is **month-to-date**.
+4. **active_start / active_end / stints:** from the merged active periods overlapping the month; `active_start` = earliest entry, `active_end` = latest exit (or `ongoing`). Drop zero-in-month-day periods. `stints` = count of remaining periods. `days_active` = **WIP + Handover days combined**.
+
+**Live facts:** 112 projects, 847 Project Version rows. Adding Handover grew April from **46 WIP-only rows → 53 active rows** (16 with a Handover stint). Examples — Clayworks Senate: `WIP 12d + Handover 18d = 30`; Hexaware GIFT City: Handover-only (now included); ANSR Gurugram: WIP + 2 Handover stints = 3 stints.
+
+### Column definitions
+
+| Column | Meaning | Source | Business date field |
+|---|---|---|---|
+| **Active Days** | days in WIP **or** Handover that month | Version history | — |
+| **Active Start / End** | earliest entry / latest exit (`Ongoing` if still active) | Version history | — |
+| **Status** (chip) | WIP (sky) / Handover (amber); both shown if it had both | derived from stints | — |
+| **DPR Count** | progress reports filed | `Project Progress Reports` | `report_date` |
+| **Inventory Count** | inventory report submissions | `Remaining Items Report` | `report_date` |
+| **DC Count** | delivery challans | `PO Delivery Documents` where `type="Delivery Challan"` | `dc_date` |
+| **DN Count** | delivery notes | `Delivery Notes` | `delivery_date` |
+
+### How the counts are computed (business date, not created/updated)
+A document counts toward the month if its **business date** is in `[month_start … month_end)`:
+`WHERE project = <p> AND COALESCE(<business_date>, creation::date) >= start AND < next_month_start`.
+- Uses the **business date** (`report_date` / `dc_date` / `delivery_date`) = *when the work happened*.
+- **`creation` is only a fallback** when the business date is blank; the **`modified`/updated date is never used** (editing later never re-buckets a doc).
+- **DC** is filtered to `type = "Delivery Challan"` (the polymorphic doctype also holds MIRs, excluded).
+- **Parent row count** = whole-month total; **per-stint counts** (expander) = the subset whose date falls in that stint's window.
+
+**Row set:** projects with `days_active` > 0 that month (includes projects that have since left; excludes never-active-that-month projects even if they had docs). Sorted by Active Days desc. Role-scoped via `api/seven_days_planning/get_projects_material_plan_stats.py` helpers.
+
+**Accepted limitations (owner OK'd):**
+- Cron CEO-Hold flips + legacy backfill use `set_value(update_modified=False)` → no Version row (best-effort). Verified: currently **0** projects are silently inflated.
+- A project that left with no Version record of ever being WIP/Handover (pure legacy backfill) can't be detected; still-active + normal-UI-transition projects are covered.
+
+---
+
+## 3. Plan A — Calculated (BUILT ✅)
+
+Live compute on each view; **no persistence, no doctype**. CSV export saves a copy.
+
+### Backend — `nirmaan_stack/api/reports/wip_monthly_report.py`
+- Constants: `WIP`, `HANDOVER`, `ACTIVE_STATUSES = (WIP, HANDOVER)`.
+- Pure helpers (unit-tested, no DB): `_build_intervals`, `_merged_active_periods`, `_active_periods_for_month`.
+- `get_wip_month_options()` → dropdown months (recent-first).
+- `get_wip_monthly_report(month)` → `{month, rows:[{project, project_name, days_active, active_start, active_end, stints, dpr, inventory, dc, dn, periods:[{status, start, end, days, dpr, inventory, dc, dn}]}]}`.
+  - Parent counts via SQL `GROUP BY` (ADR-0010); per-stint counts only for multi-stint projects (fetch `(project,date)` rows, bucket into periods).
+
+### Placement — report type in the Reports hub (NOT a sidebar item)
+Wired into the existing Projects-tab report-type mechanism:
+- `src/pages/reports/store/useReportStore.ts` — `'Monthly WIP'` added to the `ProjectReportType` union.
+- `src/pages/reports/ReportsContainer.tsx` — `{ label:'Monthly WIP', value:'Monthly WIP' }` added to `projectReportOptions`.
+- `src/pages/reports/components/ProjectReports.tsx` — lazy-imports `MonthlyWIPPage` and renders it when that type is selected.
+- Visible to the same roles as the other Project reports (Admin / PMO / Accountant / Accountant-Lead / Project-Lead).
+- The old dedicated sidebar item + `/monthly-wip` route were **removed**.
+
+### Frontend — `src/pages/monthly-wip/MonthlyWIPPage.tsx` (+ `useMonthlyWIPData.ts`)
+- **Month dropdown** (default current) drives the fetch.
+- **Expandable table** (`Set<string>` expansion): parent = project active-total; expander only when `stints > 1` → child row per stint, each with a **status badge** (WIP/Handover).
+- **Dates clamped to the selected month** with `← earlier` / `continues →` / `Ongoing` markers, plus a muted `actual: <date>` line and a hover tooltip showing the true lifetime dates.
+- **Status chips** on each project (WIP = sky, Handover = amber; both if mixed); compact sizing via a shared `BADGE_SIZE` const.
+- **Search** box (by project name), **sortable** columns (Active Days / DPR / Inventory / DC / DN), **clickable project name** → project page (`/projects/<id>?page=overview`).
+- Count columns titled **DPR Count / Inventory Count / DC Count / DN Count**.
+- **CSV export** (`utils/exportToCsv.ts`): Project, Active Days, Status, Active Start/End (in-month), Actual Start/End, and the four counts.
+
+### Files
+**Created:** `api/reports/wip_monthly_report.py`, `api/reports/test_wip_monthly_report.py`, `frontend/src/pages/monthly-wip/{MonthlyWIPPage.tsx, useMonthlyWIPData.ts}`.
+**Modified:** `frontend/src/pages/reports/{store/useReportStore.ts, ReportsContainer.tsx, components/ProjectReports.tsx}` (report-type wiring + a scoped `SelectContent` scrollbar fix on the Report-Type dropdown).
+
+### Verification — done
+- **Unit tests: 10/10 pass** (`bench --site localhost run-tests --module nirmaan_stack.api.reports.test_wip_monthly_report`) — incl. status-aware merge + WIP+Handover combined days.
+- Live: `get_wip_monthly_report("2026-04")` → 53 active rows, 16 with Handover stints (Clayworks `WIP 12 + Handover 18 = 30`, etc.).
+- No silently-held projects inflating any month (checked).
+
+---
+
+## 4. Plan B — Document save (DESIGNED 📐, NOT built)
+
+Persist saved monthly reports as documents. **Owner deferred**; trigger = **auto monthly cron**. Build only on explicit go-ahead — needs a new doctype.
+
+### Coexistence — one compute, two consumers
+Refactor the math into a single private `_compute_wip_monthly_report(month)`; `get_wip_monthly_report` returns it live (Plan A), `save_wip_monthly_report` freezes it into a doc (Plan B), `get_saved_wip_monthly_report(name)` reads a snapshot back. Plan A untouched; Plan B is a thin persistence wrapper.
+
+### Doctype (minimal, when approved)
+**`Monthly WIP Report`** — one doc per month: `month` (Data, unique) · `generated_on` · `generated_by` (Link User) · `remarks` (Small Text) · `rows_json` (JSON = frozen rows incl. `days_active` + `status` per period). No child table (add `Monthly WIP Report Row` only if cross-month SQL querying is later needed).
+
+### Trigger — auto monthly cron
+Scheduled job in `hooks.py` `scheduler_events` + `nirmaan_stack/tasks/`; on/after the 1st, compute + save the **previous completed month** (never month-to-date). Idempotent.
+
+### When it's worth building
+Everything derives from immutable history, so Plan A reproduces past months identically. Plan B only adds: official frozen archive, per-report remarks/sign-off, who-saved-when audit, and a scheduled-email feed. Build when one of those is a concrete need.
+
+---
+
+## 5. Plan A vs Plan B
+
+| | Plan A — Calculated (built) | Plan B — Document save (designed) |
+|---|---|---|
+| Storage | none — live compute | `Monthly WIP Report` doc (frozen) |
+| Freshness | always current | frozen at save time |
+| Schema | zero | 1 new doctype (needs approval) |
+| Past months | reproduce identically | frozen exactly as saved |
+| Remarks / sign-off · Audit | ✗ | ✓ |
+| Scheduled email feed | awkward | natural |
+| Trigger | on view | auto monthly cron |
+
+---
+
+## 6. Decision log (owner choices)
+
+- Metric = **Active days = WIP + Handover combined** (started WIP-only; Handover added on request).
+- Each stint is **labeled with its status**; a `WIP → Handover` transition = two stints (not merged).
+- Inclusion = projects **active at any point in the month** (not "currently active"); sorted by Active Days.
+- Days = **within the selected month**; dates clamped to the month with actual dates shown/hover; accuracy = best-effort from Version history, **no new schema** for Plan A.
+- CEO-Hold cron gap = **accepted** ("not a problem").
+- Counts use the **document business date** (`report_date`/`dc_date`/`delivery_date`), `creation` as fallback, **never `modified`**; Inventory = `Remaining Items Report` submissions; DC = `type="Delivery Challan"` only.
+- **Placement = report type in the Reports hub → Projects tab** (reversed the earlier "dedicated sidebar item + `/monthly-wip` page" decision — sidebar item + route removed).
+- Layout = month dropdown, collapsible per-project rows → per-stint sub-rows, project name (not id) + clickable, search + sort, status chips, count columns named `… Count`.
+- Persistence = **Plan A only for now**; Plan B **designed & deferred**, trigger = **auto monthly cron**.

--- a/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
+++ b/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
@@ -1,0 +1,508 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatDate } from "@/utils/FormatDate";
+import { exportToCsv } from "@/utils/exportToCsv";
+import { ColumnDef } from "@tanstack/react-table";
+import {
+  ArrowUpDown,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  Download,
+  Search,
+} from "lucide-react";
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  useMonthlyWIPData,
+  useWipMonthOptions,
+  WipMonthlyRow,
+} from "./useMonthlyWIPData";
+
+type SortKey = "project_name" | "days_active" | "dpr" | "inventory" | "dc" | "dn";
+
+const monthLabel = (options: { value: string; label: string }[], month: string) =>
+  options.find((o) => o.value === month)?.label ?? month;
+
+/**
+ * Clamp an active period's actual start/end to the SELECTED month for display.
+ * The `days_active` figure is already month-scoped; the dates must read the same
+ * way. Actual (lifetime) dates go into `tooltip` for hover ("show both").
+ */
+interface ClampedWip {
+  dispStart: string;   // formatted, clamped to month start
+  dispEnd: string;     // formatted (clamped) or "Ongoing"
+  carriedIn: boolean;  // WIP began before this month
+  carriedOut: boolean; // WIP continues after this month (or ongoing)
+  ongoing: boolean;
+  tooltip: string;     // actual lifetime range
+  actualStart: string; // formatted actual entry date
+  actualEnd: string;   // formatted actual exit date, or "Ongoing"
+}
+
+function clampWip(actualStart: string, actualEnd: string, month: string): ClampedWip {
+  const [y, m] = month.split("-").map(Number);              // m is 1-based
+  const monthStart = new Date(y, m - 1, 1);
+  const monthEndExcl = new Date(y, m, 1);                    // first of next month
+  const monthLastDay = new Date(y, m, 0);                    // last day of this month
+
+  const start = new Date(`${actualStart}T00:00:00`);
+  const ongoing = actualEnd === "ongoing";
+  const end = ongoing ? null : new Date(`${actualEnd}T00:00:00`);
+
+  const carriedIn = start < monthStart;
+  const dispStart = formatDate(carriedIn ? monthStart : start);
+
+  let dispEnd: string;
+  let carriedOut = false;
+  if (ongoing) {
+    dispEnd = "Ongoing";
+    carriedOut = true;
+  } else if (end! >= monthEndExcl) {
+    carriedOut = true;                                        // left after this month
+    dispEnd = formatDate(monthLastDay);
+  } else {
+    dispEnd = formatDate(end!);                               // left within this month
+  }
+
+  const actualStartFmt = formatDate(start);
+  const actualEndFmt = ongoing ? "Ongoing" : formatDate(end!);
+  const tooltip = `Actual: ${actualStartFmt} → ${actualEndFmt}`;
+  return {
+    dispStart,
+    dispEnd,
+    carriedIn,
+    carriedOut,
+    ongoing,
+    tooltip,
+    actualStart: actualStartFmt,
+    actualEnd: actualEndFmt,
+  };
+}
+
+/** Small muted "actual: <date>" line shown under a clamped date when they differ. */
+const ActualLine = ({ date }: { date: string }) => (
+  <div className="text-[10px] text-muted-foreground">actual: {date}</div>
+);
+
+const CarriedIn = () => (
+  <span className="ml-1 text-[10px] text-muted-foreground" title="Was already active before this month">
+    ← earlier
+  </span>
+);
+const CarriedOut = () => (
+  <span className="ml-1 text-[10px] text-muted-foreground" title="Still active after this month">
+    continues →
+  </span>
+);
+const BADGE_SIZE = "px-1.5 py-0 text-[10px] font-normal leading-tight";
+
+const OngoingBadge = () => (
+  <Badge variant="outline" className={`${BADGE_SIZE} border-green-500 text-green-600`}>
+    Ongoing
+  </Badge>
+);
+
+/** WIP = sky, Handover = amber — a compact status chip. */
+const StatusBadge = ({ status }: { status: string }) => (
+  <Badge
+    variant="outline"
+    className={`${BADGE_SIZE} ${
+      status === "Handover"
+        ? "border-amber-500 text-amber-600"
+        : "border-sky-500 text-sky-600"
+    }`}
+  >
+    {status}
+  </Badge>
+);
+
+/** Distinct statuses across a row's stints, e.g. "WIP + Handover". */
+const rowStatuses = (r: WipMonthlyRow) =>
+  Array.from(new Set(r.periods.map((p) => p.status))).join(" + ");
+
+/** One flat CSV line — a project "Total" row, then a row per stint (multi-stint only). */
+interface ExportRow {
+  project: string;
+  row: string;             // "Total" | "Stint 1" | "Stint 2" ...
+  status: string;
+  days: number;
+  start_in_month: string;
+  end_in_month: string;
+  actual_start: string;
+  actual_end: string;
+  dpr: number;
+  inventory: number;
+  dc: number;
+  dn: number;
+}
+
+const EXPORT_COLUMNS: ColumnDef<ExportRow, any>[] = [
+  { accessorKey: "project", header: "Project", meta: { exportHeaderName: "Project" } },
+  { accessorKey: "row", header: "Row", meta: { exportHeaderName: "Row" } },
+  { accessorKey: "status", header: "Status", meta: { exportHeaderName: "Status" } },
+  { accessorKey: "days", header: "Days", meta: { exportHeaderName: "Active / Stint Days" } },
+  { accessorKey: "start_in_month", header: "Start", meta: { exportHeaderName: "Start (in month)" } },
+  { accessorKey: "end_in_month", header: "End", meta: { exportHeaderName: "End (in month)" } },
+  { accessorKey: "actual_start", header: "Actual Start", meta: { exportHeaderName: "Actual Start" } },
+  { accessorKey: "actual_end", header: "Actual End", meta: { exportHeaderName: "Actual End" } },
+  { accessorKey: "dpr", header: "DPR Count", meta: { exportHeaderName: "DPR Count" } },
+  { accessorKey: "inventory", header: "Inventory Count", meta: { exportHeaderName: "Inventory Count" } },
+  { accessorKey: "dc", header: "DC Count", meta: { exportHeaderName: "DC Count" } },
+  { accessorKey: "dn", header: "DN Count", meta: { exportHeaderName: "DN Count" } },
+];
+
+/** Flatten to one Total row per project + a labeled row per stint (multi-stint only). */
+function buildExportRows(rows: WipMonthlyRow[], month: string): ExportRow[] {
+  const clamped = (start: string, end: string) => {
+    const c = clampWip(start, end, month);
+    return {
+      startIn: c.dispStart + (c.carriedIn ? " (from earlier)" : ""),
+      endIn: c.ongoing ? "Ongoing" : c.dispEnd + (c.carriedOut ? " (continues)" : ""),
+    };
+  };
+  const fmtEnd = (end: string) => (end === "ongoing" ? "Ongoing" : formatDate(end));
+
+  const out: ExportRow[] = [];
+  for (const r of rows) {
+    const t = clamped(r.active_start, r.active_end);
+    out.push({
+      project: r.project_name,
+      row: "Total",
+      status: rowStatuses(r),
+      days: r.days_active,
+      start_in_month: t.startIn,
+      end_in_month: t.endIn,
+      actual_start: formatDate(r.active_start),
+      actual_end: fmtEnd(r.active_end),
+      dpr: r.dpr, inventory: r.inventory, dc: r.dc, dn: r.dn,
+    });
+    if (r.stints > 1) {
+      r.periods.forEach((p, i) => {
+        const s = clamped(p.start, p.end);
+        out.push({
+          project: "",           // blank so the stint nests under its project's Total row
+          row: `Stint ${i + 1}`,
+          status: p.status,
+          days: p.days,
+          start_in_month: s.startIn,
+          end_in_month: s.endIn,
+          actual_start: formatDate(p.start),
+          actual_end: fmtEnd(p.end),
+          dpr: p.dpr, inventory: p.inventory, dc: p.dc, dn: p.dn,
+        });
+      });
+    }
+  }
+  return out;
+}
+
+export default function MonthlyWIPPage() {
+  const { options, isLoading: optionsLoading } = useWipMonthOptions();
+  const [month, setMonth] = useState<string>("");
+
+  // Default to the most-recent month once the dropdown options arrive.
+  useEffect(() => {
+    if (!month && options.length) setMonth(options[0].value);
+  }, [options, month]);
+
+  const { report, isLoading, error } = useMonthlyWIPData(month);
+  const rows = report?.rows ?? [];
+  const reportMonth = report?.month ?? month;
+
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("days_active");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    else {
+      setSortKey(key);
+      setSortDir(key === "project_name" ? "asc" : "desc");
+    }
+  };
+  const displayRows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const filtered = q ? rows.filter((r) => r.project_name.toLowerCase().includes(q)) : rows;
+    return [...filtered].sort((a, b) => {
+      if (sortKey === "project_name") {
+        const cmp = a.project_name.localeCompare(b.project_name);
+        return sortDir === "asc" ? cmp : -cmp;
+      }
+      const av = a[sortKey] as number;
+      const bv = b[sortKey] as number;
+      return sortDir === "asc" ? av - bv : bv - av;
+    });
+  }, [rows, search, sortKey, sortDir]);
+
+  const sortHead = (label: string, k: SortKey, align = false) => {
+    const active = sortKey === k;
+    const Icon = active ? (sortDir === "asc" ? ChevronUp : ChevronDown) : ArrowUpDown;
+    return (
+      <TableHead className={align ? "text-right" : ""}>
+        <button
+          type="button"
+          onClick={() => handleSort(k)}
+          className={`inline-flex items-center gap-1 hover:text-foreground ${align ? "flex-row-reverse" : ""}`}
+        >
+          {label}
+          <Icon className={`h-3 w-3 ${active ? "text-foreground" : "text-muted-foreground/50"}`} />
+        </button>
+      </TableHead>
+    );
+  };
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggle = (project: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      next.has(project) ? next.delete(project) : next.add(project);
+      return next;
+    });
+
+  const handleExport = () => {
+    if (!rows.length) return;
+    exportToCsv(`Monthly_WIP_${reportMonth}`, buildExportRows(rows, reportMonth), EXPORT_COLUMNS);
+  };
+
+  const numFmt = (n: number) => (n ? n : <span className="text-muted-foreground">0</span>);
+
+  const totals = useMemo(
+    () =>
+      rows.reduce(
+        (acc, r) => {
+          acc.dpr += r.dpr;
+          acc.inventory += r.inventory;
+          acc.dc += r.dc;
+          acc.dn += r.dn;
+          return acc;
+        },
+        { dpr: 0, inventory: 0, dc: 0, dn: 0 }
+      ),
+    [rows]
+  );
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header + controls */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Monthly WIP &amp; Handover</h1>
+          <p className="text-sm text-muted-foreground">
+            Days each project was active (WIP or Handover), with DPR / Inventory / DC / DN activity.
+            Dates show within the selected month — hover for the actual dates.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={month} onValueChange={setMonth} disabled={optionsLoading}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Select month" />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button variant="outline" size="sm" onClick={handleExport} disabled={!rows.length}>
+            <Download className="mr-2 h-4 w-4" />
+            Export
+          </Button>
+        </div>
+      </div>
+
+      {/* Summary line */}
+      {!isLoading && !error && (
+        <p className="text-sm text-muted-foreground">
+          {rows.length} project{rows.length === 1 ? "" : "s"} active during{" "}
+          <span className="font-medium text-foreground">{monthLabel(options, month)}</span>
+          {rows.length > 0 && (
+            <>
+              {" "}· DPR {totals.dpr} · Inventory {totals.inventory} · DC {totals.dc} · DN {totals.dn}
+            </>
+          )}
+        </p>
+      )}
+
+      {/* Search */}
+      <div className="relative max-w-xs">
+        <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search project…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-8"
+        />
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8" />
+              {sortHead("Project", "project_name")}
+              {sortHead("Active Days", "days_active", true)}
+              <TableHead>Active Start</TableHead>
+              <TableHead>Active End</TableHead>
+              {sortHead("DPR Count", "dpr", true)}
+              {sortHead("Inventory Count", "inventory", true)}
+              {sortHead("DC Count", "dc", true)}
+              {sortHead("DN Count", "dn", true)}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading && (
+              <TableRow>
+                <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                  Loading…
+                </TableCell>
+              </TableRow>
+            )}
+            {error && !isLoading && (
+              <TableRow>
+                <TableCell colSpan={9} className="h-24 text-center text-destructive">
+                  Failed to load the report.
+                </TableCell>
+              </TableRow>
+            )}
+            {!isLoading && !error && displayRows.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                  {rows.length === 0
+                    ? "No projects were active (WIP or Handover) during this month."
+                    : "No projects match your search."}
+                </TableCell>
+              </TableRow>
+            )}
+            {!isLoading &&
+              !error &&
+              displayRows.map((row) => {
+                const isOpen = expanded.has(row.project);
+                const canExpand = row.stints > 1;
+                const c = clampWip(row.active_start, row.active_end, reportMonth);
+                const distinctStatuses = Array.from(new Set(row.periods.map((p) => p.status)));
+                return (
+                  <Fragment key={row.project}>
+                    <TableRow
+                      className={canExpand ? "cursor-pointer" : ""}
+                      onClick={canExpand ? () => toggle(row.project) : undefined}
+                    >
+                      <TableCell className="w-8 p-0 pl-2">
+                        {canExpand ? (
+                          isOpen ? (
+                            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                          ) : (
+                            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                          )
+                        ) : null}
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        <Link
+                          to={`/projects/${row.project}?page=overview`}
+                          className="text-primary hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {row.project_name}
+                        </Link>
+                        <span className="ml-2 inline-flex gap-1 align-middle">
+                          {distinctStatuses.map((s) => (
+                            <StatusBadge key={s} status={s} />
+                          ))}
+                        </span>
+                        {canExpand && (
+                          <span className="ml-2 text-xs text-muted-foreground">({row.stints} stints)</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">{row.days_active}</TableCell>
+                      <TableCell title={c.tooltip}>
+                        <div>
+                          {c.dispStart}
+                          {c.carriedIn && <CarriedIn />}
+                        </div>
+                        {c.carriedIn && <ActualLine date={c.actualStart} />}
+                      </TableCell>
+                      <TableCell title={c.tooltip}>
+                        {c.ongoing ? (
+                          <OngoingBadge />
+                        ) : (
+                          <>
+                            <div>
+                              {c.dispEnd}
+                              {c.carriedOut && <CarriedOut />}
+                            </div>
+                            {c.carriedOut && <ActualLine date={c.actualEnd} />}
+                          </>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">{numFmt(row.dpr)}</TableCell>
+                      <TableCell className="text-right">{numFmt(row.inventory)}</TableCell>
+                      <TableCell className="text-right">{numFmt(row.dc)}</TableCell>
+                      <TableCell className="text-right">{numFmt(row.dn)}</TableCell>
+                    </TableRow>
+
+                    {canExpand &&
+                      isOpen &&
+                      row.periods.map((p, i) => {
+                        const cp = clampWip(p.start, p.end, reportMonth);
+                        return (
+                          <TableRow key={`${row.project}-stint-${i}`} className="bg-muted/40">
+                            <TableCell className="w-8" />
+                            <TableCell className="pl-8 text-sm text-muted-foreground">
+                              <span className="mr-2">Stint {i + 1}</span>
+                              <StatusBadge status={p.status} />
+                            </TableCell>
+                            <TableCell className="text-right text-sm">{p.days}</TableCell>
+                            <TableCell className="text-sm" title={cp.tooltip}>
+                              <div>
+                                {cp.dispStart}
+                                {cp.carriedIn && <CarriedIn />}
+                              </div>
+                              {cp.carriedIn && <ActualLine date={cp.actualStart} />}
+                            </TableCell>
+                            <TableCell className="text-sm" title={cp.tooltip}>
+                              {cp.ongoing ? (
+                                <OngoingBadge />
+                              ) : (
+                                <>
+                                  <div>
+                                    {cp.dispEnd}
+                                    {cp.carriedOut && <CarriedOut />}
+                                  </div>
+                                  {cp.carriedOut && <ActualLine date={cp.actualEnd} />}
+                                </>
+                              )}
+                            </TableCell>
+                            <TableCell className="text-right text-sm">{numFmt(p.dpr)}</TableCell>
+                            <TableCell className="text-right text-sm">{numFmt(p.inventory)}</TableCell>
+                            <TableCell className="text-right text-sm">{numFmt(p.dc)}</TableCell>
+                            <TableCell className="text-right text-sm">{numFmt(p.dn)}</TableCell>
+                          </TableRow>
+                        );
+                      })}
+                  </Fragment>
+                );
+              })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
+++ b/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
@@ -1,0 +1,60 @@
+import { useFrappeGetCall } from "frappe-react-sdk";
+
+const API = "nirmaan_stack.api.reports.wip_monthly_report";
+
+/** One active stint (WIP or Handover) within the selected month. */
+export interface WipPeriod {
+  status: string;         // "WIP" | "Handover"
+  start: string;          // ISO date the project entered this status
+  end: string;            // ISO date it left this status, or "ongoing"
+  days: number;           // days of this stint that fall in the month
+  dpr: number;
+  inventory: number;
+  dc: number;
+  dn: number;
+}
+
+/** One project's month-total row (active = WIP + Handover combined). */
+export interface WipMonthlyRow {
+  project: string;
+  project_name: string;
+  days_active: number;    // WIP + Handover days in the month
+  active_start: string;   // earliest active entry (ISO)
+  active_end: string;     // latest active exit (ISO) or "ongoing"
+  stints: number;         // number of real active periods (expander shown when > 1)
+  dpr: number;
+  inventory: number;
+  dc: number;
+  dn: number;
+  periods: WipPeriod[];
+}
+
+export interface WipMonthlyResponse {
+  month: string;
+  rows: WipMonthlyRow[];
+}
+
+export interface MonthOption {
+  value: string;          // "YYYY-MM"
+  label: string;          // "Jun 2026"
+}
+
+/** Dropdown choices (recent months, most-recent first). */
+export function useWipMonthOptions() {
+  const { data, isLoading } = useFrappeGetCall<{ message: MonthOption[] }>(
+    `${API}.get_wip_month_options`,
+    {},
+    "wip_month_options"
+  );
+  return { options: data?.message ?? [], isLoading };
+}
+
+/** The monthly WIP activity rows for a given month ("YYYY-MM"). */
+export function useMonthlyWIPData(month: string) {
+  const { data, isLoading, error, mutate } = useFrappeGetCall<{ message: WipMonthlyResponse }>(
+    `${API}.get_wip_monthly_report`,
+    { month },
+    month ? `wip_monthly_report_${month}` : null
+  );
+  return { report: data?.message, isLoading, error, mutate };
+}

--- a/frontend/src/pages/reports/ReportsContainer.tsx
+++ b/frontend/src/pages/reports/ReportsContainer.tsx
@@ -25,7 +25,8 @@ const projectReportOptions: { label: string; value: ProjectReportType }[] = [
     { label: 'Outflow Report(Non-Project)', value: 'Outflow Report(Non-Project)' },
     { label: 'Project Progress Report', value: 'Project Progress Report' },
     { label: 'Inventory Report', value: 'Inventory Report' },
-    { label: 'Project GST', value: 'Project GST' }
+    { label: 'Project GST', value: 'Project GST' },
+    { label: 'Monthly WIP', value: 'Monthly WIP' }
 ];
 const VendorReportOptions: { label: string; value: VendorReportType }[] = [{
     label: 'Vendor Ledger', value: 'Vendor Ledger'
@@ -329,7 +330,7 @@ export default function ReportsContainer() {
                             <SelectTrigger className="w-[250px] text-red-600 border-red-600">
                                 <SelectValue placeholder="Select type..." />
                             </SelectTrigger>
-                            <SelectContent>
+                            <SelectContent className="max-h-[320px] [&>div]:!h-auto [&>div]:max-h-[300px] [&>div]:overflow-y-auto [&>div]:scrollbar-thin">
                                 {currentReportOptions.map(option => (
                                     <SelectItem className='text-red-600' key={option.value} value={option.value}>
                                         {option.label}

--- a/frontend/src/pages/reports/components/ProjectReports.tsx
+++ b/frontend/src/pages/reports/components/ProjectReports.tsx
@@ -45,6 +45,7 @@ import { ProjectProgressReports } from "./ProjectProgressReports";
 import { ProjectGSTReport } from "./ProjectGSTReport";
 
 const InventoryReport = lazy(() => import('./InventoryReport'));
+const MonthlyWIPPage = lazy(() => import('@/pages/monthly-wip/MonthlyWIPPage'));
 
 import { useCEOHoldProjects } from "@/hooks/useCEOHoldProjects";
 import { CEO_HOLD_ROW_CLASSES } from "@/utils/ceoHoldRowStyles";
@@ -621,6 +622,10 @@ export default function ProjectReports() {
 
   if (selectedReportType === "Project GST") {
     return <ProjectGSTReport />;
+  }
+
+  if (selectedReportType === "Monthly WIP") {
+    return <MonthlyWIPPage />;
   }
 
   // Default to Cash Sheet report if it's selected or if no specific project report is chosen

--- a/frontend/src/pages/reports/store/useReportStore.ts
+++ b/frontend/src/pages/reports/store/useReportStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { REPORTS_TABS } from '../constants'; // Adjust path
 
-export type ProjectReportType = 'Cash Sheet' | 'Inflow Report' | 'Outflow Report(Project)' | 'Outflow Report(Non-Project)' | 'Project Progress Report' | 'Inventory Report' | 'Project GST';
+export type ProjectReportType = 'Cash Sheet' | 'Inflow Report' | 'Outflow Report(Project)' | 'Outflow Report(Non-Project)' | 'Project Progress Report' | 'Inventory Report' | 'Project GST' | 'Monthly WIP';
 
 export type VendorReportType = 'Vendor Ledger';
 // Define the specific report options for POs

--- a/nirmaan_stack/api/reports/test_wip_monthly_report.py
+++ b/nirmaan_stack/api/reports/test_wip_monthly_report.py
@@ -1,0 +1,111 @@
+"""Unit tests for the pure active-period helpers in wip_monthly_report.
+
+Covers (no DB): timeline reconstruction, status-aware contiguous-interval merging
+(WIP + Handover are both tracked; a WIP->Handover transition stays TWO labelled
+stints), and per-month day counting incl. multi-stint / zero-day-drop / combined
+WIP+Handover "active days".
+"""
+
+from datetime import date, datetime
+
+from frappe.tests.utils import FrappeTestCase
+
+from nirmaan_stack.api.reports.wip_monthly_report import (
+    _active_periods_for_month,
+    _build_intervals,
+    _merged_active_periods,
+)
+
+NOW = datetime(2026, 7, 9, 12, 0, 0)
+
+
+def _dt(y, m, d):
+    return datetime(y, m, d, 10, 0, 0)
+
+
+class TestActiveIntervals(FrappeTestCase):
+    # --- _build_intervals -------------------------------------------------- #
+    def test_no_changes_uses_current_status(self):
+        iv = _build_intervals(_dt(2025, 7, 9), "WIP", [], NOW)
+        self.assertEqual(iv, [("WIP", _dt(2025, 7, 9), NOW)])
+
+    def test_seed_status_from_first_change_old(self):
+        changes = [(_dt(2026, 1, 29), "WIP", "Completed")]
+        iv = _build_intervals(_dt(2024, 9, 11), "Completed", changes, NOW)
+        self.assertEqual(iv[0], ("WIP", _dt(2024, 9, 11), _dt(2026, 1, 29)))
+        self.assertEqual(iv[1], ("Completed", _dt(2026, 1, 29), NOW))
+
+    # --- _merged_active_periods ------------------------------------------- #
+    def test_contiguous_same_status_merge_to_one(self):
+        intervals = [
+            ("WIP", _dt(2025, 3, 20), _dt(2025, 3, 20)),
+            ("WIP", _dt(2025, 3, 20), _dt(2025, 3, 21)),
+            ("WIP", _dt(2025, 3, 21), NOW),
+        ]
+        merged = _merged_active_periods(intervals, NOW)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0][0], date(2025, 3, 20))
+        self.assertTrue(merged[0][2])          # ongoing
+        self.assertEqual(merged[0][3], "WIP")  # status label
+
+    def test_wip_then_handover_are_two_stints(self):
+        # WIP -> Handover is contiguous but DIFFERENT status => 2 labelled stints
+        intervals = [
+            ("WIP", _dt(2026, 2, 4), _dt(2026, 3, 4)),
+            ("Handover", _dt(2026, 3, 4), NOW),
+        ]
+        merged = _merged_active_periods(intervals, NOW)
+        self.assertEqual(len(merged), 2)
+        self.assertEqual([m[3] for m in merged], ["WIP", "Handover"])
+        self.assertTrue(merged[1][2])          # Handover ongoing
+
+    def test_inactive_status_is_a_gap(self):
+        # WIP, Halted (NOT active => gap), WIP, Handover => 3 active stints
+        intervals = [
+            ("WIP", _dt(2026, 1, 19), _dt(2026, 4, 4)),
+            ("Halted", _dt(2026, 4, 4), _dt(2026, 4, 11)),
+            ("WIP", _dt(2026, 4, 11), _dt(2026, 4, 20)),
+            ("Handover", _dt(2026, 4, 20), NOW),
+        ]
+        merged = _merged_active_periods(intervals, NOW)
+        self.assertEqual([m[3] for m in merged], ["WIP", "WIP", "Handover"])
+
+    # --- _active_periods_for_month ---------------------------------------- #
+    def test_full_month_ongoing(self):
+        merged = [(date(2026, 1, 21), date(2026, 7, 9), True, "WIP")]
+        total, periods = _active_periods_for_month(merged, date(2026, 4, 1), date(2026, 5, 1))
+        self.assertEqual(total, 30)  # April has 30 days
+        self.assertEqual(len(periods), 1)
+        self.assertIsNone(periods[0]["end"])
+        self.assertEqual(periods[0]["status"], "WIP")
+
+    def test_partial_entry_month(self):
+        merged = [(date(2026, 6, 9), date(2026, 7, 9), True, "WIP")]
+        total, periods = _active_periods_for_month(merged, date(2026, 6, 1), date(2026, 7, 1))
+        self.assertEqual(total, 22)  # Jun 9..30
+
+    def test_partial_exit_and_zero_day_drop(self):
+        merged = [
+            (date(2026, 1, 19), date(2026, 4, 4), False, "WIP"),
+            (date(2026, 4, 18), date(2026, 4, 18), False, "WIP"),
+        ]
+        total, periods = _active_periods_for_month(merged, date(2026, 4, 1), date(2026, 5, 1))
+        self.assertEqual(total, 3)
+        self.assertEqual(len(periods), 1)
+
+    def test_wip_plus_handover_days_combined(self):
+        # WIP Apr 1-11 (10d) + Handover Apr 11 -> ongoing (20d) => 30 active days
+        merged = [
+            (date(2026, 4, 1), date(2026, 4, 11), False, "WIP"),
+            (date(2026, 4, 11), date(2026, 7, 9), True, "Handover"),
+        ]
+        total, periods = _active_periods_for_month(merged, date(2026, 4, 1), date(2026, 5, 1))
+        self.assertEqual(total, 30)
+        self.assertEqual([p["status"] for p in periods], ["WIP", "Handover"])
+        self.assertEqual([p["days"] for p in periods], [10, 20])
+
+    def test_month_before_active_yields_nothing(self):
+        merged = [(date(2026, 4, 1), date(2026, 5, 1), False, "WIP")]
+        total, periods = _active_periods_for_month(merged, date(2026, 1, 1), date(2026, 2, 1))
+        self.assertEqual(total, 0)
+        self.assertEqual(periods, [])

--- a/nirmaan_stack/api/reports/wip_monthly_report.py
+++ b/nirmaan_stack/api/reports/wip_monthly_report.py
@@ -1,0 +1,304 @@
+"""
+Monthly WIP + Handover Activity Report.
+
+For a selected month, list every project that was ACTIVE (in ``WIP`` OR
+``Handover`` status) during that month with, for that month:
+  - how many days it was active (WIP + Handover combined),
+  - the active start / end date(s) (multi-stint aware; each stint labelled with
+    its status),
+  - counts of DPR, Inventory, DC and DN documents.
+
+There is no stored status-start date on Projects (``status`` is a free-text Data
+field). Duration is derived purely from the recorded ``-> WIP`` / ``-> Handover``
+status transitions in Frappe's built-in ``Version`` history (Projects has
+``track_changes: 1``). See the plan for the full rationale + known limitations.
+"""
+
+import frappe
+from frappe.utils import (
+    add_days,
+    add_months,
+    get_datetime,
+    get_first_day,
+    get_last_day,
+    getdate,
+    now_datetime,
+    today,
+)
+
+from nirmaan_stack.api.pmo_dashboard import _extract_status_change_value_pairs
+from nirmaan_stack.api.seven_days_planning.get_projects_material_plan_stats import (
+    _get_allowed_projects,
+    _get_user_role,
+    _should_filter_by_permissions,
+)
+
+WIP = "WIP"
+HANDOVER = "Handover"
+ACTIVE_STATUSES = (WIP, HANDOVER)
+
+# (result_key, table, business_date_column, extra_sql_filter)
+_SPECS = (
+    ("dpr", "tabProject Progress Reports", "report_date", ""),
+    ("inventory", "tabRemaining Items Report", "report_date", ""),
+    ("dc", "tabPO Delivery Documents", "dc_date", "AND type = 'Delivery Challan'"),
+    ("dn", "tabDelivery Notes", "delivery_date", ""),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no frappe.db) — unit-tested in test_wip_monthly_report.py
+# --------------------------------------------------------------------------- #
+def _build_intervals(creation_dt, current_status, changes, now_dt):
+    """Reconstruct the project's status timeline as ``[(status, start, end)]``.
+
+    ``changes`` is ``[(change_datetime, old_status, new_status)]`` ordered ascending.
+    The status *before* the first recorded change is that change's ``old`` value,
+    spanning ``[creation -> first_change]`` (some projects were already WIP before
+    their first Version row). The last interval runs to ``now_dt``.
+    """
+    intervals = []
+    if changes:
+        prev_status = changes[0][1]
+        prev_ts = creation_dt
+        for ts, _old, new in changes:
+            intervals.append((prev_status, prev_ts, ts))
+            prev_status, prev_ts = new, ts
+        intervals.append((prev_status, prev_ts, now_dt))
+    else:
+        intervals.append((current_status, creation_dt, now_dt))
+    return intervals
+
+
+def _merged_active_periods(intervals, now_dt):
+    """Return merged active periods as ``[(start_date, end_date, ongoing, status)]``.
+
+    Tracks BOTH ``WIP`` and ``Handover`` intervals. The Version log fragments a
+    continuous same-status period into touching sub-intervals; merging any where
+    ``next.start <= prev.end`` **and the status matches** makes the stint count +
+    dates truthful. A ``WIP -> Handover`` (or vice-versa) transition is NOT merged —
+    the two remain distinct, adjacent stints. ``ongoing`` means the period runs to
+    *now* (project still in that status).
+    """
+    raw = []
+    for status, start, end in intervals:
+        st = (status or "").strip()
+        if st not in ACTIVE_STATUSES:
+            continue
+        raw.append((getdate(start), getdate(end), end == now_dt, st))
+    raw.sort(key=lambda x: (x[0], x[1]))
+
+    merged = []
+    for start, end, ongoing, st in raw:
+        if merged and st == merged[-1][3] and start <= merged[-1][1]:
+            prev_start, prev_end, prev_ongoing, prev_st = merged[-1]
+            merged[-1] = (prev_start, max(prev_end, end), prev_ongoing or ongoing, prev_st)
+        else:
+            merged.append((start, end, ongoing, st))
+    return merged
+
+
+def _active_periods_for_month(merged, month_start, month_end_excl):
+    """Given merged active periods, return ``(total_days, periods)`` for one month.
+
+    Each period dict has actual ``start``/``end`` dates (``end`` is ``None`` when
+    ongoing) plus the month-clipped counting window ``cstart``/``cend``, in-month
+    ``days``, and the ``status`` (``WIP`` / ``Handover``). Convention: entry day
+    counts, exit day does not. Zero-in-month-day periods are dropped so ``stints``
+    counts only real periods. ``total_days`` = WIP + Handover days combined.
+    """
+    periods = []
+    total = 0
+    for start, end, ongoing, status in merged:
+        if end > month_start and start < month_end_excl:  # overlaps the month
+            cstart = max(start, month_start)
+            cend = min(end, month_end_excl)
+            days = (cend - cstart).days
+            if days > 0:
+                periods.append(
+                    {
+                        "start": start,
+                        "end": None if ongoing else end,
+                        "cstart": cstart,
+                        "cend": cend,
+                        "days": days,
+                        "status": status,
+                    }
+                )
+                total += days
+    periods.sort(key=lambda p: p["cstart"])
+    return total, periods
+
+
+# --------------------------------------------------------------------------- #
+# DB helpers
+# --------------------------------------------------------------------------- #
+def _counts_by_project(table, date_col, project_ids, month_start, month_end_excl, extra=""):
+    """Per-project COUNT(*) for a doctype in the month (ADR-0010: SQL GROUP BY)."""
+    if not project_ids:
+        return {}
+    rows = frappe.db.sql(
+        f'''
+        SELECT project, COUNT(*) AS c
+        FROM "{table}"
+        WHERE project IN %(ids)s
+          AND COALESCE({date_col}, creation::date) >= %(start)s
+          AND COALESCE({date_col}, creation::date) <  %(end)s
+          {extra}
+        GROUP BY project
+        ''',
+        {"ids": tuple(project_ids), "start": month_start, "end": month_end_excl},
+        as_dict=True,
+    )
+    return {r.project: r.c for r in rows}
+
+
+def _dates_by_project(table, date_col, project_ids, month_start, month_end_excl, extra=""):
+    """Fetch ``(project, date)`` rows for the month — only for multi-stint bucketing."""
+    if not project_ids:
+        return {}
+    rows = frappe.db.sql(
+        f'''
+        SELECT project, COALESCE({date_col}, creation::date) AS d
+        FROM "{table}"
+        WHERE project IN %(ids)s
+          AND COALESCE({date_col}, creation::date) >= %(start)s
+          AND COALESCE({date_col}, creation::date) <  %(end)s
+          {extra}
+        ''',
+        {"ids": tuple(project_ids), "start": month_start, "end": month_end_excl},
+        as_dict=True,
+    )
+    out = {}
+    for r in rows:
+        out.setdefault(r.project, []).append(getdate(r.d))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Endpoints
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def get_wip_month_options(months=24):
+    """Dropdown choices: the last ``months`` months, most-recent first."""
+    months = int(months or 24)
+    cur = getdate(get_first_day(today()))
+    options = []
+    for k in range(months):
+        ms = getdate(get_first_day(add_months(cur, -k)))
+        options.append({"value": ms.strftime("%Y-%m"), "label": ms.strftime("%b %Y")})
+    return options
+
+
+@frappe.whitelist()
+def get_wip_monthly_report(month=None):
+    """Return the monthly WIP activity rows for ``month`` (``"YYYY-MM"``)."""
+    now_dt = now_datetime()
+    if not month:
+        month = getdate(get_first_day(today())).strftime("%Y-%m")
+    month_start = getdate(f"{month}-01")
+    month_end_excl = getdate(add_days(get_last_day(month_start), 1))
+
+    # Role scoping — restricted roles only see their permitted projects.
+    user = frappe.session.user
+    role = _get_user_role(user)
+    project_filters = {}
+    if _should_filter_by_permissions(user, role):
+        allowed = _get_allowed_projects(user)
+        if not allowed:
+            return {"month": month, "rows": []}
+        project_filters["name"] = ["in", allowed]
+
+    projects = frappe.get_all(
+        "Projects",
+        filters=project_filters,
+        fields=["name", "project_name", "status", "creation"],
+    )
+    proj_map = {p.name: p for p in projects}
+
+    # Full status-change history (all rows — needed so a WIP period that ended
+    # *after* the month still shows its real end date).
+    version_rows = frappe.get_all(
+        "Version",
+        filters={"ref_doctype": "Projects"},
+        fields=["docname", "creation", "data"],
+        order_by="docname asc, creation asc",
+    )
+    changes_by_project = {}
+    for v in version_rows:
+        if v.docname not in proj_map:
+            continue
+        for old, new in _extract_status_change_value_pairs(v.data):
+            changes_by_project.setdefault(v.docname, []).append(
+                (get_datetime(v.creation), old, new)
+            )
+
+    # Derive per-project active (WIP + Handover) periods overlapping the month.
+    proj_periods = {}
+    for name, p in proj_map.items():
+        intervals = _build_intervals(
+            get_datetime(p.creation), p.status, changes_by_project.get(name, []), now_dt
+        )
+        merged = _merged_active_periods(intervals, now_dt)
+        days, periods = _active_periods_for_month(merged, month_start, month_end_excl)
+        if days > 0:
+            proj_periods[name] = periods
+
+    active_ids = list(proj_periods.keys())
+    if not active_ids:
+        return {"month": month, "rows": []}
+
+    # Parent month totals (SQL GROUP BY over all active projects).
+    parent_counts = {
+        key: _counts_by_project(table, date_col, active_ids, month_start, month_end_excl, extra)
+        for key, table, date_col, extra in _SPECS
+    }
+
+    # Per-stint counts only for the few multi-stint projects.
+    multi_ids = [pid for pid in active_ids if len(proj_periods[pid]) > 1]
+    stint_dates = {}
+    if multi_ids:
+        stint_dates = {
+            key: _dates_by_project(table, date_col, multi_ids, month_start, month_end_excl, extra)
+            for key, table, date_col, extra in _SPECS
+        }
+
+    rows = []
+    for pid, periods in proj_periods.items():
+        p = proj_map[pid]
+        child_periods = []
+        for pr in periods:
+            child = {
+                "status": pr["status"],
+                "start": pr["start"].isoformat(),
+                "end": "ongoing" if pr["end"] is None else pr["end"].isoformat(),
+                "days": pr["days"],
+                "dpr": 0,
+                "inventory": 0,
+                "dc": 0,
+                "dn": 0,
+            }
+            if pid in multi_ids:
+                for key in ("dpr", "inventory", "dc", "dn"):
+                    dates = stint_dates.get(key, {}).get(pid, [])
+                    child[key] = sum(1 for d in dates if pr["cstart"] <= d < pr["cend"])
+            child_periods.append(child)
+
+        rows.append(
+            {
+                "project": pid,
+                "project_name": p.project_name or pid,
+                "days_active": sum(pr["days"] for pr in periods),
+                "active_start": periods[0]["start"].isoformat(),
+                "active_end": "ongoing" if periods[-1]["end"] is None else periods[-1]["end"].isoformat(),
+                "stints": len(periods),
+                "dpr": parent_counts["dpr"].get(pid, 0),
+                "inventory": parent_counts["inventory"].get(pid, 0),
+                "dc": parent_counts["dc"].get(pid, 0),
+                "dn": parent_counts["dn"].get(pid, 0),
+                "periods": child_periods,
+            }
+        )
+
+    rows.sort(key=lambda r: -r["days_active"])
+    return {"month": month, "rows": rows}


### PR DESCRIPTION
…om status history

Adds a "Monthly WIP" report type under Reports -> Projects (report-type dropdown). For a selected month it lists every project that was ACTIVE (WIP or Handover) that month with combined Active days, a per-stint breakdown, and DPR/Inventory/DC/DN activity counts. Wired into the existing Projects report-type mechanism (useReportStore + ReportsContainer + ProjectReports) — no sidebar item / route.

Active-days logic (backend api/reports/wip_monthly_report.py):
- Projects.status is a free-text field with no stored status-start date, so durations are DERIVED by replaying the recorded "-> WIP" / "-> Handover" transitions from Frappe's built-in Version history (Projects track_changes:1).
- _build_intervals reconstructs the status timeline; _merged_active_periods merges touching SAME-status intervals (collapses Version-log fragmentation) but keeps a WIP<->Handover transition as two distinct, labelled stints; _active_periods_for_month clips each period to the month (entry day counts, exit day does not; current month is month-to-date) and drops zero-in-month-day periods.
- days_active = WIP + Handover days combined; each stint carries its status.
- Row set = projects with active days > 0 that month (includes ones that have since left). Best-effort re the CEO-Hold cron gap (owner-accepted).

Activity counts (SQL GROUP BY per project, ADR-0010) use the document BUSINESS date, NOT the created or updated date:
- DPR=Project Progress Reports.report_date; Inventory=Remaining Items Report.report_date; DC=PO Delivery Documents.dc_date (type='Delivery Challan' only); DN=Delivery Notes.delivery_date.
- COALESCE(<business_date>, creation::date) — creation is a fallback ONLY; the modified/updated date is never used (editing a doc later never re-buckets it).
- Parent row = whole-month count; per-stint counts (multi-stint only) bucket docs into each stint's date window.

Frontend (pages/monthly-wip/): month dropdown; expandable table (project Total row + per-stint child rows) with WIP/Handover status chips; dates clamped to the selected month with "<- earlier" / "continues ->" / "Ongoing" markers plus the actual dates (inline + hover); project search; sortable columns; project-name drill-through to the project page; and a stint-wise CSV export (a Total row per project followed by blank-project stint rows). 10 backend unit tests pass.