### PR TITLE
feat(reports): rework Monthly WIP into a grouped compliance report

### DIFF
--- a/.claude/plans/monthly-wip-plan.md
+++ b/.claude/plans/monthly-wip-plan.md
@@ -1,6 +1,8 @@
 # Monthly WIP & Handover Report — Full Plan (as-built)
 
-**Feature:** For a selected month, list every project that was **active** (in `WIP` **or** `Handover` status) that month, with — for that month — how many **days it was active** (WIP + Handover combined), the **active start/end** dates, per-project **status chips**, and monthly **counts of DPR, Inventory, DC, DN**. Collapsible per-project rows expand to per-stint sub-rows, each labeled with its status.
+> **⚠️ 2026-07-24 — the table was reworked from raw document COUNTS to a 5-group / 15-column COMPLIANCE view (+ a senior-dev refactor). §§2–6 below describe the ORIGINAL build; the current column set, semantics and owner rulings are in [§7 — Compliance rework](#7--compliance-rework-2026-07-24) which is now the source of truth for the table. The active-days engine (§2) and placement (§3) are unchanged.**
+
+**Feature:** For a selected month, list every project that was **active** (in `WIP` **or** `Handover` status) that month, with — for that month — how many **days it was active** (WIP + Handover combined), the **active start/end** dates, per-project **status chips**, and (post-rework) **DPR / Inventory compliance** plus **lifetime PO-dispatch / DC** figures. Collapsible per-project rows expand to per-stint sub-rows, each labeled with its status.
 
 **Placement:** it is a **report type inside the Reports hub** — *Reports → Projects tab → Report Type dropdown → "Monthly WIP"* — **not** a sidebar item or standalone route.
 
@@ -141,3 +143,59 @@ Everything derives from immutable history, so Plan A reproduces past months iden
 - **Placement = report type in the Reports hub → Projects tab** (reversed the earlier "dedicated sidebar item + `/monthly-wip` page" decision — sidebar item + route removed).
 - Layout = month dropdown, collapsible per-project rows → per-stint sub-rows, project name (not id) + clickable, search + sort, status chips, count columns named `… Count`.
 - Persistence = **Plan A only for now**; Plan B **designed & deferred**, trigger = **auto monthly cron**.
+
+---
+
+## 7 — Compliance rework (2026-07-24)
+
+The four raw document counts (DPR / Inventory / DC / DN) were replaced by a **two-tier grouped header, 5 groups / 15 columns**. The month-scoped DC/DN count columns were **removed**; DC/DN now live in the two new **lifetime** groups. Owner-ruled across an interactive session; every decision below is deliberate — do **not** "fix" them.
+
+### Final layout
+
+| G1 · Project | G2 · DPR — Daily (excl. Sun) | G3 · Inventory — Weekly (Mon) | G4 · PO Dispatch — Lifetime | G5 · DC — Lifetime |
+|---|---|---|---|---|
+| Project · Active Start · Active End | Active Days · Total DPR · Missing DPR | Expected · Actual · Missing | Dispatched · Total DN · Missing DN | Total DC · Missing DC |
+
+### Metric semantics (owner-locked)
+
+- **Active Days = active WORKING days = active calendar days − Sundays.** Redefined so **`Active Days == Total DPR + Missing DPR`** exactly. This DELIBERATELY breaks the tie to the Active End − Active Start span and makes the number smaller than the old calendar count. Backend still keeps `days_active` (full calendar, incl. Sundays) internally; the displayed value is the new `active_working_days`.
+- **DPR — daily, Sundays excluded.** `Total DPR` = active working days with ≥1 DPR (distinct days, **not** a doc count; a Sunday DPR is not counted). `Missing DPR` = working days with none.
+- **Inventory — weekly, Monday-dated ONLY.** `Expected` = active Mondays; `Actual` = active Mondays whose `report_date` is **exactly** that Monday (a Tue–Sun report does **not** cover the week — owner chose strict over week-window); `Missing` = Expected − Actual.
+- **G4 & G5 are LIFETIME (whole-project, month-INDEPENDENT).** They are identical for a project no matter which month is picked; the row set is still month-gated. Shown **only** on the project row — **stint sub-rows render "—"**.
+  - `Dispatched` = POs in `DISPATCHED_PO_STATUSES = (Partially Dispatched, Dispatched, Partially Delivered, Delivered)` — excludes Merged / PO Approved / Cancelled / Inactive. (PO `status` is **free-text**, no Select options.)
+  - `Total DN` = **raw** `Delivery Notes` doc count, **returns excluded** (`is_return = 0`).
+  - `Total DC` = `PO Delivery Documents` where `type='Delivery Challan' AND parent_doctype='Procurement Orders'` (excludes ITM + Material Inspection Reports).
+  - `Missing DN = max(0, Dispatched − Total DN)`; `Missing DC = max(0, Total DN − Total DC)`. **Both clamped at 0** — a PO carries several DNs and DC can exceed DN, so the raw subtraction routinely goes negative (verified: nearly all live rows have DN > Dispatched → Missing DN = 0). **Not a reconciling triad** — three independent numbers.
+
+### Backend — `api/reports/wip_monthly_report.py`
+
+- New pure helpers (unit-tested, no DB): `_period_day_set(cstart, cend)` (calendar dates of a stint window, entry-in/exit-out) and `_compliance_metrics(active_days, dpr_days, inv_days)` (`MONDAY=0`/`SUNDAY=6`; the 6 day-based fields).
+- DPR/Inventory fetch **distinct `report_date` SETS per project** (`_distinct_dates_by_project`) and intersect with the active-day set — **per row AND per stint**.
+- G4/G5 via `_lifetime_counts_by_project(table, ids, extra)` — `COUNT(*) GROUP BY project`, **no date filter**. `DISPATCHED_PO_STATUSES` literals are inlined (code constant, no user input).
+- The old month-scoped `_counts_by_project` / `_dates_by_project` were **deleted** (dead once DC/DN went lifetime).
+- Row shape now: `days_active` (internal) · `active_working_days` · `total_dpr_days` · `missing_dpr_days` · `expected_inventory` · `actual_inventory` · `missing_inventory` · `dispatched_po` · `total_dn` · `missing_dn` · `total_dc` · `missing_dc` · `periods[]` (each stint carries the 6 day-based fields only — **no** G4/G5).
+
+### Frontend — `MonthlyWIPPage.tsx` (+ `useMonthlyWIPData.ts`) — senior-dev refactor
+
+- **Column-config-driven.** `NUMERIC_COLUMNS` (11 entries: `key`/`label`/`groupStart`/`emphasize`/`lifetime`) + `COLUMN_GROUPS` (the 5 group headers) are the single source of truth — the two-tier header, every body cell, sorting and the group dividers all derive from them. Adding/renaming/reordering a column = one edit.
+- **Extracted presentational cells:** `StartCell` / `EndCell` (shared by project + stint rows, `small` prop), `NumberCell` (align/emphasis/`tabular-nums`/group-edge), `DashCell` (stint lifetime "—"); module-level `numFmt`. Types split `ComplianceField` (on stints) vs `LifetimeField` (project only) so stint cells are type-safe.
+- **Fit-to-viewport columns (no horizontal scroll on a laptop):** `Table className="table-fixed"` + a `<colgroup>` whose widths are **PERCENTAGES** (`COL_W` = chevron 2% / project 14% / date 9% / numeric 6%; sum 100), so the table always fills exactly the available width and scales with it — the 15 columns never overflow into a horizontal scroll. Numeric cells/headers trim shadcn's `p-4` to `!px-2`; numeric headers are `text-xs` + `break-words` so they wrap in the tight columns. Labels shortened (group header carries context): "Total DPR", "Missing DPR", "Expected", "Actual", "Missing", "Disp.", "Total DN", … Project cell is `break-words`. (Was fixed-px + `overflow-x-auto` scroll; changed 2026-07-24 on the "view laptop fully" request.)
+- **Grid / group separation:** `GROUP_EDGE` (`border-l-2 border-muted-foreground/40`) on each group's first column = a darker 2px divider between the 5 groups; `LEAN_EDGE` (`border-l border-border/50`) on every other column = a faint 1px rule between the in-between columns. Both run continuously through the header band + every body row. The group-header tier is a banded row (`bg-muted/60`, uppercase semibold labels); the leftmost collapse-chevron gutter carries the same `bg-muted/60` top-to-bottom (header + rows) as one strip. Summary line trimmed to just the project count (the per-metric totals were removed).
+- **Export = current view.** `handleExport` now flattens **`displayRows`** (current sort + search), not the raw `rows` — WYSIWYG. Export columns include all 15 metrics (full names + "(lifetime)" suffix on G4/G5); G4/G5 are blank on stint rows. The CSV also carries a **group-header row** above the column names (merged-cell style, aligned to each group's first column) via a new backward-compatible `options.groupHeaders` param on the shared `utils/exportToCsv.ts` (`EXPORT_GROUP_HEADERS` on the page maps accessorKey → group label; omitting the param leaves every other caller byte-identical).
+- **Stint sub-rows** are tinted **light blue** (`bg-sky-50 dark:bg-sky-950/30`, matching the WIP chip), hover-locked so they don't flip to the default row-hover.
+- Summary line: `DPR days X · missing Y · Inventory a/b · dispatched POs Z · missing DN M · missing DC N`. Subtitle states G4/G5 are lifetime / month-independent.
+
+### Verification
+
+- **Backend: 15/15 unit tests pass** (5 new: Sunday exclusion + reconciliation, Monday-only inventory, empty set). Live Jul-2026: **0 invariant violations** (both day-based sums reconcile, per-stint sums to parent, working ≤ calendar; G4/G5 formulas correct, absent from stint periods). **Month-independence: 0 mismatches** across 28 projects present in both Jun & Jul. Backend cleanup proven behaviour-neutral (identical output before/after).
+- **Frontend: `tsc` clean** for the two files (project-wide pre-existing errors unchanged; app builds via Vite).
+
+### Rework decision log (2026-07-24)
+
+- Active Days redefined to **working days** (Sundays out) so the DPR triad sums exactly — accepted the broken tie to the date span.
+- DPR daily / Sundays excluded; Inventory weekly / **Monday-dated only** (strict, not week-window).
+- G4 `Total DN` = **raw DN doc count** (owner picked this over "distinct POs with a DN"); returns excluded.
+- G5 = **document counts** (`Missing DC = Total DN − Total DC`).
+- Missing DN & Missing DC **clamped at 0** (raw subtraction goes negative by design).
+- The month-scoped DC/DN columns were **removed** (replaced by the lifetime groups), not kept alongside.
+- Refactor to column-config + fixed-width compact numeric columns + export-the-current-view.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,5 +345,6 @@ editor (Luckysheet-as-static-assets planned) whose workbook state is persisted s
 | Invoice Autofill | `.claude/context/domain/invoice-autofill.md` |
 | **Invoice Qty** (derived `invoice_qty`, recompute classifier, backfill + Gemini extraction, cache, Resolve UI) | `.claude/context/domain/invoice-qty.md` |
 | Vendor Hold | `frontend/.claude/context/domain/vendor-hold.md` |
+| **Monthly WIP & Handover report** (Reports hub → Projects → "Monthly WIP"; 5-group/15-col compliance table: DPR-daily / Inventory-weekly / lifetime PO-dispatch + DC; active-days from Version history) | `.claude/plans/monthly-wip-plan.md` |
 | Frontend domain context (full) | `frontend/.claude/context/_index.md` |
 | Session changelog | `.claude/CHANGELOG.md` |

--- a/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
+++ b/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { formatDate } from "@/utils/FormatDate";
 import { exportToCsv } from "@/utils/exportToCsv";
 import { ColumnDef } from "@tanstack/react-table";
@@ -32,10 +33,79 @@ import { Link } from "react-router-dom";
 import {
   useMonthlyWIPData,
   useWipMonthOptions,
+  WipCompliance,
   WipMonthlyRow,
+  WipPeriod,
 } from "./useMonthlyWIPData";
 
-type SortKey = "project_name" | "days_active" | "dpr" | "inventory" | "dc" | "dn";
+// --------------------------------------------------------------------------- //
+// Column model — the single source of truth for the numeric columns. The header
+// (two-tier), the body cells, sorting and the group dividers all derive from it,
+// so a column is added/renamed/reordered in ONE place.
+// --------------------------------------------------------------------------- //
+
+/** Month-scoped, day-based fields (present on both a project row AND its stints). */
+type ComplianceField = keyof WipCompliance;
+/** Lifetime, project-level fields (present only on the project row). */
+type LifetimeField = "dispatched_po" | "total_dn" | "missing_dn" | "total_dc" | "missing_dc";
+type NumericField = ComplianceField | LifetimeField;
+
+type SortKey = "project_name" | NumericField;
+
+interface NumericColumn {
+  key: NumericField;
+  label: string;
+  /** First column of a group — draws the left divider. */
+  groupStart?: boolean;
+  /** Bold — the "base" figure of its group (Active Days, Dispatched POs). */
+  emphasize?: boolean;
+  /** Lifetime & project-level — stint sub-rows render "—" instead of a value. */
+  lifetime?: boolean;
+  /** A "missing" gap column — a non-zero value is shown red (0 stays muted). */
+  danger?: boolean;
+}
+
+const NUMERIC_COLUMNS: NumericColumn[] = [
+  { key: "active_working_days", label: "Active Days", groupStart: true, emphasize: true },
+  { key: "total_dpr_days", label: "Total DPR" },
+  { key: "missing_dpr_days", label: "Missing DPR", danger: true },
+  { key: "expected_inventory", label: "Expected", groupStart: true },
+  { key: "actual_inventory", label: "Actual" },
+  { key: "missing_inventory", label: "Missing", danger: true },
+  { key: "dispatched_po", label: "Disp.", groupStart: true, emphasize: true, lifetime: true },
+  { key: "total_dn", label: "Total DN", lifetime: true },
+  { key: "missing_dn", label: "Missing DN", lifetime: true, danger: true },
+  { key: "total_dc", label: "Total DC", groupStart: true, lifetime: true },
+  { key: "missing_dc", label: "Missing DC", lifetime: true, danger: true },
+];
+
+interface ColumnGroup {
+  label: string;
+  span: number;
+}
+const COLUMN_GROUPS: ColumnGroup[] = [
+  { label: "Project", span: 3 },
+  { label: "DPR · Daily (excl. Sun)", span: 3 },
+  { label: "Inventory · Weekly (Mon)", span: 3 },
+  { label: "Delivery Notes (ALL)", span: 3 },
+  { label: "Delivery Chellans (All)", span: 2 },
+];
+
+/** A visible vertical divider between column groups — runs continuously through
+ *  the header band and every body row (applied to each group's first column). */
+const GROUP_EDGE = "border-l-2 border-muted-foreground/40";
+/** A very lean 1px rule between the individual columns WITHIN a group. */
+const LEAN_EDGE = "border-l border-border/50";
+/** Layout widths as PERCENTAGES so the table always fills the viewport exactly —
+ *  no horizontal scroll on a laptop; every column scales with the available width.
+ *  Sum: 2 + 14 + 9·2 + 6·11 = 100. Numeric columns stay tight (the group header
+ *  carries the wider context). */
+const COL_W = { chevron: "2%", project: "14%", date: "9%", num: "6%" } as const;
+/** chevron + project + start + end + every numeric column. */
+const TOTAL_COLS = 4 + NUMERIC_COLUMNS.length;
+
+/** 0 rendered muted so real gaps read louder than compliant zeros. */
+const numFmt = (n: number) => (n ? n : <span className="text-muted-foreground">0</span>);
 
 const monthLabel = (options: { value: string; label: string }[], month: string) =>
   options.find((o) => o.value === month)?.label ?? month;
@@ -96,6 +166,10 @@ function clampWip(actualStart: string, actualEnd: string, month: string): Clampe
   };
 }
 
+// --------------------------------------------------------------------------- //
+// Presentational cells (shared by the project row and its stint sub-rows).
+// --------------------------------------------------------------------------- //
+
 /** Small muted "actual: <date>" line shown under a clamped date when they differ. */
 const ActualLine = ({ date }: { date: string }) => (
   <div className="text-[10px] text-muted-foreground">actual: {date}</div>
@@ -133,44 +207,117 @@ const StatusBadge = ({ status }: { status: string }) => (
   </Badge>
 );
 
+const StartCell = ({ c, small }: { c: ClampedWip; small?: boolean }) => (
+  <TableCell className={cn(LEAN_EDGE, small && "text-sm")} title={c.tooltip}>
+    <div>
+      {c.dispStart}
+      {c.carriedIn && <CarriedIn />}
+    </div>
+    {c.carriedIn && <ActualLine date={c.actualStart} />}
+  </TableCell>
+);
+
+const EndCell = ({ c, small }: { c: ClampedWip; small?: boolean }) => (
+  <TableCell className={cn(LEAN_EDGE, small && "text-sm")} title={c.tooltip}>
+    {c.ongoing ? (
+      <OngoingBadge />
+    ) : (
+      <>
+        <div>
+          {c.dispEnd}
+          {c.carriedOut && <CarriedOut />}
+        </div>
+        {c.carriedOut && <ActualLine date={c.actualEnd} />}
+      </>
+    )}
+  </TableCell>
+);
+
+// Numeric columns are tight (see COL_W.num) — trim shadcn's default p-4 side padding.
+const NUM_CELL = "text-center tabular-nums !px-2";
+
+const NumberCell = ({ value, col, small }: { value: number; col: NumericColumn; small?: boolean }) => (
+  <TableCell
+    className={cn(
+      NUM_CELL,
+      small && "text-sm",
+      col.emphasize && "font-medium",
+      col.danger && value > 0 && "font-semibold text-red-600 dark:text-red-500",
+      col.groupStart ? GROUP_EDGE : LEAN_EDGE,
+    )}
+  >
+    {numFmt(value)}
+  </TableCell>
+);
+
+/** Lifetime column on a stint row — a muted em-dash (G4/G5 are project-level). */
+const DashCell = ({ col }: { col: NumericColumn }) => (
+  <TableCell className={cn(NUM_CELL, "text-sm text-muted-foreground/40", col.groupStart ? GROUP_EDGE : LEAN_EDGE)}>
+    —
+  </TableCell>
+);
+
 /** Distinct statuses across a row's stints, e.g. "WIP + Handover". */
 const rowStatuses = (r: WipMonthlyRow) =>
   Array.from(new Set(r.periods.map((p) => p.status))).join(" + ");
 
-/** One flat CSV line — a project "Total" row, then a row per stint (multi-stint only). */
+// --------------------------------------------------------------------------- //
+// CSV export — one "Total" row per project + a labeled row per stint (multi-stint
+// only). G4/G5 are lifetime & project-level, so they carry "" on stint rows.
+// --------------------------------------------------------------------------- //
 interface ExportRow {
   project: string;
   row: string;             // "Total" | "Stint 1" | "Stint 2" ...
   status: string;
-  days: number;
   start_in_month: string;
   end_in_month: string;
   actual_start: string;
   actual_end: string;
-  dpr: number;
-  inventory: number;
-  dc: number;
-  dn: number;
+  active_days: number;     // active working days (excl. Sundays)
+  total_dpr_days: number;
+  missing_dpr_days: number;
+  expected_inventory: number;
+  actual_inventory: number;
+  missing_inventory: number;
+  dispatched_po: number | "";
+  total_dn: number | "";
+  missing_dn: number | "";
+  total_dc: number | "";
+  missing_dc: number | "";
 }
 
 const EXPORT_COLUMNS: ColumnDef<ExportRow, any>[] = [
   { accessorKey: "project", header: "Project", meta: { exportHeaderName: "Project" } },
   { accessorKey: "row", header: "Row", meta: { exportHeaderName: "Row" } },
   { accessorKey: "status", header: "Status", meta: { exportHeaderName: "Status" } },
-  { accessorKey: "days", header: "Days", meta: { exportHeaderName: "Active / Stint Days" } },
   { accessorKey: "start_in_month", header: "Start", meta: { exportHeaderName: "Start (in month)" } },
   { accessorKey: "end_in_month", header: "End", meta: { exportHeaderName: "End (in month)" } },
   { accessorKey: "actual_start", header: "Actual Start", meta: { exportHeaderName: "Actual Start" } },
   { accessorKey: "actual_end", header: "Actual End", meta: { exportHeaderName: "Actual End" } },
-  { accessorKey: "dpr", header: "DPR Count", meta: { exportHeaderName: "DPR Count" } },
-  { accessorKey: "inventory", header: "Inventory Count", meta: { exportHeaderName: "Inventory Count" } },
-  { accessorKey: "dc", header: "DC Count", meta: { exportHeaderName: "DC Count" } },
-  { accessorKey: "dn", header: "DN Count", meta: { exportHeaderName: "DN Count" } },
+  { accessorKey: "active_days", header: "Active Days", meta: { exportHeaderName: "Active Days (excl. Sun)" } },
+  { accessorKey: "total_dpr_days", header: "Total DPR Days", meta: { exportHeaderName: "Total DPR Days" } },
+  { accessorKey: "missing_dpr_days", header: "Missing DPR Days", meta: { exportHeaderName: "Missing DPR Days" } },
+  { accessorKey: "expected_inventory", header: "Expected Inventory", meta: { exportHeaderName: "Expected Inventory" } },
+  { accessorKey: "actual_inventory", header: "Actual Inventory", meta: { exportHeaderName: "Actual Inventory" } },
+  { accessorKey: "missing_inventory", header: "Missing Inventory", meta: { exportHeaderName: "Missing Inventory" } },
+  { accessorKey: "dispatched_po", header: "Dispatched POs", meta: { exportHeaderName: "Dispatched POs (lifetime)" } },
+  { accessorKey: "total_dn", header: "Total DN", meta: { exportHeaderName: "Total DN (lifetime)" } },
+  { accessorKey: "missing_dn", header: "Missing DN", meta: { exportHeaderName: "Missing DN (lifetime)" } },
+  { accessorKey: "total_dc", header: "Total DC", meta: { exportHeaderName: "Total DC (lifetime)" } },
+  { accessorKey: "missing_dc", header: "Missing DC", meta: { exportHeaderName: "Missing DC (lifetime)" } },
 ];
 
-/** Flatten to one Total row per project + a labeled row per stint (multi-stint only). */
+/** Group-header row for the CSV (merged-cell style — label at each group's first
+ *  column, aligned with the on-screen two-tier header). Keyed by accessorKey. */
+const EXPORT_GROUP_HEADERS: Record<string, string> = {
+  active_days: "DPR · Daily (excl. Sun)",
+  expected_inventory: "Inventory · Weekly (Mon)",
+  dispatched_po: "PO Dispatch · Lifetime",
+  total_dc: "DC · Lifetime",
+};
+
 function buildExportRows(rows: WipMonthlyRow[], month: string): ExportRow[] {
-  const clamped = (start: string, end: string) => {
+  const clampedLabels = (start: string, end: string) => {
     const c = clampWip(start, end, month);
     return {
       startIn: c.dispStart + (c.carriedIn ? " (from earlier)" : ""),
@@ -179,33 +326,48 @@ function buildExportRows(rows: WipMonthlyRow[], month: string): ExportRow[] {
   };
   const fmtEnd = (end: string) => (end === "ongoing" ? "Ongoing" : formatDate(end));
 
+  // Fields shared by a project Total row and its stint rows (the day-based block).
+  const compliance = (x: WipCompliance) => ({
+    active_days: x.active_working_days,
+    total_dpr_days: x.total_dpr_days,
+    missing_dpr_days: x.missing_dpr_days,
+    expected_inventory: x.expected_inventory,
+    actual_inventory: x.actual_inventory,
+    missing_inventory: x.missing_inventory,
+  });
+
   const out: ExportRow[] = [];
   for (const r of rows) {
-    const t = clamped(r.active_start, r.active_end);
+    const t = clampedLabels(r.active_start, r.active_end);
     out.push({
       project: r.project_name,
       row: "Total",
       status: rowStatuses(r),
-      days: r.days_active,
       start_in_month: t.startIn,
       end_in_month: t.endIn,
       actual_start: formatDate(r.active_start),
       actual_end: fmtEnd(r.active_end),
-      dpr: r.dpr, inventory: r.inventory, dc: r.dc, dn: r.dn,
+      ...compliance(r),
+      dispatched_po: r.dispatched_po,
+      total_dn: r.total_dn,
+      missing_dn: r.missing_dn,
+      total_dc: r.total_dc,
+      missing_dc: r.missing_dc,
     });
     if (r.stints > 1) {
       r.periods.forEach((p, i) => {
-        const s = clamped(p.start, p.end);
+        const s = clampedLabels(p.start, p.end);
         out.push({
           project: "",           // blank so the stint nests under its project's Total row
           row: `Stint ${i + 1}`,
           status: p.status,
-          days: p.days,
           start_in_month: s.startIn,
           end_in_month: s.endIn,
           actual_start: formatDate(p.start),
           actual_end: fmtEnd(p.end),
-          dpr: p.dpr, inventory: p.inventory, dc: p.dc, dn: p.dn,
+          ...compliance(p),
+          // G4/G5 are lifetime & project-level — blank on stint rows.
+          dispatched_po: "", total_dn: "", missing_dn: "", total_dc: "", missing_dc: "",
         });
       });
     }
@@ -227,7 +389,7 @@ export default function MonthlyWIPPage() {
   const reportMonth = report?.month ?? month;
 
   const [search, setSearch] = useState("");
-  const [sortKey, setSortKey] = useState<SortKey>("days_active");
+  const [sortKey, setSortKey] = useState<SortKey>("active_working_days");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const handleSort = (key: SortKey) => {
     if (key === sortKey) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
@@ -236,6 +398,7 @@ export default function MonthlyWIPPage() {
       setSortDir(key === "project_name" ? "asc" : "desc");
     }
   };
+
   const displayRows = useMemo(() => {
     const q = search.trim().toLowerCase();
     const filtered = q ? rows.filter((r) => r.project_name.toLowerCase().includes(q)) : rows;
@@ -244,28 +407,10 @@ export default function MonthlyWIPPage() {
         const cmp = a.project_name.localeCompare(b.project_name);
         return sortDir === "asc" ? cmp : -cmp;
       }
-      const av = a[sortKey] as number;
-      const bv = b[sortKey] as number;
-      return sortDir === "asc" ? av - bv : bv - av;
+      const diff = a[sortKey] - b[sortKey];
+      return sortDir === "asc" ? diff : -diff;
     });
   }, [rows, search, sortKey, sortDir]);
-
-  const sortHead = (label: string, k: SortKey, align = false) => {
-    const active = sortKey === k;
-    const Icon = active ? (sortDir === "asc" ? ChevronUp : ChevronDown) : ArrowUpDown;
-    return (
-      <TableHead className={align ? "text-right" : ""}>
-        <button
-          type="button"
-          onClick={() => handleSort(k)}
-          className={`inline-flex items-center gap-1 hover:text-foreground ${align ? "flex-row-reverse" : ""}`}
-        >
-          {label}
-          <Icon className={`h-3 w-3 ${active ? "text-foreground" : "text-muted-foreground/50"}`} />
-        </button>
-      </TableHead>
-    );
-  };
 
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const toggle = (project: string) =>
@@ -275,27 +420,30 @@ export default function MonthlyWIPPage() {
       return next;
     });
 
+  // Export mirrors what's on screen — current sort + search, not the raw payload.
   const handleExport = () => {
-    if (!rows.length) return;
-    exportToCsv(`Monthly_WIP_${reportMonth}`, buildExportRows(rows, reportMonth), EXPORT_COLUMNS);
+    if (!displayRows.length) return;
+    exportToCsv(`Monthly_WIP_${reportMonth}`, buildExportRows(displayRows, reportMonth), EXPORT_COLUMNS, {
+      groupHeaders: EXPORT_GROUP_HEADERS,
+    });
   };
 
-  const numFmt = (n: number) => (n ? n : <span className="text-muted-foreground">0</span>);
-
-  const totals = useMemo(
-    () =>
-      rows.reduce(
-        (acc, r) => {
-          acc.dpr += r.dpr;
-          acc.inventory += r.inventory;
-          acc.dc += r.dc;
-          acc.dn += r.dn;
-          return acc;
-        },
-        { dpr: 0, inventory: 0, dc: 0, dn: 0 }
-      ),
-    [rows]
-  );
+  const sortHead = (label: string, k: SortKey, align = false, extraClass = "") => {
+    const active = sortKey === k;
+    const Icon = active ? (sortDir === "asc" ? ChevronUp : ChevronDown) : ArrowUpDown;
+    return (
+      <TableHead key={k} className={cn(align && "text-center !px-2 text-xs whitespace-normal break-words", extraClass)}>
+        <button
+          type="button"
+          onClick={() => handleSort(k)}
+          className={cn("inline-flex items-center gap-1 hover:text-foreground", align && "justify-center")}
+        >
+          {label}
+          <Icon className={cn("h-3 w-3", active ? "text-foreground" : "text-muted-foreground/50")} />
+        </button>
+      </TableHead>
+    );
+  };
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -304,8 +452,9 @@ export default function MonthlyWIPPage() {
         <div>
           <h1 className="text-xl font-semibold tracking-tight">Monthly WIP &amp; Handover</h1>
           <p className="text-sm text-muted-foreground">
-            Days each project was active (WIP or Handover), with DPR / Inventory / DC / DN activity.
-            Dates show within the selected month — hover for the actual dates.
+            DPR (daily, Sundays excluded) and Inventory (weekly, each active Monday) are scoped to the
+            selected month. PO Dispatch and DC are <span className="font-medium">lifetime</span> totals —
+            unaffected by the month picker. Hover dates for the actuals.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -321,7 +470,7 @@ export default function MonthlyWIPPage() {
               ))}
             </SelectContent>
           </Select>
-          <Button variant="outline" size="sm" onClick={handleExport} disabled={!rows.length}>
+          <Button variant="outline" size="sm" onClick={handleExport} disabled={!displayRows.length}>
             <Download className="mr-2 h-4 w-4" />
             Export
           </Button>
@@ -333,11 +482,6 @@ export default function MonthlyWIPPage() {
         <p className="text-sm text-muted-foreground">
           {rows.length} project{rows.length === 1 ? "" : "s"} active during{" "}
           <span className="font-medium text-foreground">{monthLabel(options, month)}</span>
-          {rows.length > 0 && (
-            <>
-              {" "}· DPR {totals.dpr} · Inventory {totals.inventory} · DC {totals.dc} · DN {totals.dn}
-            </>
-          )}
         </p>
       )}
 
@@ -354,38 +498,61 @@ export default function MonthlyWIPPage() {
 
       {/* Table */}
       <div className="rounded-md border overflow-x-auto">
-        <Table>
+        <Table className="table-fixed">
+          <colgroup>
+            <col style={{ width: COL_W.chevron }} />
+            <col style={{ width: COL_W.project }} />
+            <col style={{ width: COL_W.date }} />
+            <col style={{ width: COL_W.date }} />
+            {NUMERIC_COLUMNS.map((col) => (
+              <col key={col.key} style={{ width: COL_W.num }} />
+            ))}
+          </colgroup>
           <TableHeader>
-            <TableRow>
-              <TableHead className="w-8" />
-              {sortHead("Project", "project_name")}
-              {sortHead("Active Days", "days_active", true)}
-              <TableHead>Active Start</TableHead>
-              <TableHead>Active End</TableHead>
-              {sortHead("DPR Count", "dpr", true)}
-              {sortHead("Inventory Count", "inventory", true)}
-              {sortHead("DC Count", "dc", true)}
-              {sortHead("DN Count", "dn", true)}
+            {/* Group row — a distinct banded header so each group reads as a block */}
+            <TableRow className="border-b-0 bg-muted/60 hover:bg-muted/60">
+              <TableHead rowSpan={2} />
+              {COLUMN_GROUPS.map((g, i) => (
+                <TableHead
+                  key={g.label}
+                  colSpan={g.span}
+                  className={cn(
+                    "h-9 text-center text-[11px] font-semibold uppercase tracking-wide text-foreground",
+                    i > 0 && GROUP_EDGE
+                  )}
+                >
+                  {g.label}
+                </TableHead>
+              ))}
+            </TableRow>
+            {/* Column row */}
+            <TableRow className="hover:bg-transparent">
+              {sortHead("Project", "project_name", false, LEAN_EDGE)}
+              <TableHead className={LEAN_EDGE}>Active Start</TableHead>
+              <TableHead className={LEAN_EDGE}>Active End</TableHead>
+              {NUMERIC_COLUMNS.map((col) =>
+                sortHead(col.label, col.key, true, col.groupStart ? GROUP_EDGE : LEAN_EDGE)
+              )}
             </TableRow>
           </TableHeader>
           <TableBody>
             {isLoading && (
               <TableRow>
-                <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                <TableCell colSpan={TOTAL_COLS} className="h-24 text-center text-muted-foreground">
                   Loading…
                 </TableCell>
               </TableRow>
             )}
             {error && !isLoading && (
               <TableRow>
-                <TableCell colSpan={9} className="h-24 text-center text-destructive">
+                <TableCell colSpan={TOTAL_COLS} className="h-24 text-center text-destructive">
                   Failed to load the report.
                 </TableCell>
               </TableRow>
             )}
             {!isLoading && !error && displayRows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                <TableCell colSpan={TOTAL_COLS} className="h-24 text-center text-muted-foreground">
                   {rows.length === 0
                     ? "No projects were active (WIP or Handover) during this month."
                     : "No projects match your search."}
@@ -405,7 +572,7 @@ export default function MonthlyWIPPage() {
                       className={canExpand ? "cursor-pointer" : ""}
                       onClick={canExpand ? () => toggle(row.project) : undefined}
                     >
-                      <TableCell className="w-8 p-0 pl-2">
+                      <TableCell className="bg-muted/60 p-0 pl-2">
                         {canExpand ? (
                           isOpen ? (
                             <ChevronDown className="h-4 w-4 text-muted-foreground" />
@@ -414,7 +581,7 @@ export default function MonthlyWIPPage() {
                           )
                         ) : null}
                       </TableCell>
-                      <TableCell className="font-medium">
+                      <TableCell className={cn("font-medium break-words", LEAN_EDGE)}>
                         <Link
                           to={`/projects/${row.project}?page=overview`}
                           className="text-primary hover:underline"
@@ -422,40 +589,20 @@ export default function MonthlyWIPPage() {
                         >
                           {row.project_name}
                         </Link>
-                        <span className="ml-2 inline-flex gap-1 align-middle">
+                        <div className="mt-1 flex items-center gap-1">
                           {distinctStatuses.map((s) => (
                             <StatusBadge key={s} status={s} />
                           ))}
-                        </span>
-                        {canExpand && (
-                          <span className="ml-2 text-xs text-muted-foreground">({row.stints} stints)</span>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right font-medium">{row.days_active}</TableCell>
-                      <TableCell title={c.tooltip}>
-                        <div>
-                          {c.dispStart}
-                          {c.carriedIn && <CarriedIn />}
+                          {canExpand && (
+                            <span className="text-xs text-muted-foreground">({row.stints} stints)</span>
+                          )}
                         </div>
-                        {c.carriedIn && <ActualLine date={c.actualStart} />}
                       </TableCell>
-                      <TableCell title={c.tooltip}>
-                        {c.ongoing ? (
-                          <OngoingBadge />
-                        ) : (
-                          <>
-                            <div>
-                              {c.dispEnd}
-                              {c.carriedOut && <CarriedOut />}
-                            </div>
-                            {c.carriedOut && <ActualLine date={c.actualEnd} />}
-                          </>
-                        )}
-                      </TableCell>
-                      <TableCell className="text-right">{numFmt(row.dpr)}</TableCell>
-                      <TableCell className="text-right">{numFmt(row.inventory)}</TableCell>
-                      <TableCell className="text-right">{numFmt(row.dc)}</TableCell>
-                      <TableCell className="text-right">{numFmt(row.dn)}</TableCell>
+                      <StartCell c={c} />
+                      <EndCell c={c} />
+                      {NUMERIC_COLUMNS.map((col) => (
+                        <NumberCell key={col.key} value={row[col.key]} col={col} />
+                      ))}
                     </TableRow>
 
                     {canExpand &&
@@ -463,37 +610,29 @@ export default function MonthlyWIPPage() {
                       row.periods.map((p, i) => {
                         const cp = clampWip(p.start, p.end, reportMonth);
                         return (
-                          <TableRow key={`${row.project}-stint-${i}`} className="bg-muted/40">
-                            <TableCell className="w-8" />
-                            <TableCell className="pl-8 text-sm text-muted-foreground">
+                          <TableRow
+                            key={`${row.project}-stint-${i}`}
+                            className="bg-sky-50 hover:bg-sky-50 dark:bg-sky-950/30 dark:hover:bg-sky-950/30"
+                          >
+                            <TableCell className="bg-muted/60" />
+                            <TableCell className={cn("pl-8 text-sm text-muted-foreground", LEAN_EDGE)}>
                               <span className="mr-2">Stint {i + 1}</span>
                               <StatusBadge status={p.status} />
                             </TableCell>
-                            <TableCell className="text-right text-sm">{p.days}</TableCell>
-                            <TableCell className="text-sm" title={cp.tooltip}>
-                              <div>
-                                {cp.dispStart}
-                                {cp.carriedIn && <CarriedIn />}
-                              </div>
-                              {cp.carriedIn && <ActualLine date={cp.actualStart} />}
-                            </TableCell>
-                            <TableCell className="text-sm" title={cp.tooltip}>
-                              {cp.ongoing ? (
-                                <OngoingBadge />
+                            <StartCell c={cp} small />
+                            <EndCell c={cp} small />
+                            {NUMERIC_COLUMNS.map((col) =>
+                              col.lifetime ? (
+                                <DashCell key={col.key} col={col} />
                               ) : (
-                                <>
-                                  <div>
-                                    {cp.dispEnd}
-                                    {cp.carriedOut && <CarriedOut />}
-                                  </div>
-                                  {cp.carriedOut && <ActualLine date={cp.actualEnd} />}
-                                </>
-                              )}
-                            </TableCell>
-                            <TableCell className="text-right text-sm">{numFmt(p.dpr)}</TableCell>
-                            <TableCell className="text-right text-sm">{numFmt(p.inventory)}</TableCell>
-                            <TableCell className="text-right text-sm">{numFmt(p.dc)}</TableCell>
-                            <TableCell className="text-right text-sm">{numFmt(p.dn)}</TableCell>
+                                <NumberCell
+                                  key={col.key}
+                                  value={p[col.key as keyof WipPeriod] as number}
+                                  col={col}
+                                  small
+                                />
+                              )
+                            )}
                           </TableRow>
                         );
                       })}

--- a/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
+++ b/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
@@ -2,30 +2,40 @@ import { useFrappeGetCall } from "frappe-react-sdk";
 
 const API = "nirmaan_stack.api.reports.wip_monthly_report";
 
+/** DPR (daily) + Inventory (weekly) compliance figures for a row or a stint. */
+export interface WipCompliance {
+  active_working_days: number; // active calendar days minus Sundays — the "Active Days" shown
+  total_dpr_days: number;      // working days that have a DPR
+  missing_dpr_days: number;    // working days without a DPR (total + missing == working days)
+  expected_inventory: number;  // active Mondays (one inventory expected each)
+  actual_inventory: number;    // active Mondays whose inventory report is dated that Monday
+  missing_inventory: number;   // expected − actual
+}
+
 /** One active stint (WIP or Handover) within the selected month. */
-export interface WipPeriod {
+export interface WipPeriod extends WipCompliance {
   status: string;         // "WIP" | "Handover"
   start: string;          // ISO date the project entered this status
   end: string;            // ISO date it left this status, or "ongoing"
-  days: number;           // days of this stint that fall in the month
-  dpr: number;
-  inventory: number;
-  dc: number;
-  dn: number;
+  days: number;           // calendar days of this stint that fall in the month (incl. Sundays)
+  // NB: G4 (PO dispatch) + G5 (DC) are LIFETIME/project-level — NOT present on stints.
 }
 
 /** One project's month-total row (active = WIP + Handover combined). */
-export interface WipMonthlyRow {
+export interface WipMonthlyRow extends WipCompliance {
   project: string;
   project_name: string;
-  days_active: number;    // WIP + Handover days in the month
+  days_active: number;    // WIP + Handover calendar days in the month (incl. Sundays)
   active_start: string;   // earliest active entry (ISO)
   active_end: string;     // latest active exit (ISO) or "ongoing"
   stints: number;         // number of real active periods (expander shown when > 1)
-  dpr: number;
-  inventory: number;
-  dc: number;
-  dn: number;
+  // G4 — PO dispatch vs delivery (LIFETIME, month-independent):
+  dispatched_po: number;  // POs in Partially Dispatched / Dispatched / Partially Delivered / Delivered
+  total_dn: number;       // Delivery Note docs (returns excluded)
+  missing_dn: number;     // max(0, dispatched_po − total_dn)
+  // G5 — DC compliance (LIFETIME, month-independent):
+  total_dc: number;       // Delivery Challan docs (PO-parented)
+  missing_dc: number;     // max(0, total_dn − total_dc)
   periods: WipPeriod[];
 }
 

--- a/frontend/src/utils/exportToCsv.ts
+++ b/frontend/src/utils/exportToCsv.ts
@@ -156,11 +156,16 @@ const getCellValue = (row: any, column: ColumnDef<any, any>): string | number | 
  * @param filename - The desired filename (without .csv extension).
  * @param data - The array of data objects (or rows) to export.
  * @param columns - The Tanstack Table column definitions to determine headers and accessors.
+ * @param options - Optional. `groupHeaders` maps a column's accessorKey/id to a group
+ *   label; when provided, a group-header row is emitted ABOVE the column-name row
+ *   (merged-cell style — label once at each group's first column, "" elsewhere).
+ *   Omit it and the output is byte-identical to before.
  */
 export const exportToCsv = <TData extends RowData>(
     filename: string,
     data: TData[],
-    columns: ColumnDef<TData, any>[]
+    columns: ColumnDef<TData, any>[],
+    options?: { groupHeaders?: Record<string, string> }
 ) => {
     if (!data || data.length === 0) {
         console.warn('No data provided for CSV export.');
@@ -210,6 +215,14 @@ export const exportToCsv = <TData extends RowData>(
             return 'Unknown Column';
         });
 
+        // 2b. Optional group-header row, aligned to the SAME exportable columns.
+        const groupRow = options?.groupHeaders
+            ? exportableColumns.map(col => {
+                  const key = String((col as any).accessorKey ?? col.id ?? '');
+                  return options.groupHeaders![key] ?? '';
+              })
+            : null;
+
         // 3. Extract Row Data using getCellValue
         const rows = data.map(rowDataItem => // rowDataItem is an individual object from your TData[]
             exportableColumns.map(col => getCellValue(rowDataItem, col))
@@ -217,7 +230,7 @@ export const exportToCsv = <TData extends RowData>(
 
         // 4. Convert data (including headers) to CSV string
         const csvString = unparse(
-            [headers, ...rows],
+            groupRow ? [groupRow, headers, ...rows] : [headers, ...rows],
             {
                 skipEmptyLines: true,
             }

--- a/nirmaan_stack/api/reports/test_wip_monthly_report.py
+++ b/nirmaan_stack/api/reports/test_wip_monthly_report.py
@@ -13,7 +13,9 @@ from frappe.tests.utils import FrappeTestCase
 from nirmaan_stack.api.reports.wip_monthly_report import (
     _active_periods_for_month,
     _build_intervals,
+    _compliance_metrics,
     _merged_active_periods,
+    _period_day_set,
 )
 
 NOW = datetime(2026, 7, 9, 12, 0, 0)
@@ -109,3 +111,62 @@ class TestActiveIntervals(FrappeTestCase):
         total, periods = _active_periods_for_month(merged, date(2026, 1, 1), date(2026, 2, 1))
         self.assertEqual(total, 0)
         self.assertEqual(periods, [])
+
+
+class TestComplianceMetrics(FrappeTestCase):
+    # Anchor: 2026-01-01 is a Thursday, so 2026-01-05 is a Monday and 2026-01-04
+    # / 11 / 18 / 25 are Sundays. All windows below use ``[cstart, cend)``.
+
+    # --- _period_day_set --------------------------------------------------- #
+    def test_period_day_set_entry_in_exit_out(self):
+        s = _period_day_set(date(2026, 1, 5), date(2026, 1, 12))  # Mon 5 .. Sun 11
+        self.assertEqual(len(s), 7)
+        self.assertIn(date(2026, 1, 5), s)        # entry day counts
+        self.assertNotIn(date(2026, 1, 12), s)    # exit day does not
+
+    # --- _compliance_metrics: DPR (daily, Sundays excluded) ---------------- #
+    def test_dpr_excludes_sundays_and_reconciles(self):
+        active = _period_day_set(date(2026, 1, 5), date(2026, 1, 12))  # Mon..Sun (7d)
+        dpr = {
+            date(2026, 1, 5), date(2026, 1, 7), date(2026, 1, 9),  # 3 working-day DPRs
+            date(2026, 1, 11),  # Sunday DPR — NOT counted (Sunday isn't a working day)
+            date(2026, 1, 20),  # outside the active window — NOT counted
+        }
+        m = _compliance_metrics(active, dpr, set())
+        self.assertEqual(m["active_working_days"], 6)   # 7 days − 1 Sunday
+        self.assertEqual(m["total_dpr_days"], 3)
+        self.assertEqual(m["missing_dpr_days"], 3)
+        # The reconciliation guarantee the report is built on:
+        self.assertEqual(m["total_dpr_days"] + m["missing_dpr_days"], m["active_working_days"])
+
+    # --- _compliance_metrics: Inventory (weekly, Monday-dated) ------------- #
+    def test_inventory_counts_only_monday_dated_reports(self):
+        active = _period_day_set(date(2026, 1, 5), date(2026, 1, 12))  # one Monday: Jan 5
+        # Filed on Tuesday — does NOT cover the Monday.
+        m1 = _compliance_metrics(active, set(), {date(2026, 1, 6)})
+        self.assertEqual(m1["expected_inventory"], 1)
+        self.assertEqual(m1["actual_inventory"], 0)
+        self.assertEqual(m1["missing_inventory"], 1)
+        # Filed on the Monday itself — covers it.
+        m2 = _compliance_metrics(active, set(), {date(2026, 1, 5)})
+        self.assertEqual(m2["actual_inventory"], 1)
+        self.assertEqual(m2["missing_inventory"], 0)
+
+    def test_inventory_two_mondays_partial(self):
+        active = _period_day_set(date(2026, 1, 5), date(2026, 1, 19))  # Mon 5 .. Sun 18
+        m = _compliance_metrics(active, set(), {date(2026, 1, 12)})  # 2nd Monday only
+        self.assertEqual(m["active_working_days"], 12)  # 14 days − 2 Sundays
+        self.assertEqual(m["expected_inventory"], 2)    # Jan 5 + Jan 12
+        self.assertEqual(m["actual_inventory"], 1)
+        self.assertEqual(m["missing_inventory"], 1)
+
+    def test_empty_active_set_is_all_zero(self):
+        m = _compliance_metrics(set(), {date(2026, 1, 5)}, {date(2026, 1, 5)})
+        self.assertEqual(
+            (m["active_working_days"], m["total_dpr_days"], m["missing_dpr_days"]),
+            (0, 0, 0),
+        )
+        self.assertEqual(
+            (m["expected_inventory"], m["actual_inventory"], m["missing_inventory"]),
+            (0, 0, 0),
+        )

--- a/nirmaan_stack/api/reports/wip_monthly_report.py
+++ b/nirmaan_stack/api/reports/wip_monthly_report.py
@@ -6,13 +6,24 @@ For a selected month, list every project that was ACTIVE (in ``WIP`` OR
   - how many days it was active (WIP + Handover combined),
   - the active start / end date(s) (multi-stint aware; each stint labelled with
     its status),
-  - counts of DPR, Inventory, DC and DN documents.
+  - DPR compliance on a DAILY cadence (Sundays excluded): active working days,
+    days that have a DPR, and the missing days (total + missing == working days),
+  - Inventory compliance on a WEEKLY (Monday) cadence: expected inventories
+    (active Mondays), the Mondays actually filled, and the missing ones.
+
+Two further groups are LIFETIME (whole-project, NOT scoped to the month — the
+same regardless of which month is picked), shown only on the project row:
+  - PO dispatch: dispatched POs (status in DISPATCHED_PO_STATUSES), total DNs
+    (deliveries, returns excluded), and missing DN = dispatched − DN (clamped ≥0),
+  - DC compliance: total Delivery Challans and missing DC = total DN − total DC.
 
 There is no stored status-start date on Projects (``status`` is a free-text Data
 field). Duration is derived purely from the recorded ``-> WIP`` / ``-> Handover``
 status transitions in Frappe's built-in ``Version`` history (Projects has
 ``track_changes: 1``). See the plan for the full rationale + known limitations.
 """
+
+from datetime import timedelta
 
 import frappe
 from frappe.utils import (
@@ -37,13 +48,20 @@ WIP = "WIP"
 HANDOVER = "Handover"
 ACTIVE_STATUSES = (WIP, HANDOVER)
 
-# (result_key, table, business_date_column, extra_sql_filter)
+# Month-scoped day-based metrics: (result_key, table, business_date_column).
 _SPECS = (
-    ("dpr", "tabProject Progress Reports", "report_date", ""),
-    ("inventory", "tabRemaining Items Report", "report_date", ""),
-    ("dc", "tabPO Delivery Documents", "dc_date", "AND type = 'Delivery Challan'"),
-    ("dn", "tabDelivery Notes", "delivery_date", ""),
+    ("dpr", "tabProject Progress Reports", "report_date"),
+    ("inventory", "tabRemaining Items Report", "report_date"),
 )
+_SPEC_BY_KEY = {key: (table, date_col) for key, table, date_col in _SPECS}
+
+# Python date.weekday(): Monday == 0 ... Sunday == 6.
+MONDAY = 0
+SUNDAY = 6
+
+# Lifetime (NOT month-scoped) PO-dispatch / DC groups. A PO counts as "dispatched"
+# once it has left "PO Approved" into any dispatch/delivery state.
+DISPATCHED_PO_STATUSES = ("Partially Dispatched", "Dispatched", "Partially Delivered", "Delivered")
 
 
 # --------------------------------------------------------------------------- #
@@ -130,31 +148,54 @@ def _active_periods_for_month(merged, month_start, month_end_excl):
     return total, periods
 
 
+def _period_day_set(cstart, cend):
+    """Calendar dates in a stint's counting window ``[cstart, cend)``.
+
+    Same convention as the day count: entry day is included, exit day is not.
+    Merged stints never overlap, so the union of period sets has no double-count.
+    """
+    days = set()
+    d = cstart
+    while d < cend:
+        days.add(d)
+        d = d + timedelta(days=1)
+    return days
+
+
+def _compliance_metrics(active_days, dpr_days, inv_days):
+    """Day-based DPR + Inventory compliance for one active-day set.
+
+    ``active_days`` is the set of active calendar dates; ``dpr_days`` / ``inv_days``
+    are the project's distinct DPR / Inventory report dates in the month.
+
+    DPR (DAILY, Sundays excluded): the working days are the active non-Sunday days.
+    ``total_dpr_days`` = working days that have a DPR, ``missing_dpr_days`` = working
+    days without one — so ``active_working_days == total + missing`` by construction.
+
+    Inventory (WEEKLY, Mondays): ``expected_inventory`` = active Mondays;
+    ``actual_inventory`` = active Mondays whose inventory report is dated on that
+    exact Monday; ``missing_inventory`` = expected − actual.
+    """
+    working = {d for d in active_days if d.weekday() != SUNDAY}
+    mondays = {d for d in active_days if d.weekday() == MONDAY}
+    total_dpr = len(working & dpr_days)
+    expected_inv = len(mondays)
+    actual_inv = len(mondays & inv_days)
+    return {
+        "active_working_days": len(working),
+        "total_dpr_days": total_dpr,
+        "missing_dpr_days": len(working) - total_dpr,
+        "expected_inventory": expected_inv,
+        "actual_inventory": actual_inv,
+        "missing_inventory": expected_inv - actual_inv,
+    }
+
+
 # --------------------------------------------------------------------------- #
 # DB helpers
 # --------------------------------------------------------------------------- #
-def _counts_by_project(table, date_col, project_ids, month_start, month_end_excl, extra=""):
-    """Per-project COUNT(*) for a doctype in the month (ADR-0010: SQL GROUP BY)."""
-    if not project_ids:
-        return {}
-    rows = frappe.db.sql(
-        f'''
-        SELECT project, COUNT(*) AS c
-        FROM "{table}"
-        WHERE project IN %(ids)s
-          AND COALESCE({date_col}, creation::date) >= %(start)s
-          AND COALESCE({date_col}, creation::date) <  %(end)s
-          {extra}
-        GROUP BY project
-        ''',
-        {"ids": tuple(project_ids), "start": month_start, "end": month_end_excl},
-        as_dict=True,
-    )
-    return {r.project: r.c for r in rows}
-
-
-def _dates_by_project(table, date_col, project_ids, month_start, month_end_excl, extra=""):
-    """Fetch ``(project, date)`` rows for the month — only for multi-stint bucketing."""
+def _distinct_dates_by_project(table, date_col, project_ids, month_start, month_end_excl):
+    """Per-project SET of distinct business dates in the month (day-based metrics)."""
     if not project_ids:
         return {}
     rows = frappe.db.sql(
@@ -164,15 +205,35 @@ def _dates_by_project(table, date_col, project_ids, month_start, month_end_excl,
         WHERE project IN %(ids)s
           AND COALESCE({date_col}, creation::date) >= %(start)s
           AND COALESCE({date_col}, creation::date) <  %(end)s
-          {extra}
+        GROUP BY project, COALESCE({date_col}, creation::date)
         ''',
         {"ids": tuple(project_ids), "start": month_start, "end": month_end_excl},
         as_dict=True,
     )
     out = {}
     for r in rows:
-        out.setdefault(r.project, []).append(getdate(r.d))
+        out.setdefault(r.project, set()).add(getdate(r.d))
     return out
+
+
+def _lifetime_counts_by_project(table, project_ids, extra=""):
+    """Per-project COUNT(*) with NO date filter — the month-independent lifetime
+    totals for the PO-dispatch (G4) and DC (G5) groups. ``extra`` is an extra
+    ``AND ...`` clause (status set, is_return, type, etc.)."""
+    if not project_ids:
+        return {}
+    rows = frappe.db.sql(
+        f'''
+        SELECT project, COUNT(*) AS c
+        FROM "{table}"
+        WHERE project IN %(ids)s
+          {extra}
+        GROUP BY project
+        ''',
+        {"ids": tuple(project_ids)},
+        as_dict=True,
+    )
+    return {r.project: r.c for r in rows}
 
 
 # --------------------------------------------------------------------------- #
@@ -248,54 +309,70 @@ def get_wip_monthly_report(month=None):
     if not active_ids:
         return {"month": month, "rows": []}
 
-    # Parent month totals (SQL GROUP BY over all active projects).
-    parent_counts = {
-        key: _counts_by_project(table, date_col, active_ids, month_start, month_end_excl, extra)
-        for key, table, date_col, extra in _SPECS
-    }
+    # DPR / Inventory (G2/G3): month-scoped, day-based — each project's distinct
+    # report-date SETS, intersected with the active-day set below.
+    dpr_table, dpr_col = _SPEC_BY_KEY["dpr"]
+    inv_table, inv_col = _SPEC_BY_KEY["inventory"]
+    dpr_dates = _distinct_dates_by_project(dpr_table, dpr_col, active_ids, month_start, month_end_excl)
+    inv_dates = _distinct_dates_by_project(inv_table, inv_col, active_ids, month_start, month_end_excl)
 
-    # Per-stint counts only for the few multi-stint projects.
-    multi_ids = [pid for pid in active_ids if len(proj_periods[pid]) > 1]
-    stint_dates = {}
-    if multi_ids:
-        stint_dates = {
-            key: _dates_by_project(table, date_col, multi_ids, month_start, month_end_excl, extra)
-            for key, table, date_col, extra in _SPECS
-        }
+    # PO-dispatch (G4) + DC (G5): LIFETIME totals, NOT month-scoped. DISPATCHED_PO_STATUSES
+    # is a code constant (no user input) so its literals are safe to inline.
+    status_in = ", ".join(f"'{s}'" for s in DISPATCHED_PO_STATUSES)
+    dispatched_po = _lifetime_counts_by_project(
+        "tabProcurement Orders", active_ids, f"AND status IN ({status_in})"
+    )
+    total_dn = _lifetime_counts_by_project("tabDelivery Notes", active_ids, "AND is_return = 0")
+    total_dc = _lifetime_counts_by_project(
+        "tabPO Delivery Documents", active_ids,
+        "AND type = 'Delivery Challan' AND parent_doctype = 'Procurement Orders'",
+    )
 
     rows = []
     for pid, periods in proj_periods.items():
         p = proj_map[pid]
-        child_periods = []
+        pdpr = dpr_dates.get(pid, set())
+        pinv = inv_dates.get(pid, set())
+
+        all_days = set()
+        per_stint_days = []
         for pr in periods:
-            child = {
+            s = _period_day_set(pr["cstart"], pr["cend"])
+            per_stint_days.append(s)
+            all_days |= s
+
+        # G4/G5 are lifetime, project-level — they do NOT split per stint.
+        child_periods = [
+            {
                 "status": pr["status"],
                 "start": pr["start"].isoformat(),
                 "end": "ongoing" if pr["end"] is None else pr["end"].isoformat(),
                 "days": pr["days"],
-                "dpr": 0,
-                "inventory": 0,
-                "dc": 0,
-                "dn": 0,
+                **_compliance_metrics(sdays, pdpr, pinv),
             }
-            if pid in multi_ids:
-                for key in ("dpr", "inventory", "dc", "dn"):
-                    dates = stint_dates.get(key, {}).get(pid, [])
-                    child[key] = sum(1 for d in dates if pr["cstart"] <= d < pr["cend"])
-            child_periods.append(child)
+            for pr, sdays in zip(periods, per_stint_days)
+        ]
 
+        n_dispatched = dispatched_po.get(pid, 0)
+        n_dn = total_dn.get(pid, 0)
+        n_dc = total_dc.get(pid, 0)
         rows.append(
             {
                 "project": pid,
                 "project_name": p.project_name or pid,
                 "days_active": sum(pr["days"] for pr in periods),
+                **_compliance_metrics(all_days, pdpr, pinv),
                 "active_start": periods[0]["start"].isoformat(),
                 "active_end": "ongoing" if periods[-1]["end"] is None else periods[-1]["end"].isoformat(),
                 "stints": len(periods),
-                "dpr": parent_counts["dpr"].get(pid, 0),
-                "inventory": parent_counts["inventory"].get(pid, 0),
-                "dc": parent_counts["dc"].get(pid, 0),
-                "dn": parent_counts["dn"].get(pid, 0),
+                # G4 — PO dispatch vs delivery (lifetime). Missing clamped at 0: a PO can
+                # carry several DNs, so raw (dispatched − dn) can go negative.
+                "dispatched_po": n_dispatched,
+                "total_dn": n_dn,
+                "missing_dn": max(0, n_dispatched - n_dn),
+                # G5 — DC compliance (lifetime). Missing = total DN − total DC, clamped at 0.
+                "total_dc": n_dc,
+                "missing_dc": max(0, n_dn - n_dc),
                 "periods": child_periods,
             }
         )


### PR DESCRIPTION
Replace the four raw document counts (DPR/Inventory/DC/DN) on the Monthly WIP & Handover report with a two-tier, 5-group / 15-column compliance table.

Backend (api/reports/wip_monthly_report.py + tests):
- DPR compliance (daily, Sundays excluded): active working days, days with a DPR, missing days — reconciles so Active Days = Total + Missing.
- Inventory compliance (weekly, Monday-dated only): expected / actual / missing.
- New lifetime, month-independent groups: PO dispatch (dispatched POs, total DNs with returns excluded, missing DN) and DC (total / missing DC); missing clamped at 0.
- Add pure helpers _period_day_set / _compliance_metrics and _lifetime_counts_by_project (SQL GROUP BY, no date filter); drop the now-dead month-scoped count helpers. Add 5 unit tests (Sunday exclusion, Monday-only inventory, reconciliation).

Frontend (pages/monthly-wip/*, utils/exportToCsv.ts):
- Column-config-driven table (NUMERIC_COLUMNS + COLUMN_GROUPS): header, body, sorting and dividers all derive from one source; extract Start/End/Number/Dash cells.
- Percentage column widths so the table fits the viewport (no horizontal scroll); grouped header band with 2px group dividers + 1px lean inter-column lines; centered counts; non-zero "Missing" values in red; light-blue stints.
- Export mirrors the current view (sort + search) and adds a group-header row via a new backward-compatible options.groupHeaders on exportToCsv.

Docs: update .claude/plans/monthly-wip-plan.md (§7) and link it from CLAUDE.md.