### PR TITLE
Friday fixes

### DIFF
--- a/frontend/src/components/helpers/ItemsHoverCard.tsx
+++ b/frontend/src/components/helpers/ItemsHoverCard.tsx
@@ -57,6 +57,27 @@ export const ItemsHoverCard: React.FC<ItemsHoverCardProps> = ({
     }
   );
 
+  // Delivery Note items carry no rate of their own — the rate lives on the source
+  // Procurement Order's `items` child table (the same table the PO tab's hover card
+  // reads). Fetch that PO (only for a DN, only while open) and index quote by item_id.
+  const isDeliveryNote = parentDoctype === "Delivery Notes";
+  const sourcePoName = isDeliveryNote ? parentDoc?.procurement_order : undefined;
+  const { data: sourcePoData } = useFrappeGetDoc(
+    "Procurement Orders",
+    sourcePoName,
+    isOpen && isDeliveryNote && sourcePoName ? `DN-source-PO-${sourcePoName}` : null,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+  const poRateByItemId = new Map<string, number>();
+  if (Array.isArray(sourcePoData?.items)) {
+    sourcePoData.items.forEach((it: any) => {
+      if (it?.item_id != null) poRateByItemId.set(String(it.item_id), it.quote);
+    });
+  }
+
   // console.log(parentDoctype, parentDoc?.name,parentDocData)
   // Extract the child table items once the parent data is loaded
   // Only use parentDocData if it matches the current parentDocId to prevent stale data
@@ -76,6 +97,18 @@ export const ItemsHoverCard: React.FC<ItemsHoverCardProps> = ({
       uom: row.uom,
       quantity: row.quantity,
       rate: row.rate,
+    }));
+  } else if (parentDoctype === "Delivery Notes") {
+    // Delivery Note items store the delivered qty under `delivered_quantity` (there is
+    // no `quantity` field), so normalize it to the `quantity` key the render reads, and
+    // join `quote` (rate) from the source PO's items by item_id (DN items carry no rate).
+    const childRows = isCorrectData && Array.isArray(parentDocData?.[childTableName])
+      ? parentDocData[childTableName]
+      : [];
+    itemsToDisplay = childRows.map((row: any) => ({
+      ...row,
+      quantity: row.delivered_quantity,
+      quote: poRateByItemId.get(String(row.item_id)),
     }));
   } else {
     itemsToDisplay = isCorrectData
@@ -112,7 +145,9 @@ export const ItemsHoverCard: React.FC<ItemsHoverCardProps> = ({
       <PopoverContent className="w-[550px] max-h-[60vh] overflow-auto p-0 relative">
         {/* Close Button */}
         <div className="sticky top-0 bg-white z-20 flex justify-between items-center px-3 py-2 border-b">
-          <h4 className="font-semibold text-sm">Order Items</h4>
+          <h4 className="font-semibold text-sm">
+            {isDeliveryNote ? "Delivery Items" : "Order Items"}
+          </h4>
           <Button
             variant="ghost"
             size="sm"

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -442,7 +442,8 @@ export function NewSidebar() {
       "Nirmaan PMO Executive Profile",
       "Nirmaan Project Lead Profile",
       "Nirmaan Accountant Profile",
-      "Nirmaan Accountant Lead Profile"
+      "Nirmaan Accountant Lead Profile",
+      "Nirmaan Estimates Executive Profile"
     ].includes(role as string)
       ? [
         {

--- a/frontend/src/pages/vendors/components/VendorApprovedQuotesTable.tsx
+++ b/frontend/src/pages/vendors/components/VendorApprovedQuotesTable.tsx
@@ -38,6 +38,7 @@ export const VendorApprovedQuotesTable: React.FC<
       "name",
       "item_id",
       "quote",
+      "quantity",
       "creation",
       "procurement_order",
       "unit",

--- a/frontend/src/pages/vendors/components/VendorDeliveryNotesTable.tsx
+++ b/frontend/src/pages/vendors/components/VendorDeliveryNotesTable.tsx
@@ -80,9 +80,16 @@ export const VendorDeliveryNotesTable: React.FC<VendorDeliveryNotesTableProps> =
           <DataTableColumnHeader column={column} title="DN ID" />
         ),
         cell: ({ row }) => (
-          <div className="font-medium text-sm">{row.original.name}</div>
+          <div className="flex items-center gap-1.5">
+            <span className="font-medium text-sm">{row.original.name}</span>
+            <ItemsHoverCard
+              parentDoc={row.original}
+              parentDoctype="Delivery Notes"
+              childTableName="items"
+            />
+          </div>
         ),
-        size: 150,
+        size: 190,
       },
       {
         accessorKey: "procurement_order",
@@ -102,9 +109,11 @@ export const VendorDeliveryNotesTable: React.FC<VendorDeliveryNotesTableProps> =
               >
                 {poId}
               </Link>
+              {/* Book on PO ID shows the SOURCE PO's full item list (ordered qty + rate),
+                  not this DN's delivered subset — that lives on the DN ID book. */}
               <ItemsHoverCard
-                parentDoc={row.original}
-                parentDoctype="Delivery Notes"
+                parentDoc={{ name: poId }}
+                parentDoctype="Procurement Orders"
                 childTableName="items"
               />
             </div>

--- a/nirmaan_stack/api/sidebar_counts.py
+++ b/nirmaan_stack/api/sidebar_counts.py
@@ -15,6 +15,7 @@ def sidebar_counts(user: str) -> str:
         "Nirmaan PMO Executive Profile",
         "Nirmaan Accountant Profile",  # Accountants need access to all projects for financial operations
         "Nirmaan Accountant Lead Profile",  # Accountant Leads mirror Accountant access
+        "Nirmaan Estimates Executive Profile"
     ]
     user_role = frappe.get_value("Nirmaan Users", user, "role_profile") if user != "Administrator" else None
     is_full_access = user == "Administrator" or user_role in full_access_roles


### PR DESCRIPTION
## Summary
Three independent fixes, one per commit:

1. **Grant Estimates Executive full project access** (`b27c3488`)
   Added `Nirmaan Estimates Executive Profile` to the full-access role lists in
   both the frontend sidebar (`NewSidebar.tsx`) and the backend `sidebar_counts.`
   API, so Estimates Executives can see all projects.

2. **Show item details on Delivery Note rows** (`8ac9500c`)
   - Added an items hover card to the **DN ID** column showing delivered
     quantities, with rates joined from the source Procurement Order (DN items
     carry no rate of their own).
   - Repointed the **PO ID** hover card to the source PO's full ordered item
     list (ordered qty + rate), instead of the DN's delivered subset.
   - Labeled the DN card "Delivery Items".

3. **Fetch quantity for the Approved Quotes table** (`62e5f92f`)
   The quantity column rendered blank because `quantity` was missing from the
   requested fields. Added it so the existing column populates.

## Changes by area
| Area | Files |
|------|-------|
| Sidebar/access | `frontend/src/components/layout/NewSidebar.tsx`, `nirmaan_stack/api/sidebar_counts.py` |
| Vendor Delivery Notes | `frontend/src/components/helpers/ItemsHoverCard.tsx`, `frontend/src/pages/vendors/components/VendorDeliveryNotesTable.tsx` |
| Vendor Approved Quotes | `frontend/src/pages/vendors/components/VendorApprovedQuotesTable.tsx` |

## Testing
- [ ] Estimates Executive user sees all projects in the sidebar and correct sidebar counts.
- [ ] DN ID hover card shows delivered qty + rate; PO ID hover card shows the source PO's full item list.
- [ ] Approved Quotes table shows quantity values (no longer blank).