### PR TITLE
Remove deprecated invoice_data JSON field from PO and SR doctypes

### DIFF
--- a/frontend/src/config/queryKeys.ts
+++ b/frontend/src/config/queryKeys.ts
@@ -54,8 +54,8 @@ interface ProjectExpenseListParams extends ListParams { }
 
 // --- Define Fields Constants (Good Practice) ---
 const PROJECT_REPORT_FIELDS: (keyof Projects)[] = ['name', 'project_name', 'project_value', 'creation', 'modified'];
-const PO_REPORT_FIELDS: (keyof ProcurementOrder)[] = ['name', 'creation', 'project', 'vendor', 'total_amount', 'loading_charges', 'freight_charges', 'invoice_data', 'status', 'modified', 'project_name', 'vendor_name', 'dispatch_date','expected_delivery_date',"latest_delivery_date","latest_payment_date",'amount_paid','po_amount_delivered'];
-const SR_REPORT_FIELDS: (keyof ServiceRequests)[] = ['name', 'creation', 'project', 'vendor', 'gst', 'invoice_data', 'status', 'modified', 'amount_paid', 'total_amount'];
+const PO_REPORT_FIELDS: (keyof ProcurementOrder)[] = ['name', 'creation', 'project', 'vendor', 'total_amount', 'loading_charges', 'freight_charges', 'status', 'modified', 'project_name', 'vendor_name', 'dispatch_date','expected_delivery_date',"latest_delivery_date","latest_payment_date",'amount_paid','po_amount_delivered'];
+const SR_REPORT_FIELDS: (keyof ServiceRequests)[] = ['name', 'creation', 'project', 'vendor', 'gst', 'status', 'modified', 'amount_paid', 'total_amount'];
 const PAYMENT_REPORT_FIELDS: (keyof ProjectPayments)[] = ['name', 'document_type', 'document_name', 'project', 'amount', 'status','creation','payment_date']; // Added 'project'
 const INFLOW_REPORT_FIELDS: (keyof ProjectInflows)[] = ['name', 'project', 'amount', 'payment_date', 'creation']; // Add fields as needed
 const PROJECT_INVOICE_REPORT_FIELDS: (keyof ProjectInvoice)[] = ['name', 'project', 'amount','creation','invoice_date']; // Add fields as needed
@@ -236,7 +236,7 @@ export const getProjectReportListOptions = (): ProjectListParams => ({
 });
 
 export const getPOForProjectInvoiceOptions = (): POListParams => ({
-  fields: ['name', 'project', 'loading_charges', 'freight_charges', 'invoice_data',"total_amount","amount","tax_amount",'creation', 'po_amount_delivered', 'amount_paid'], // Added po_amount_delivered and amount_paid for totalLiabilities calc
+  fields: ['name', 'project', 'loading_charges', 'freight_charges', "total_amount","amount","tax_amount",'creation', 'po_amount_delivered', 'amount_paid'], // Added po_amount_delivered and amount_paid for totalLiabilities calc
   filters: [["status", "not in", ["Merged", "Cancelled", "Inactive"]]], // Match PO report filters
   limit: 100000,
 });
@@ -244,7 +244,7 @@ export const getPOForProjectInvoiceOptions = (): POListParams => ({
 export const getSRForProjectInvoiceOptions = (): SRListParams => ({
   // `total_amount` is required by getSRTotal() (reads sr.total_amount directly).
   // Used by Cash Sheet report to compute "Total PO+SR Value incl. GST" per project.
-  fields: ['name', 'project', 'gst', 'invoice_data', 'creation', 'total_amount'],
+  fields: ['name', 'project', 'gst', 'creation', 'total_amount'],
   filters: [['status', '=', "Approved"]],
   limit: 100000,
 });

--- a/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/PurchaseOrder.tsx
@@ -216,8 +216,8 @@ export const PurchaseOrder = ({
   useEffect(() => {
     if (po) {
       setPO(po);
-      const data = { ...po, invoice_data: po?.invoice_data && JSON.parse(po?.invoice_data), delivery_data: po?.delivery_data && JSON.parse(po?.delivery_data) }
-      setInvoicePO(data);
+      const data = { ...po, delivery_data: po?.delivery_data && JSON.parse(po?.delivery_data as string) }
+      setInvoicePO(data as any);
     }
   }, [po]);
 

--- a/frontend/src/pages/ProcurementOrders/purchase-order/release-po-select.tsx
+++ b/frontend/src/pages/ProcurementOrders/purchase-order/release-po-select.tsx
@@ -255,7 +255,6 @@ export const ReleasePOSelect: React.FC = () => {
         "amount",
         // "loading_charges",
         // "freight_charges",
-        "invoice_data",
         ...([PO_TABS.PARTIALLY_DISPATCHED_PO, PO_TABS.DISPATCHED_PO, PO_TABS.PARTIALLY_DELIVERED_PO, PO_TABS.DELIVERED_PO].includes(tab as any)
             ? ["expected_delivery_date"] : []),
         ...([PO_TABS.PARTIALLY_DISPATCHED_PO, PO_TABS.PARTIALLY_DELIVERED_PO, PO_TABS.DELIVERED_PO].includes(tab as any)

--- a/frontend/src/pages/projects/components/ProjectPOSummaryTable.tsx
+++ b/frontend/src/pages/projects/components/ProjectPOSummaryTable.tsx
@@ -88,8 +88,6 @@ export const PO_SUMMARY_LIST_FIELDS_TO_FETCH: (
   // -----------------
   "expected_delivery_date",
   "latest_delivery_date",
-  "custom", // Add custom if used for badge
-  // Add invoice_data if needed for a column in this specific summary table
 ];
 
 // Searchable fields configuration for PO Summary tables

--- a/frontend/src/pages/projects/data/root/useProjectRootApi.ts
+++ b/frontend/src/pages/projects/data/root/useProjectRootApi.ts
@@ -396,7 +396,6 @@ export const useProjectViewFinancialData = (projectId: string) => {
         "amount",
         "tax_amount",
         "total_amount",
-        "invoice_data",
         "po_amount_delivered",
         "amount_paid",
       ] as const,

--- a/frontend/src/pages/reports/hooks/usePOAttachmentReconcileData.ts
+++ b/frontend/src/pages/reports/hooks/usePOAttachmentReconcileData.ts
@@ -1,11 +1,10 @@
 import { useFrappeGetDocList, FrappeDoc, GetDocListArgs } from 'frappe-react-sdk';
 import { useMemo } from 'react';
-import { ProcurementOrder, InvoiceDataType } from '@/types/NirmaanStack/ProcurementOrders';
+import { ProcurementOrder } from '@/types/NirmaanStack/ProcurementOrders';
 import { NirmaanAttachment } from '@/types/NirmaanStack/NirmaanAttachment';
 import { Projects } from '@/types/NirmaanStack/Projects';
 import { Vendors } from '@/types/NirmaanStack/Vendors';
 import { ProjectPayments } from '@/types/NirmaanStack/ProjectPayments';
-import { getTotalInvoiceAmount } from '@/utils/getAmounts';
 import { parseNumber } from '@/utils/parseNumber';
 import { queryKeys, getPaymentReportListOptions } from '@/config/queryKeys';
 
@@ -68,7 +67,7 @@ interface UsePOAttachmentReconcileDataResult {
 const getPOAttachmentReconcileOptions = (): GetDocListArgs<FrappeDoc<ProcurementOrder>> => ({
     fields: [
         'name', 'creation', 'modified', 'project', 'vendor', 'total_amount',
-        'loading_charges', 'freight_charges', 'invoice_data', 'status',
+        'loading_charges', 'freight_charges', 'status',
         'project_name', 'vendor_name', 'latest_delivery_date', 'amount_paid',
         'po_amount_delivered'
     ],
@@ -189,6 +188,43 @@ export const usePOAttachmentReconcileData = (): UsePOAttachmentReconcileDataResu
     }, [payments]);
 
     // Group attachments by PO name
+
+    // Fetch Vendor Invoices
+    const poNames = useMemo(() => purchaseOrders?.map(po => po.name) || [], [purchaseOrders]);
+    const {
+        data: vendorInvoices,
+        isLoading: invoicesLoading,
+        error: invoicesError,
+    } = useFrappeGetDocList<VendorInvoice>(
+        "Vendor Invoices",
+        {
+            fields: ['name', 'document_name', 'invoice_no', 'invoice_date', 'invoice_amount'],
+            filters: [
+                ['document_type', '=', 'Procurement Orders'],
+                ['status', '=', 'Approved'],
+                ['document_name', 'in', poNames]
+            ],
+            limit: 100000
+        },
+        poNames.length > 0 ? ["Vendor Invoices", "poAttachmentReconcile", ...poNames] : null
+    );
+
+    // Group invoices by PO
+    const invoicesByPO = useMemo(() => {
+        const map: Record<string, InvoiceHoverItem[]> = {};
+        if (vendorInvoices) {
+            vendorInvoices.forEach(inv => {
+                if (!map[inv.document_name]) map[inv.document_name] = [];
+                map[inv.document_name].push({
+                    date: inv.invoice_date,
+                    invoiceNo: inv.invoice_no,
+                    amount: inv.invoice_amount || 0
+                });
+            });
+        }
+        return map;
+    }, [vendorInvoices]);
+
     const attachmentsByPO = useMemo(() => {
         const map: Record<string, { dcs: AttachmentHoverItem[]; mirs: AttachmentHoverItem[] }> = {};
 
@@ -218,7 +254,7 @@ export const usePOAttachmentReconcileData = (): UsePOAttachmentReconcileDataResu
 
     // Transform PO data to row data
     const reportData = useMemo<POAttachmentReconcileRowData[] | null>(() => {
-        if (poLoading || attachmentsLoading || paymentsLoading || projectsLoading || vendorsLoading) {
+        if (poLoading || attachmentsLoading || paymentsLoading || projectsLoading || vendorsLoading || invoicesLoading) {
             return null;
         }
 
@@ -227,19 +263,8 @@ export const usePOAttachmentReconcileData = (): UsePOAttachmentReconcileDataResu
         }
 
         return purchaseOrders.map((po) => {
-            // Parse invoices from invoice_data
-            const invoiceData = po.invoice_data?.data as InvoiceDataType | undefined;
-            const invoices: InvoiceHoverItem[] = [];
-
-            if (invoiceData) {
-                Object.entries(invoiceData).forEach(([date, invoice]) => {
-                    invoices.push({
-                        date,
-                        invoiceNo: invoice.invoice_no,
-                        amount: parseNumber(invoice.amount),
-                    });
-                });
-            }
+            const invoices = invoicesByPO[po.name] || [];
+            const totalInvoiceAmount = invoices.reduce((sum, inv) => sum + inv.amount, 0);
 
             // Get attachments for this PO
             const poAttachments = attachmentsByPO[po.name] || { dcs: [], mirs: [] };
@@ -256,7 +281,7 @@ export const usePOAttachmentReconcileData = (): UsePOAttachmentReconcileDataResu
                 status: po.status,
                 totalPOAmount: parseNumber(po.total_amount),
                 totalAmountPaid: paymentsMap[po.name] || 0,
-                totalInvoiceAmount: getTotalInvoiceAmount(po.invoice_data),
+                totalInvoiceAmount,
                 poAmountDelivered: parseNumber(po.po_amount_delivered),
                 invoiceCount: invoices.length,
                 dcCount: poAttachments.dcs.length,

--- a/frontend/src/pages/reports/hooks/useProjectReportCalculations.ts
+++ b/frontend/src/pages/reports/hooks/useProjectReportCalculations.ts
@@ -35,7 +35,7 @@ interface ProjectReportParams { // <--- NEW INTERFACE
 // Define the structure for the calculated fields
 export interface ProjectCalculatedFields {
     totalInvoiced: number;
-    totalPoSrInvoiced: number; // This is the new field for invoiced amounts from invoice_data
+    totalPoSrInvoiced: number; // This is the combined invoiced amount for POs and SRs
     totalProjectInvoiced: number;
     totalInflow: number;
     totalOutflow: number;
@@ -443,7 +443,7 @@ export interface ProcessedProject extends Projects {
     // They are dynamically fetched/calculated by the cell renderers.
     // For typing purposes in cells or if you enrich data for export, they can be optional.
     totalInvoiced?: number;
-    totalPoSrInvoiced: number; // This is the new field for invoiced amounts from invoice_data
+    totalPoSrInvoiced: number; // This is the combined invoiced amount for POs and SRs
     totalProjectInvoiced?: number;
     totalInflow?: number;
     totalOutflow?: number;

--- a/frontend/src/pages/reports/hooks/useVendorLedgerCalculations.ts
+++ b/frontend/src/pages/reports/hooks/useVendorLedgerCalculations.ts
@@ -66,13 +66,13 @@ export const useVendorLedgerCalculations = (params: VendorLedgerParams = {}): Us
     }, 'all-vendors-with-opening-balances');
 
     const { data: purchaseOrders, isLoading: isLoadingPOs, error: errorPOs } = useFrappeGetDocList<ProcurementOrder>('Procurement Orders', {
-        fields: ['name', 'vendor', 'total_amount', 'invoice_data', 'creation'],
+        fields: ['name', 'vendor', 'total_amount', 'creation'],
         limit: 0
     }, 'all-pos-for-vendor-ledger');
 
     const { data: serviceRequests, isLoading: isLoadingSRs, error: errorSRs } = useFrappeGetDocList<ServiceRequests>('Service Requests', {
         // total_amount is fresh on every save (incl. GST when sr.gst === "true").
-        fields: ['name', 'vendor', 'gst', 'total_amount', 'invoice_data', 'creation'],
+        fields: ['name', 'vendor', 'gst', 'total_amount', 'creation'],
         limit: 0
     }, 'all-srs-for-vendor-ledger');
 

--- a/frontend/src/types/NirmaanStack/ProcurementOrders.ts
+++ b/frontend/src/types/NirmaanStack/ProcurementOrders.ts
@@ -66,17 +66,6 @@ export interface DeliveryDataType {
 	};
 }
 
-export interface InvoiceItem {
-	invoice_no: string;
-	amount: number;
-	invoice_attachment_id?: string;
-	updated_by: string;
-	status?: "Pending" | "Approved" | "Rejected";
-}
-
-export interface InvoiceDataType {
-	[date: string]: InvoiceItem
-}
 
 
 export interface ProcurementOrder {
@@ -150,7 +139,6 @@ export interface ProcurementOrder {
 	delivery_contact?: string
 	custom?: string
 	delivery_data?: { data: DeliveryDataType }
-	invoice_data?: { data: InvoiceDataType }
 	dispatch_date?: string | null;
 	expected_delivery_date?: string | null;
 	latest_delivery_date?: string | null;

--- a/frontend/src/types/NirmaanStack/ServiceRequests.ts
+++ b/frontend/src/types/NirmaanStack/ServiceRequests.ts
@@ -1,5 +1,3 @@
-import { InvoiceDataType } from "./ProcurementOrders"
-
 export interface ServiceCategoryType {
 	name: string
 }
@@ -57,7 +55,6 @@ export interface ServiceRequests {
 	advance?: string
 	/**	Project GST : Data	*/
 	project_gst?: string
-	invoice_data?: { data: InvoiceDataType }
 
 	invoice_no?: string
 	invoice_date?: string

--- a/frontend/src/utils/getAmounts.ts
+++ b/frontend/src/utils/getAmounts.ts
@@ -1,8 +1,7 @@
-import { InvoiceDataType } from "@/types/NirmaanStack/ProcurementOrders";
 import { VendorInvoice } from "@/types/NirmaanStack/VendorInvoice";
 import { ProjectInflows } from "@/types/NirmaanStack/ProjectInflows";
 import { ProjectPayments } from "@/types/NirmaanStack/ProjectPayments";
-import { ServiceItemType, ServiceRequests } from "@/types/NirmaanStack/ServiceRequests";
+import { ServiceRequests } from "@/types/NirmaanStack/ServiceRequests";
 import memoize from "lodash/memoize";
 import { parseNumber } from "./parseNumber";
 import { ProjectInvoice } from "@/types/NirmaanStack/ProjectInvoice";
@@ -120,75 +119,7 @@ export const getTotalProjectInvoiceAmount = memoize(
 );
 
 
-/**
- * Calculates the total invoice amount from a procurement order's invoice data
- * with currency-safe precision handling and error protection.
- *
- * @deprecated This function parses the old JSON-based `invoice_data` field stored
- * directly in PO/SR documents. Use one of these alternatives instead:
- *
- * - **For pre-fetched Vendor Invoice data:** Use `getTotalVendorInvoiceAmount(vendorInvoices)`
- *   from this same file.
- *
- * - **For React components:** Use `useDocumentInvoiceTotals` hook from
- *   `@/hooks/useDocumentInvoiceTotals.ts` which fetches from Vendor Invoices doctype.
- *
- * The Vendor Invoices doctype provides:
- * - Better queryability and filtering
- * - Consistent data across all views
- * - Support for multi-vendor invoicing
- *
- * This function will be removed in a future version.
- *
- * @param data - The invoice_data JSON from a procurement order
- * @returns The total invoice amount formatted as a number with 2 decimal places
- *
- * @example
- * // OLD (deprecated):
- * const total = getTotalInvoiceAmount(procurementOrder.invoice_data);
- *
- * // NEW (recommended):
- * const { totalsMap } = useDocumentInvoiceTotals("Procurement Orders", poNames);
- * const total = totalsMap.get(poName) ?? 0;
- */
-export const getTotalInvoiceAmount = memoize(
-  (data: any): number => {
-    if (!data) return 0;
-    try {
-      let invoiceData: InvoiceDataType
-      if (typeof data === "string") {
-        invoiceData = JSON.parse(data)?.data || {};
-      } else {
-        invoiceData = data?.data || {};
-      }
 
-      const invoiceItems = Object.values(invoiceData);
-      if (!Array.isArray(invoiceItems)) return 0;
-
-      // Calculate total with currency-safe operations
-      const total = invoiceItems.reduce((acc: number, item) => {
-        // Validate item structure
-        if (!item || typeof item !== 'object' || item?.status !== "Approved") return acc;
-
-        const amount = item?.amount
-
-        // Handle valid numbers only
-        if (Number.isFinite(amount)) {
-          // Use currency-safe arithmetic
-          const amountInCents = Math.round(amount * 100);
-          return acc + amountInCents;
-        }
-        return acc;
-      }, 0);
-
-      // Convert back to dollars with proper rounding
-      return Number((total / 100).toFixed(2));
-    } catch (error) {
-      // Log error and return safe value
-      console.error('Error calculating invoice total:', error);
-      return 0;
-    }
-  }, (order: any) => JSON.stringify(order));
 
 
 /**

--- a/nirmaan_stack/nirmaan_stack/doctype/procurement_orders/procurement_orders.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/procurement_orders/procurement_orders.json
@@ -41,7 +41,6 @@
   "billing_status",
   "delivery_contact",
   "delivery_data",
-  "invoice_data",
   "dispatch_date",
   "expected_delivery_date",
   "latest_delivery_date",
@@ -219,11 +218,6 @@
    "label": "Delivery Data"
   },
   {
-   "fieldname": "invoice_data",
-   "fieldtype": "JSON",
-   "label": "Invoice Data"
-  },
-  {
    "fieldname": "dispatch_date",
    "fieldtype": "Datetime",
    "label": "Dispatch Date"
@@ -300,8 +294,8 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-11 22:52:33.550809",
- "modified_by": "Administrator",
+ "modified": "2026-07-31 18:30:00.342919",
+ "modified_by": "nitesh@nirmaan.app",
  "module": "Nirmaan Stack",
  "name": "Procurement Orders",
  "owner": "Administrator",

--- a/nirmaan_stack/nirmaan_stack/doctype/service_requests/service_requests.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/service_requests/service_requests.json
@@ -12,7 +12,6 @@
   "service_order_list",
   "work_order_items",
   "service_category_list",
-  "invoice_data",
   "status",
   "notes",
   "gst",
@@ -93,11 +92,6 @@
    "fieldname": "project_gst",
    "fieldtype": "Data",
    "label": "Project GST"
-  },
-  {
-   "fieldname": "invoice_data",
-   "fieldtype": "JSON",
-   "label": "Invoice Data"
   },
   {
    "fieldname": "invoice_no",


### PR DESCRIPTION


This commit completely removes the legacy `invoice_data` JSON field from the Procurement Orders and Service Requests doctypes, as invoice tracking is now fully handled by the Vendor Invoices doctype.

Backend (Doctype) Changes:
- Removed the `invoice_data` JSON field from `procurement_orders.json`.
- Removed the `invoice_data` JSON field from `service_requests.json`.

Frontend (TypeScript/React) Cleanup:
- Removed `"invoice_data"` from `fieldsToFetch` in `release-po-select.tsx` to prevent silent null returns.
- Removed the deprecated `getTotalInvoiceAmount` function from `getAmounts.ts` (this parsed the old JSON field and was already replaced by `getTotalVendorInvoiceAmount` / `useDocumentInvoiceTotals`).
- Removed orphaned `InvoiceItem` and `InvoiceDataType` interface definitions from `ProcurementOrders.ts`.
- Removed unused `InvoiceDataType` imports from `ServiceRequests.ts`, `getAmounts.ts`, and `usePOAttachmentReconcileData.ts`.
- Removed broken `getTotalInvoiceAmount` import from `usePOAttachmentReconcileData.ts`.