### PR TITLE
Common fixes

### DIFF
--- a/frontend/src/components/helpers/renderRightActionButton.tsx
+++ b/frontend/src/components/helpers/renderRightActionButton.tsx
@@ -163,12 +163,12 @@ export const RenderRightActionButton = ({
       </Button>
     );
   } else if (locationPath === "/reminders") {
-    // Only roles that can create a Reminder Schedule get the button (matches the
-    // doctype's create permission: Admin / PMO / Accountant Lead). Accountant is
-    // read-only, so they see the table but not this button.
+    // Reminders are Admin-only to manage (owner ruling): Add, Edit and Delete all share
+    // one gate. Every other role with sidebar access sees the table read-only.
+    // MUST stay in step with `canManage` in pages/Reminders/RemindersPage.tsx and with
+    // the server's `_require_reminder_editor` (api/reminders/write.py).
     const canCreateReminder =
-      user_id === "Administrator" ||
-      ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Accountant Lead Profile"].includes(role);
+      user_id === "Administrator" || role === "Nirmaan Admin Profile";
     if (!canCreateReminder) return null;
     return (
       <Button

--- a/frontend/src/components/layout/NewSidebar.tsx
+++ b/frontend/src/components/layout/NewSidebar.tsx
@@ -195,7 +195,7 @@ export function NewSidebar() {
 
   const items = useMemo(() => [
     { key: "/", icon: LayoutGrid, label: "Dashboard" },
-    ...(user_id == "Administrator" || ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile", "Nirmaan Accountant Profile", "Nirmaan Accountant Lead Profile"].includes(role as string)
+    ...(user_id == "Administrator" || ["Nirmaan Admin Profile", "Nirmaan PMO Executive Profile"].includes(role as string)
       ? [
         {
           key: "/reminders",

--- a/frontend/src/pages/InternalTransferMemos/Create/CreateITMPage.tsx
+++ b/frontend/src/pages/InternalTransferMemos/Create/CreateITMPage.tsx
@@ -50,10 +50,17 @@ export default function CreateITMPage() {
   const { items, isLoading, error } = useInventoryPickerData("");
   const { create, isLoading: isCreating } = useCreateITMs();
 
+  // Destination list is restricted to WON projects only — a tender-stage project
+  // has no site to receive material. `tendering_status` is populated on every
+  // project (Won | Tendering), so this is a clean split, not a fallback.
   const { data: projects, isLoading: projectsLoading } = useFrappeGetDocList<Projects>(
     "Projects",
-    { fields: ["name", "project_name"], limit: 0 },
-    "itm-all-projects-minimal"
+    {
+      fields: ["name", "project_name"],
+      filters: [["tendering_status", "=", "Won"]],
+      limit: 0,
+    },
+    "itm-won-projects-minimal"
   );
 
   const projectOptions = useMemo<ProjectOption[]>(() => {

--- a/frontend/src/pages/Reminders/NewReminderDialog.tsx
+++ b/frontend/src/pages/Reminders/NewReminderDialog.tsx
@@ -15,6 +15,7 @@ import {
   useFrappeCreateDoc,
   useFrappeGetCall,
   useFrappeGetDoc,
+  useFrappePostCall,
   useFrappeUpdateDoc,
 } from "frappe-react-sdk";
 import ReactSelect from "react-select";
@@ -28,20 +29,47 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/components/ui/use-toast";
 import { useDialogStore } from "@/zustand/useDialogStore";
+import { useUserData } from "@/hooks/useUserData";
+import { cn } from "@/lib/utils";
+
+/**
+ * May this user RENAME a Reminder Schedule? Mirrors the server gate
+ * `_require_reminder_editor` (Administrator user OR the Nirmaan Admin Profile) by
+ * construction — CONVENIENCE ONLY; `rename_reminder` is the real boundary.
+ *
+ * The `role === "Loading"` guard is load-bearing: `useUserData` returns the literal
+ * "Loading" while the Nirmaan Users doc is in flight, and without it an ADMIN would
+ * see the Title field flash read-only on open.
+ */
+export function canRenameReminder(role: string, userId: string): boolean {
+  if (role === "Loading") return false;
+  return userId === "Administrator" || role === "Nirmaan Admin Profile";
+}
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const SCHEDULE_TYPES = ["Monthly", "Quarterly", "Half-Yearly", "Custom Dates"] as const;
 // Months each span-based schedule covers (auto-fills the end month from the start).
 const SPAN: Record<string, number> = { Quarterly: 3, "Half-Yearly": 6 };
 
-const selectClass =
-  "flex h-10 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-all focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-50";
+// Dropdowns use the app's Radix <Select>, never a native <select>. A native select's
+// popup is drawn by the browser and mis-anchors inside DialogContent (which is
+// `fixed` + `translate-x-[-50%] translate-y-[-50%]`) — the list rendered detached in
+// the top-left of the viewport. Radix anchors to the trigger, so it stays put.
+const errorRing = "border-red-500 focus:border-red-500 focus:ring-2 focus:ring-red-500/20";
+const okRing = "focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500";
 
 const dueDateRowSchema = z.object({
   from_month: z.string().optional(),
@@ -68,6 +96,27 @@ const schema = z
       }
     } else if (!val.due_dates || val.due_dates.length === 0) {
       ctx.addIssue({ path: ["due_dates"], code: z.ZodIssueCode.custom, message: "Add at least one due date" });
+    } else {
+      // from_month/to_month stay .optional() on the row schema ON PURPOSE: a Monthly
+      // schedule keeps its due_dates rows in form state (useFieldArray does not drop
+      // them on type switch), and requiring them there would block a Monthly submit on
+      // hidden fields. Every non-Monthly type needs both, so the check belongs here.
+      val.due_dates.forEach((row, i) => {
+        if (!row.from_month) {
+          ctx.addIssue({
+            path: ["due_dates", i, "from_month"],
+            code: z.ZodIssueCode.custom,
+            message: "Covers From is required",
+          });
+        }
+        if (!row.to_month) {
+          ctx.addIssue({
+            path: ["due_dates", i, "to_month"],
+            code: z.ZodIssueCode.custom,
+            message: "Covers To is required",
+          });
+        }
+      });
     }
   });
 
@@ -88,8 +137,19 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
   const { toast } = useToast();
   const { createDoc, loading: creating } = useFrappeCreateDoc();
   const { updateDoc, loading: updating } = useFrappeUpdateDoc();
+  // Title changes cannot ride updateDoc (autoname `field:title` — see onSubmit).
+  const { call: renameReminder, loading: renaming } = useFrappePostCall<{
+    message: { name: string; renamed: boolean };
+  }>("nirmaan_stack.api.reminders.write.rename_reminder");
   const isEdit = !!editReminderScheduleName;
-  const loading = creating || updating;
+  const loading = creating || updating || renaming;
+
+  // Rename is Admin-only. The lock is EDIT-ONLY on purpose: creating goes through
+  // createDoc, where autoname derives the name from the title — no rename involved —
+  // so every create-capable role must still be able to name a new reminder.
+  const { user_id, role } = useUserData();
+  const canRename = canRenameReminder(role, user_id);
+  const titleLocked = isEdit && !canRename;
 
   // In EDIT mode, load the schedule — get_doc hydrates the child tables (role_profiles,
   // due_dates) one level deep, so no child-table list query is needed.
@@ -176,11 +236,17 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
 
   // Quarterly/Half-Yearly: derive the end month from the picked start month.
   const handleFromMonthChange = (index: number, value: string) => {
-    setValue(`due_dates.${index}.from_month`, value);
+    // shouldValidate: unlike a Controller's field.onChange, a bare setValue does not
+    // re-run the resolver, so a "Covers From is required" error would stay red after
+    // the user picked a month.
+    setValue(`due_dates.${index}.from_month`, value, { shouldValidate: true });
     const span = SPAN[scheduleType];
     if (span && value) {
       const start = MONTHS.indexOf(value);
-      if (start >= 0) setValue(`due_dates.${index}.to_month`, MONTHS[(start + span - 1) % 12]);
+      if (start >= 0)
+        setValue(`due_dates.${index}.to_month`, MONTHS[(start + span - 1) % 12], {
+          shouldValidate: true,
+        });
     }
   };
 
@@ -220,7 +286,23 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
         }));
       }
       if (isEdit && editReminderScheduleName) {
-        await updateDoc("Reminder Schedule", editReminderScheduleName, payload);
+        // `Reminder Schedule` is autonamed `field:title`, so the doc NAME *is* the title
+        // and Frappe force-syncs name -> title on every save — a `title` in the payload is
+        // silently reverted. A real rename must go through `rename_doc` FIRST, and the
+        // returned new name becomes the target of the field update below (the old name no
+        // longer exists). `rename_doc` repoints the linked Reminder Schedule Log rows.
+        let targetName = editReminderScheduleName;
+        // `canRename &&` makes "a non-admin never calls rename" a property of the code,
+        // not of a DOM attribute — so their save can never fail on the Admin-only gate.
+        if (canRename && values.title !== editReminderScheduleName) {
+          const res = await renameReminder({
+            name: editReminderScheduleName,
+            new_title: values.title,
+          });
+          targetName = res?.message?.name || editReminderScheduleName;
+          setEditReminderScheduleName(targetName);
+        }
+        await updateDoc("Reminder Schedule", targetName, payload);
         toast({ title: "Reminder updated", description: `"${values.title}" was saved.` });
       } else {
         await createDoc("Reminder Schedule", payload);
@@ -274,7 +356,10 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
 
   return (
     <Dialog open={newReminderDialog} onOpenChange={(open) => (open ? setNewReminderDialog(true) : close())}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+      {/* max-w-2xl (not the base lg): a due-date row is ~540px of fixed content, so at
+          lg the row overflowed — and overflow-y-auto computes overflow-x to auto, which
+          is what put a horizontal scrollbar on the whole dialog. */}
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit Reminder" : "Add Reminder"}</DialogTitle>
         </DialogHeader>
@@ -288,9 +373,25 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
             <Input
               id="reminder-title"
               placeholder="e.g. GSTR-3B"
-              className={`h-10 transition-all focus:ring-2 ${errors.title ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : 'focus:ring-emerald-500/20 focus:border-emerald-500'}`}
+              // readOnly, NEVER disabled: a disabled input drops out of the form value
+              // pipeline, so `title` would arrive undefined and the zod min(1) rule would
+              // fail EVERY non-admin save — the exact breakage this lock removes.
+              readOnly={titleLocked}
+              aria-readonly={titleLocked || undefined}
+              className={cn(
+                "h-10 transition-all focus:ring-2",
+                errors.title
+                  ? "border-red-500 focus:border-red-500 focus:ring-red-500/20"
+                  : "focus:ring-emerald-500/20 focus:border-emerald-500",
+                titleLocked && "bg-muted cursor-not-allowed"
+              )}
               {...register("title")}
             />
+            {titleLocked && (
+              <p className="text-xs text-muted-foreground">
+                Only an Admin can rename a reminder.
+              </p>
+            )}
             {errors.title && <p className="text-xs text-red-500">{errors.title.message}</p>}
           </div>
 
@@ -331,13 +432,27 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
               <Label htmlFor="reminder-type" className="text-sm font-medium text-slate-700 dark:text-slate-300">
                 Schedule Type <span className="text-red-500">*</span>
               </Label>
-              <select id="reminder-type" className={`${selectClass} ${errors.schedule_type ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : 'focus:ring-emerald-500/20 focus:border-emerald-500'}`} {...register("schedule_type")}>
-                {SCHEDULE_TYPES.map((t) => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
-                ))}
-              </select>
+              <Controller
+                control={control}
+                name="schedule_type"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      id="reminder-type"
+                      className={cn("h-10 transition-all", errors.schedule_type ? errorRing : okRing)}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SCHEDULE_TYPES.map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {t}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="notify-before" className="text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -398,52 +513,125 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
               )}
               {fields.map((row, index) => {
                 const rowErr = errors.due_dates?.[index];
-                const hasError = !!(rowErr?.due_month || rowErr?.due_day);
-                
+                const hasError = !!(
+                  rowErr?.due_month ||
+                  rowErr?.due_day ||
+                  rowErr?.from_month ||
+                  rowErr?.to_month
+                );
+
                 return (
                   <div key={row.id} className="flex flex-col gap-1">
-                    <div className={`flex items-center gap-2 rounded-md border px-2 py-1.5 transition-colors ${hasError ? 'border-red-200 bg-red-50/30' : 'bg-gray-50/50'}`}>
+                    {/* Stacks to two lines below sm (the single row needs ~540px); the
+                        delete button pins to the corner so it never eats a whole line. */}
+                    <div
+                      className={cn(
+                        "relative flex flex-col gap-2 rounded-md border py-2 pl-2 pr-10 transition-colors sm:flex-row sm:items-center sm:gap-2 sm:py-1.5 sm:pr-2",
+                        hasError ? "border-red-200 bg-red-50/30" : "bg-gray-50/50"
+                      )}
+                    >
                       {/* Due Date */}
-                      <div className="flex items-center gap-1.5">
-                        <span className={`text-xs font-medium w-9 ${hasError ? 'text-red-600' : 'text-gray-700'}`}>Due:</span>
-                        <select className={`${selectClass} w-20 bg-white h-8 ${rowErr?.due_month ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : 'focus:ring-emerald-500/20 focus:border-emerald-500'}`} {...register(`due_dates.${index}.due_month`)}>
-                          <option value="">Mon</option>
-                          {MONTHS.map((m) => (
-                            <option key={m} value={m}>{m}</option>
-                          ))}
-                        </select>
+                      <div className="flex items-center gap-1.5 sm:shrink-0">
+                        <span
+                          className={cn(
+                            "w-14 shrink-0 text-xs font-medium sm:w-9",
+                            hasError ? "text-red-600" : "text-gray-700"
+                          )}
+                        >
+                          Due:
+                        </span>
+                        <Controller
+                          control={control}
+                          name={`due_dates.${index}.due_month`}
+                          render={({ field }) => (
+                            <Select value={field.value || ""} onValueChange={field.onChange}>
+                              <SelectTrigger
+                                className={cn(
+                                  "h-8 w-24 shrink-0 bg-white px-2 transition-all",
+                                  rowErr?.due_month ? errorRing : okRing
+                                )}
+                              >
+                                <SelectValue placeholder="Month" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {MONTHS.map((m) => (
+                                  <SelectItem key={m} value={m}>
+                                    {m}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        />
                         <Input
                           type="number"
                           min={1}
                           max={31}
                           placeholder="Day"
-                          className={`w-16 h-8 bg-white transition-all focus:ring-2 ${rowErr?.due_day ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20' : 'focus:ring-emerald-500/20 focus:border-emerald-500'}`}
+                          className={cn(
+                            "h-8 w-14 shrink-0 bg-white transition-all",
+                            rowErr?.due_day ? errorRing : okRing
+                          )}
                           {...register(`due_dates.${index}.due_day`)}
                         />
                       </div>
-                      
-                      <div className="w-px h-5 bg-gray-200 mx-1 hidden sm:block"></div>
-                      
+
+                      <div className="mx-1 hidden h-5 w-px bg-gray-200 sm:block"></div>
+
                       {/* Covers Period */}
-                      <div className="flex flex-wrap sm:flex-nowrap items-center gap-1.5 flex-1">
-                        <span className="text-xs font-medium text-gray-500 hidden sm:inline-block">Covers:</span>
-                        <select
-                          className={`${selectClass} w-16 sm:w-20 bg-white h-8 text-muted-foreground focus:ring-emerald-500/20 focus:border-emerald-500`}
-                          value={watch(`due_dates.${index}.from_month`) || ""}
-                          onChange={(e) => handleFromMonthChange(index, e.target.value)}
+                      <div className="flex items-center gap-1.5 sm:flex-1">
+                        <span
+                          className={cn(
+                            "w-14 shrink-0 text-xs font-medium sm:w-auto",
+                            rowErr?.from_month || rowErr?.to_month ? "text-red-600" : "text-gray-500"
+                          )}
                         >
-                          <option value="">From</option>
-                          {MONTHS.map((m) => (
-                            <option key={m} value={m}>{m}</option>
-                          ))}
-                        </select>
-                        <span className="text-xs text-gray-400 hidden sm:inline-block">-</span>
-                        <select className={`${selectClass} w-16 sm:w-20 bg-white h-8 text-muted-foreground focus:ring-emerald-500/20 focus:border-emerald-500`} {...register(`due_dates.${index}.to_month`)}>
-                          <option value="">To</option>
-                          {MONTHS.map((m) => (
-                            <option key={m} value={m}>{m}</option>
-                          ))}
-                        </select>
+                          Covers:
+                        </span>
+                        <Select
+                          value={watch(`due_dates.${index}.from_month`) || ""}
+                          onValueChange={(v) => handleFromMonthChange(index, v)}
+                        >
+                          <SelectTrigger
+                            className={cn(
+                              "h-8 min-w-0 flex-1 bg-white px-2 transition-all",
+                              rowErr?.from_month ? errorRing : okRing
+                            )}
+                          >
+                            <SelectValue placeholder="From" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {MONTHS.map((m) => (
+                              <SelectItem key={m} value={m}>
+                                {m}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <span className="text-xs text-gray-400">-</span>
+                        <Controller
+                          control={control}
+                          name={`due_dates.${index}.to_month`}
+                          render={({ field }) => (
+                            <Select value={field.value || ""} onValueChange={field.onChange}>
+                              <SelectTrigger
+                                className={cn(
+                                  "h-8 min-w-0 flex-1 bg-white px-2 transition-all",
+                                  rowErr?.to_month ? errorRing : okRing
+                                )}
+                              >
+                                <SelectValue placeholder="To" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {MONTHS.map((m) => (
+                                  <SelectItem key={m} value={m}>
+                                    {m}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                        />
                       </div>
 
                       {/* Delete */}
@@ -451,12 +639,20 @@ export function NewReminderDialog({ onCreated }: NewReminderDialogProps) {
                         type="button"
                         size="icon"
                         variant="ghost"
-                        className="h-8 w-8 shrink-0 text-gray-400 hover:bg-red-50 hover:text-red-600"
+                        className="absolute right-1 top-1 h-8 w-8 shrink-0 text-gray-400 hover:bg-red-50 hover:text-red-600 sm:static sm:right-auto sm:top-auto"
                         onClick={() => remove(index)}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </div>
+                    {hasError && (
+                      <p className="pl-2 text-xs text-red-500">
+                        {rowErr?.due_month?.message ||
+                          rowErr?.due_day?.message ||
+                          rowErr?.from_month?.message ||
+                          rowErr?.to_month?.message}
+                      </p>
+                    )}
                   </div>
                 );
               })}

--- a/frontend/src/pages/Reminders/RemindersPage.tsx
+++ b/frontend/src/pages/Reminders/RemindersPage.tsx
@@ -7,8 +7,12 @@
  * this list. Role profiles are hydrated with ONE extra query over the child table
  * (grouped by parent) — no per-row fetch.
  */
-import { useMemo } from "react";
-import { useFrappeGetCall, useFrappeGetDocList } from "frappe-react-sdk";
+import { useMemo, useState } from "react";
+import {
+  useFrappeGetCall,
+  useFrappeGetDocList,
+  useFrappePostCall,
+} from "frappe-react-sdk";
 
 import {
   Table,
@@ -18,13 +22,24 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate } from "@/utils/FormatDate";
-import { NewReminderDialog } from "./NewReminderDialog";
+import { NewReminderDialog, canRenameReminder } from "./NewReminderDialog";
 import { useUserData } from "@/hooks/useUserData";
 import { Button } from "@/components/ui/button";
-import { Pencil } from "lucide-react";
+import { toast } from "@/components/ui/use-toast";
+import { Pencil, Trash2 } from "lucide-react";
 import { useDialogStore } from "@/zustand/useDialogStore";
 
 interface ReminderScheduleRow {
@@ -44,18 +59,25 @@ interface ReminderRoleProfileRow {
 }
 
 export default function RemindersPage() {
-  // Create is limited to these roles (mirrors the "Add Reminder" right-action button).
-  // Accountants can VIEW this page but not create — and mounting NewReminderDialog for them
-  // would fire a Role Profile fetch they have no permission for.
+  // Add / Edit / Delete on this page are ALL Admin-only (owner ruling) — one predicate
+  // for the whole action surface, mirroring the server's `_require_reminder_editor`.
+  // Every other role with sidebar access (PMO Executive, Accountant Lead, Accountant)
+  // sees the table read-only. Keeping this to ONE flag also matters because mounting
+  // NewReminderDialog fires a Role Profile fetch that non-admins have no permission for.
+  // NOTE: the "Add Reminder" right-action button carries the same gate in
+  // components/helpers/renderRightActionButton.tsx — change the two together.
   const { user_id, role } = useUserData();
-  const canCreate =
-    user_id === "Administrator" ||
-    [
-      "Nirmaan Admin Profile",
-      "Nirmaan PMO Executive Profile",
-      "Nirmaan Accountant Lead Profile",
-    ].includes(role);
+  const canManage = canRenameReminder(role, user_id);
   const { setNewReminderDialog, setEditReminderScheduleName } = useDialogStore();
+  const [pendingDelete, setPendingDelete] = useState<ReminderScheduleRow | null>(null);
+  const { call: deleteReminder, loading: deleting } = useFrappePostCall<{
+    message: {
+      deleted: boolean;
+      name: string;
+      kept_done: number;
+      removed_pending: number;
+    };
+  }>("nirmaan_stack.api.reminders.delete.delete_reminder");
 
   const { data, isLoading, error, mutate } = useFrappeGetDocList<ReminderScheduleRow>(
     "Reminder Schedule",
@@ -93,7 +115,44 @@ export default function RemindersPage() {
   );
 
   const rows = data ?? [];
-  const colCount = canCreate ? 8 : 7;
+  const colCount = canManage ? 8 : 7;
+
+  const handleDelete = async () => {
+    if (!pendingDelete) return;
+    try {
+      const res = await deleteReminder({ name: pendingDelete.name });
+      const kept = res?.message?.kept_done ?? 0;
+      const removed = res?.message?.removed_pending ?? 0;
+      const parts: string[] = [];
+      if (kept) parts.push(`${kept} completed ${kept === 1 ? "entry" : "entries"} kept`);
+      if (removed)
+        parts.push(`${removed} pending ${removed === 1 ? "entry" : "entries"} removed`);
+      toast({
+        title: "Reminder deleted",
+        description: parts.length
+          ? `"${pendingDelete.title}" was deleted — ${parts.join(", ")}.`
+          : `"${pendingDelete.title}" was deleted.`,
+      });
+      setPendingDelete(null);
+      mutate();
+      mutateRpData();
+    } catch (err: any) {
+      // Frappe wraps the real message in _server_messages; fall back to .message.
+      let msg = err?.message || "Something went wrong.";
+      if (err?._server_messages) {
+        try {
+          msg = JSON.parse(JSON.parse(err._server_messages)[0]).message || msg;
+        } catch {
+          msg = err._server_messages;
+        }
+      }
+      toast({
+        title: "Couldn't delete reminder",
+        description: String(msg).replace(/<[^>]*>?/gm, ""),
+        variant: "destructive",
+      });
+    }
+  };
 
   return (
     <div className="flex-1 space-y-6 p-4">
@@ -118,7 +177,7 @@ export default function RemindersPage() {
               <TableHead className="text-center">Notify Before</TableHead>
               <TableHead>Role Profiles</TableHead>
               <TableHead className="text-center">Status</TableHead>
-              {canCreate && <TableHead className="text-right">Actions</TableHead>}
+              {canManage && <TableHead className="text-right">Actions</TableHead>}
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -176,7 +235,7 @@ export default function RemindersPage() {
                       <Badge variant="outline" className="text-muted-foreground">Off</Badge>
                     )}
                   </TableCell>
-                  {canCreate && (
+                  {canManage && (
                     <TableCell className="text-right">
                       <Button
                         size="sm"
@@ -187,7 +246,15 @@ export default function RemindersPage() {
                           setNewReminderDialog(true);
                         }}
                       >
-                        <Pencil className="mr-1 h-3.5 w-3.5" /> Edit
+                        <Pencil className="mr-1 h-3.5 w-3.5" /> 
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                        onClick={() => setPendingDelete(r)}
+                      >
+                        <Trash2 className="mr-1 h-3.5 w-3.5" /> 
                       </Button>
                     </TableCell>
                   )}
@@ -200,6 +267,78 @@ export default function RemindersPage() {
 
       {/* Create dialog — opened by the top-nav "Add Reminder" button */}
       <NewReminderDialog onCreated={() => { mutate(); mutateRpData(); }} />
+
+      <AlertDialog
+        open={!!pendingDelete}
+        onOpenChange={(open) => !open && !deleting && setPendingDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete “{pendingDelete?.title}”?</AlertDialogTitle>
+            {/* asChild: Radix renders Description as a <p>, and a <ul> inside a <p> is
+                invalid nesting that the browser silently restructures. Swapping in a
+                <div> keeps the list valid and keeps aria-describedby pointing here. */}
+            <AlertDialogDescription asChild>
+              <div className="space-y-3 text-sm">
+                <p className="text-muted-foreground">
+                  Deleting this reminder does four things:
+                </p>
+                <ul className="space-y-2">
+                  <li className="flex gap-2">
+                    <span className="text-destructive">•</span>
+                    <span className="font-medium text-destructive">
+                      The reminder is deleted permanently. This cannot be undone.
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-destructive">•</span>
+                    <span className="text-muted-foreground">
+                      <span className="font-medium text-destructive">
+                        Its pending entries are deleted
+                      </span>{" "}
+                      — nothing can act on them once the reminder is gone.
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-muted-foreground">•</span>
+                    <span className="text-muted-foreground">
+                      <span className="font-medium text-foreground">
+                        Its completed entries are kept
+                      </span>{" "}
+                      as a permanent record.
+                    </span>
+                  </li>
+                  <li className="flex gap-2">
+                    <span className="text-muted-foreground">•</span>
+                    <span className="text-muted-foreground">
+                      Those kept entries will{" "}
+                      <span className="font-medium text-foreground">
+                        no longer appear in the Compliance History
+                      </span>
+                      .
+                    </span>
+                  </li>
+                </ul>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                // Keep the dialog mounted through the await so the pending state shows;
+                // handleDelete closes it on success and leaves it open on failure.
+                e.preventDefault();
+                handleDelete();
+              }}
+              disabled={deleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {deleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/pages/tasks/invoices/components/PoInvoices.tsx
+++ b/frontend/src/pages/tasks/invoices/components/PoInvoices.tsx
@@ -111,7 +111,7 @@ const InvoiceAmountCell: React.FC<{ item: InvoiceItem }> = ({ item }) => {
     return (
         <>
             <div
-                className="font-medium text-green-600 underline underline-offset-2 cursor-pointer hover:text-green-700"
+                className="font-medium text-green-600 underline underline-offset-2 cursor-pointer hover:text-green-700 whitespace-nowrap"
                 onClick={(e) => { e.stopPropagation(); setOpen(true); }}
                 title="View invoice items"
             >
@@ -309,8 +309,10 @@ export const PoInvoices: React.FC<PoInvoicesProps> = ({ vendorId, vendorName }) 
                 cell: ({ row }) => {
                     const userId = row.original.modified_by;
                     if (!userId) return <span className="text-gray-400">-</span>;
+                    // Falls back to the raw user id (an email) when no Nirmaan Users doc matches —
+                    // truncate so a long unbreakable email can't spill into the Invoice Amount column.
                     const fullName = getUserFullName(userId);
-                    return <div className="font-medium">{fullName}</div>;
+                    return <div className="font-medium truncate" title={fullName}>{fullName}</div>;
                 },
                 filterFn: (row, id, value) => value.includes(row.getValue(id)),
                 meta: {

--- a/frontend/src/pages/vendors/components/LedgerTableRow.tsx
+++ b/frontend/src/pages/vendors/components/LedgerTableRow.tsx
@@ -4,6 +4,7 @@ import { TableRow, TableCell } from "@/components/ui/table";
 import { formatToRoundedIndianRupee } from '@/utils/FormatPrice';
 import { formatDate } from '@/utils/FormatDate';
 import {Link} from "react-router-dom";
+import { INACTIVE_PO_ROW_CLASSES } from '@/utils/inactivePoRowStyles';
 
 export interface LedgerEntry {
     date: string;
@@ -13,6 +14,8 @@ export interface LedgerEntry {
     amount: number;
     payment: number;
     balance: number;
+    /** True when this transaction belongs to a PO whose status is "Inactive". */
+    isInactive?: boolean;
 }
 
 interface LedgerTableRowProps {
@@ -78,7 +81,10 @@ export const LedgerTableRow: React.FC<LedgerTableRowProps> = ({ item }) => {
   };
 
   return (
-    <TableRow>
+    <TableRow
+      className={item.isInactive ? INACTIVE_PO_ROW_CLASSES : undefined}
+      title={item.isInactive ? "Linked PO is Inactive" : undefined}
+    >
       <TableCell className="px-2 py-1 text-sm">{formatDate(new Date(item.date))}</TableCell>
       <TableCell className={`px-2 py-1 text-sm ${getTransactionClass()}`}>
         {item.transactionType}

--- a/frontend/src/pages/vendors/components/POVendorLedger.tsx
+++ b/frontend/src/pages/vendors/components/POVendorLedger.tsx
@@ -6,7 +6,7 @@ import { useUpdateVendorDoc } from '../data/useVendorMutations';
 import Fuse from 'fuse.js';
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Button } from '@/components/ui/button';
-import { FileUp } from 'lucide-react';
+import { Info, FileUp } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { toast } from '@/components/ui/use-toast';
 import { AlertDestructive } from '@/components/layout/alert-banner/error-alert';
@@ -26,6 +26,7 @@ interface ApiTransaction {
     details: string;
     amount: number; // in rupees
     payment: number; // in rupees
+    is_inactive?: boolean; // true when the linked PO's status is "Inactive"
 }
 
 type LedgerTab = 'poLedger' | 'srLedger' | 'invoicesLedger';
@@ -132,7 +133,12 @@ export const POVendorLedger: React.FC<{ vendorId: string }> = ({ vendorId }) => 
         let runningBalance = Number(activeOpeningBalance);
         return items.map((entry): LedgerEntry => {
             runningBalance += entry.amount - entry.payment;
-            return { ...entry, transactionType: entry.type as LedgerEntry['transactionType'], balance: runningBalance };
+            return {
+                ...entry,
+                transactionType: entry.type as LedgerEntry['transactionType'],
+                balance: runningBalance,
+                isInactive: !!entry.is_inactive,
+            };
         });
 
     }, [flatTransactionsFromApi, activeSubTab, activeOpeningBalance, dateFilter, searchTerm, projectFilter]);
@@ -149,6 +155,12 @@ export const POVendorLedger: React.FC<{ vendorId: string }> = ({ vendorId }) => 
     }, [processedItems]);
 
     const endBalance = processedItems.length > 0 ? processedItems[processedItems.length - 1].balance : activeOpeningBalance;
+
+    // Drives the red-tint legend: only explain the colour when a tinted row is present.
+    const hasInactiveRows = useMemo(
+        () => processedItems.some((item) => item.isInactive),
+        [processedItems]
+    );
 
     const handleExportCsv = useCallback(() => {
         const exportColumns = [
@@ -214,6 +226,24 @@ export const POVendorLedger: React.FC<{ vendorId: string }> = ({ vendorId }) => 
                     />
                 </div>
             </div>
+
+            {/* Legend for the red row tint — rendered ONLY when a tinted row is actually
+                on screen. Inactive POs are rare (9 across 8 vendors in live data), so an
+                always-on legend would explain a colour most vendors never show. */}
+            {/* A plain info glyph: this is an explanatory note, not a warning or an error,
+                and unlike a bordered swatch it cannot be mistaken for a control. */}
+            {hasInactiveRows && (
+                <div className="flex items-start gap-1.5 text-xs text-muted-foreground">
+                    <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                    <span>
+                        Rows shown with a{" "}
+                        <span className="rounded-[3px] bg-red-50 px-1.5 py-0.5 font-medium text-red-700 dark:bg-red-950/40 dark:text-red-400">
+                            red background
+                        </span>{" "}
+                        belong to an Inactive PO.
+                    </span>
+                </div>
+            )}
 
             <VirtualizedLedgerTable
                 items={processedItems}

--- a/frontend/src/pages/vendors/components/VendorMaterialOrdersTable.tsx
+++ b/frontend/src/pages/vendors/components/VendorMaterialOrdersTable.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   DataTable,
   SearchFieldOption,
 } from "@/components/data-table/new-data-table";
+import { Row as TanRow } from "@tanstack/react-table";
 import { FacetDeclaration } from "@/components/data-table/facetConfig";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
 import { ItemsHoverCard } from "@/components/helpers/ItemsHoverCard";
@@ -24,6 +25,8 @@ import { PaymentsDataDialog } from "@/pages/ProjectPayments/PaymentsDataDialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { TailSpin } from "react-loader-spinner";
+import { Info } from "lucide-react";
+import { INACTIVE_PO_ROW_CLASSES } from "@/utils/inactivePoRowStyles";
 
 interface VendorMaterialOrdersTableProps {
   vendorId: string;
@@ -76,12 +79,21 @@ export const VendorMaterialOrdersTable: React.FC<
   const [selectedPaymentPO, setSelectedPaymentPO] = useState<ProcurementOrder | undefined>();
 
   // --- Static Filters ---
+  // Inactive POs ARE included here (they are shown with a red row tint) — only
+  // Merged POs stay hidden.
   const staticFilters = useMemo(() => {
     return [
       ["vendor", "=", vendorId],
-      ["status", "not in", ["Merged", "Inactive"]],
+      ["status", "not in", ["Merged"]],
     ];
   }, [vendorId]);
+
+  // Inactive (superseded) POs get a red row tint so they are visibly distinct.
+  const getRowClassName = useCallback(
+    (row: TanRow<ProcurementOrder>) =>
+      row.original.status === "Inactive" ? INACTIVE_PO_ROW_CLASSES : undefined,
+    []
+  );
 
   // Fetch Vendor Invoices for this vendor to calculate total invoiced per PO
   const { data: vendorInvoices } = useVendorInvoices(vendorId);
@@ -169,11 +181,13 @@ export const VendorMaterialOrdersTable: React.FC<
         cell: ({ row }) => (
           <Badge
             variant={
-              ["Partially Delivered", "Delivered"].includes(row.original.status)
-                ? "green"
-                : ["Partially Dispatched"].includes(row.original.status)
-                  ? "yellow"
-                  : "outline"
+              row.original.status === "Inactive"
+                ? "red"
+                : ["Partially Delivered", "Delivered"].includes(row.original.status)
+                  ? "green"
+                  : ["Partially Dispatched"].includes(row.original.status)
+                    ? "yellow"
+                    : "outline"
             }
           >
             {row.original.status}
@@ -493,6 +507,14 @@ export const VendorMaterialOrdersTable: React.FC<
 
   const amountDue = totalInvoiced - totalPaidForPOs;
 
+  // Drives the red-tint legend. Read off the rendered rows rather than a separate
+  // count query: the list is server-paginated, so "is anything red right now" is the
+  // only question the page can answer cheaply — and it is the question the legend
+  // answers. Recomputed per render, which is what makes it track pagination.
+  const hasInactiveOnPage = table
+    .getRowModel()
+    .rows.some((r) => r.original.status === "Inactive");
+
   return (
     <>
       <DataTable<ProcurementOrder>
@@ -505,6 +527,7 @@ export const VendorMaterialOrdersTable: React.FC<
         onSelectedSearchFieldChange={setSelectedSearchField}
         searchTerm={searchTerm}
         onSearchTermChange={setSearchTerm}
+        getRowClassName={getRowClassName}
         facetDoctype="Procurement Orders"
         facetOverrides={{
           project: { additionalFilters: staticFilters },
@@ -577,6 +600,26 @@ export const VendorMaterialOrdersTable: React.FC<
                   </div>
                 </div>
               </div>
+
+              {/* Legend for the red row tint — rendered ONLY when an Inactive PO is
+                  actually on the current page. Inactive POs are rare (9 across 8 vendors
+                  in live data), so an always-on legend would explain a colour most
+                  vendors never show. */}
+              {/* A plain info glyph: this is an explanatory note, not a warning or an error,
+                  and unlike a bordered swatch it cannot be mistaken for a control. */}
+              {hasInactiveOnPage && (
+                <div className="mt-3 flex items-start gap-1.5 border-t pt-3 text-xs text-muted-foreground">
+                  <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    Rows shown with a{" "}
+                    <span className="rounded-[3px] bg-red-50 px-1.5 py-0.5 font-medium text-red-700 dark:bg-red-950/40 dark:text-red-400">
+                      red background
+                    </span>{" "}
+                    are Inactive POs (superseded by a revision) — they are included in the
+                    list and in the PO Totals above.
+                  </span>
+                </div>
+              )}
             </CardContent>
           </Card>
         }

--- a/frontend/src/pages/vendors/data/useVendorQueries.ts
+++ b/frontend/src/pages/vendors/data/useVendorQueries.ts
@@ -55,6 +55,8 @@ interface ApiTransaction {
   details: string;
   amount: number;
   payment: number;
+  /** True when this transaction belongs to a PO whose status is "Inactive". */
+  is_inactive?: boolean;
 }
 
 

--- a/frontend/src/utils/inactivePoRowStyles.ts
+++ b/frontend/src/utils/inactivePoRowStyles.ts
@@ -1,0 +1,17 @@
+/**
+ * Tailwind classes for Inactive PO row highlighting in vendor tables.
+ * Uses light red to clearly mark rows belonging to an Inactive (superseded) PO.
+ *
+ * Used with DataTable's getRowClassName prop:
+ * ```tsx
+ * const getRowClassName = useCallback((row) => {
+ *   if (row.original.status === "Inactive") {
+ *     return INACTIVE_PO_ROW_CLASSES;
+ *   }
+ *   return undefined;
+ * }, []);
+ * ```
+ * and directly on the vendor-ledger `<TableRow>` for transactions linked to an Inactive PO.
+ */
+export const INACTIVE_PO_ROW_CLASSES =
+  "bg-red-50 hover:bg-red-100 dark:bg-red-950/30 dark:hover:bg-red-950/50";

--- a/nirmaan_stack/api/data_table/facets.py
+++ b/nirmaan_stack/api/data_table/facets.py
@@ -9,7 +9,8 @@ from .constants import LINK_FIELD_MAP, CHILD_TABLE_ITEM_SEARCH_MAP, JSON_ITEM_SE
 from .utils import (
     _parse_filters_input, _process_filters_for_query,
     _parse_target_search_field,
-    split_name_in_constraints, enumerate_matching_names
+    split_name_in_constraints, enumerate_matching_names,
+    append_search_filter
 )
 from .token_search import tokenize
 
@@ -189,7 +190,17 @@ def get_facet_values_impl(
                 else:
                     # Plain column field — original behavior
                     for token in search_tokens:
-                        processed_filters.append([doctype, target_search_field, "like", f"%{token}%"])
+                        # A non-text field returns names rather than appending a filter.
+                        # Appending them as `name in` is safe HERE (and only here) because
+                        # `split_name_in_constraints` runs a few lines below and pulls the
+                        # set straight back out, so it never reaches the generated SQL.
+                        _name_matches = append_search_filter(
+                            doctype, target_search_field, token, processed_filters
+                        )
+                        if _name_matches is not None:
+                            processed_filters.append(
+                                [doctype, "name", "in", list(_name_matches) or ["__NO_MATCH__"]]
+                            )
         
         # limit=0 means no limit, otherwise use the requested limit (no artificial cap)
         limit_int = cint(limit) if cint(limit) > 0 else None

--- a/nirmaan_stack/api/data_table/search.py
+++ b/nirmaan_stack/api/data_table/search.py
@@ -15,7 +15,8 @@ from .constants import (
 from .utils import (
     _parse_filters_input, _process_filters_for_query,
     _parse_search_fields_input, _parse_target_search_field,
-    split_name_in_constraints, enumerate_matching_names
+    split_name_in_constraints, enumerate_matching_names,
+    append_search_filter, merge_name_constraint
 )
 from .aggregations import get_aggregates, get_group_by_results
 from .token_search import rank_parents_by_token_score, tokenize
@@ -268,7 +269,12 @@ def get_list_with_count_enhanced_impl(
             child_status_field = search_config.get("status_field")
             if child_status_field:
                 if search_term and target_search_field_name and target_search_field_name not in CHILD_TABLE_ITEM_SEARCH_MAP[doctype]:
-                    final_and_filters.append([doctype, target_search_field_name, "like", f"%{search_term}%"])
+                    # A non-text field returns names instead of a filter; fold them into the
+                    # name constraint, which is re-applied to this branch's result below.
+                    base_name_constraint = merge_name_constraint(
+                        base_name_constraint,
+                        append_search_filter(doctype, target_search_field_name, search_term, final_and_filters),
+                    )
                 parent_names_query_args = {"doctype": doctype, "filters": final_and_filters, "fields": ["name"], "limit_page_length": 0}
                 potential_parent_names = [doc.get("name") for doc in reportview_execute(**parent_names_query_args) if doc.get("name")]
                 if potential_parent_names:
@@ -326,7 +332,11 @@ def get_list_with_count_enhanced_impl(
                 total_records = len(final_matching_parent_names)
 
         elif use_json_pending_filter:
-            if search_term and target_search_field_name: final_and_filters.append([doctype, target_search_field_name, "like", f"%{search_term}%"])
+            if search_term and target_search_field_name:
+                base_name_constraint = merge_name_constraint(
+                    base_name_constraint,
+                    append_search_filter(doctype, target_search_field_name, search_term, final_and_filters),
+                )
             parent_names_query_args = {"doctype": doctype, "filters": final_and_filters, "fields": ["name"], "limit_page_length": 0}
             potential_parent_names = [doc.get("name") for doc in reportview_execute(**parent_names_query_args) if doc.get("name")]
             if potential_parent_names:
@@ -340,7 +350,13 @@ def get_list_with_count_enhanced_impl(
 
         else: # Standard Search -- Frappe-native: count via COUNT(*), page via direct LIMIT/OFFSET.
             if search_term and target_search_field_name:
-                for token in tokenize(search_term): final_and_filters.append([doctype, target_search_field_name, "like", f"%{token}%"])
+                for token in tokenize(search_term):
+                    # Successive intersection gives AND-across-tokens, matching the
+                    # stacked `like` filters the text path still produces.
+                    base_name_constraint = merge_name_constraint(
+                        base_name_constraint,
+                        append_search_filter(doctype, target_search_field_name, token, final_and_filters),
+                    )
             if base_name_constraint is None:
                 # Total via a single COUNT(*) (frappe.db.count -> query builder, which bypasses the sqlparse
                 # gate). No enumeration of the full name set, no `name IN (...)`.

--- a/nirmaan_stack/api/data_table/utils.py
+++ b/nirmaan_stack/api/data_table/utils.py
@@ -280,6 +280,79 @@ def _parse_target_search_field(search_fields_input: str | None, doctype_for_log:
         
     return None
 
+# Fieldtypes whose PostgreSQL column is NOT text, so `col LIKE '%x%'` has no operator:
+# psycopg2 raises `operator does not exist: numeric ~~* unknown`. Mirrors the set already
+# used in facets.py for the `col != ''` guard — the same PG strict-typing class of bug.
+NON_TEXT_SEARCH_FIELDTYPES = {
+    "Currency", "Float", "Int", "Percent", "Rating",
+    "Date", "Datetime", "Time", "Duration", "Check",
+}
+
+
+def append_search_filter(doctype: str, field: str, token: str, filters: list) -> set | None:
+    """Add a substring-search condition for `token` on `doctype.field`.
+
+    Returns None when the condition was appended to `filters` as a normal `like`, or a SET
+    OF NAMES that the CALLER MUST APPLY as a name constraint. Callers must handle both —
+    ignoring the return value silently drops the search condition entirely.
+
+    TEXT fields keep the plain `like` filter — byte-identical to the pre-fix behaviour, so
+    every existing text search on every other table is untouched.
+
+    NON-TEXT fields (Currency/Float/Int/... — see NON_TEXT_SEARCH_FIELDTYPES) cannot take a
+    `like`: PostgreSQL has no `numeric ~~ unknown` operator and, unlike MariaDB, will not
+    implicitly cast. Frappe's filter list cannot express a cast, so those are resolved here
+    with a raw `col::text ILIKE` and handed back as names.
+
+    ⚠️ The names are RETURNED, never appended as `["name","in",[...]]`. Injecting that
+    filter is exactly the shape that trips sqlparse's 10k-token cap once the set is large
+    (a real production crash on this module): a broad numeric search matches thousands of
+    rows, and `reportview_execute` would inline every one of them into the query text. The
+    caller's own name-constraint machinery (`base_name_constraint` /
+    `enumerate_matching_names`) applies the set WITHOUT inlining it.
+
+    Substring semantics are preserved for numbers on purpose: typing `95` must still find
+    9,516 and 149,140. Parsing the token and using `=` would avoid the crash but silently
+    return almost nothing — a worse failure, because nobody would report it.
+    """
+    field_meta = None
+    try:
+        field_meta = frappe.get_meta(doctype).get_field(field)
+    except Exception:
+        field_meta = None
+
+    # get_field returns None for standard fields (name/owner/creation/...). Those keep the
+    # existing `like` path: unchanged behaviour, and the safe default for anything unknown.
+    is_non_text = bool(field_meta) and field_meta.fieldtype in NON_TEXT_SEARCH_FIELDTYPES
+    if not is_non_text:
+        filters.append([doctype, field, "like", f"%{token}%"])
+        return None
+
+    # Cast the COLUMN, never the pattern: `col::text ILIKE '%9%'`. Casting the other way
+    # (`col ILIKE '9'::numeric`) is the same error with the operands swapped.
+    matches = frappe.db.sql(
+        f'SELECT name FROM `tab{doctype}` WHERE `{field}`::text ILIKE %(pattern)s',
+        {"pattern": f"%{token}%"},
+        as_list=True,
+    )
+    # An empty set is meaningful: it must narrow to nothing, never widen to everything.
+    return {r[0] for r in matches if r and r[0]}
+
+
+def merge_name_constraint(existing: set | None, incoming: set | None) -> set | None:
+    """Intersect two optional name constraints (AND semantics, matching stacked filters).
+
+    None means "no constraint". An EMPTY incoming set is a real constraint meaning "nothing
+    matched" and must survive the merge — returning `existing` for a falsy incoming would
+    turn a zero-result search into an unfiltered one.
+    """
+    if incoming is None:
+        return existing
+    if existing is None:
+        return incoming
+    return existing & incoming
+
+
 def split_name_in_constraints(processed_filters: list) -> tuple[list, set | None]:
     """Pull `name in [...]` filters out of a processed filter list so a downstream ORM query never inlines a
     giant `name IN (...)` (the sqlparse 10,000-token trap). The JSON-field facet path above injects exactly

--- a/nirmaan_stack/api/reminders/delete.py
+++ b/nirmaan_stack/api/reminders/delete.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
+# See license.txt
+"""
+Reminders — DELETE endpoint (retire a `Reminder Schedule`).
+
+Split out of `write.py`: that module owns the per-cycle instance writes (complete /
+reopen) plus the rename, all of which MUTATE live state. Deleting a schedule is a
+different kind of operation with its own history-preservation contract, so it gets its
+own file.
+
+The admin gate is IMPORTED from `write.py` rather than re-minted here — a permission
+predicate must have exactly one home, or the two copies can drift and disagree about the
+same user.
+"""
+
+import frappe
+from frappe import _
+
+from nirmaan_stack.api.reminders.write import _require_reminder_editor
+
+
+@frappe.whitelist(methods=["POST"])
+def delete_reminder(name):
+	"""Hard-delete a `Reminder Schedule`. Its DONE history is KEPT; its PENDING rows go.
+
+	`Reminder Schedule Log` rows are NOT child rows of the schedule — they are a separate
+	doctype holding a Link — so `delete_doc` does not cascade into them. What happens to
+	them is decided here, and the two statuses are treated differently ON PURPOSE
+	(owner ruling):
+
+	* ``Done`` — a record that someone completed this filing on this date. This is the
+	  audit trail and is NEVER deleted.
+	* ``Pending`` — an un-actioned to-do for a reminder that will no longer exist. Nothing
+	  ever happened on it, so it is not audit; leaving it behind would strand a task nobody
+	  can complete (its schedule is gone, so it fails scoping and cannot be marked done).
+	  These are deleted with the schedule.
+
+	Pending rows go through `delete_doc`, not a raw `db.delete`, so each one is archived
+	into Frappe's `Deleted Document` and stays recoverable.
+
+	Three deliberate mechanics:
+
+	* ``force=1`` — Frappe refuses to delete a doc that is Linked elsewhere
+	  (`LinkExistsError`), and `force` is the documented way past that check. Without it a
+	  schedule could only ever be deleted before its first reminder was raised.
+	* The title is re-stamped onto every one of its logs FIRST. `reminder_title` carries
+	  ``fetch_from: reminder_schedule.title``, so Frappe already fills it at insert — this
+	  is NOT the only copy. It is re-stamped because a fetched value is a SNAPSHOT taken at
+	  the log's last save: a schedule renamed after its logs were raised leaves them holding
+	  the old title, and once the master is gone there is nothing left to fetch from. The
+	  write makes the surviving rows self-describing and current at the moment of deletion.
+
+	⚠️ KNOWN CONSEQUENCE, accepted by the owner: the retained Done rows stop appearing in
+	the Compliance History. `get_my_reminder_logs` scopes visible logs through the
+	schedule's `Reminder Role Profile` CHILD rows, and those DO die with the master, so the
+	surviving logs match no profile. They remain in the database, titled and queryable, but
+	are no longer surfaced. Making them visible again needs a role-profile snapshot on the
+	log plus a read-endpoint rework — deliberately not in this slice.
+
+	Returns ``{"deleted": True, "name": <name>, "kept_done": N, "removed_pending": M}``.
+	"""
+	_require_reminder_editor()
+
+	name = (name or "").strip()
+	if not name:
+		frappe.throw(_("name is required."))
+
+	row = frappe.db.get_value("Reminder Schedule", name, ["title"], as_dict=True)
+	if not row:
+		frappe.throw(_("Reminder not found."), frappe.DoesNotExistError)
+
+	# Pending rows first: they are the ones being removed, so they must not be counted as
+	# kept history nor re-stamped. delete_doc (not db.delete) archives each into
+	# `Deleted Document`, so an over-eager delete stays recoverable.
+	pending = frappe.get_all(
+		"Reminder Schedule Log",
+		filters={"reminder_schedule": name, "status": "Pending"},
+		pluck="name",
+	)
+	for log_name in pending:
+		frappe.delete_doc(
+			"Reminder Schedule Log", log_name, ignore_permissions=True, force=1
+		)
+
+	kept_done = frappe.db.count("Reminder Schedule Log", {"reminder_schedule": name})
+
+	# Re-stamp BEFORE the delete: afterwards there is no master left to read a title from,
+	# so a log still holding a pre-rename snapshot could never be corrected.
+	# update_modified=False: stamping provenance is not a content edit by this user.
+	if kept_done:
+		frappe.db.set_value(
+			"Reminder Schedule Log",
+			{"reminder_schedule": name},
+			"reminder_title",
+			row.title or name,
+			update_modified=False,
+		)
+
+	frappe.delete_doc(
+		"Reminder Schedule",
+		name,
+		force=1,  # past the LinkExistsError raised by the surviving Done rows
+		ignore_permissions=True,  # gated above on the role profile, like every endpoint here
+	)
+	frappe.db.commit()
+
+	return {
+		"deleted": True,
+		"name": name,
+		"kept_done": kept_done,
+		"removed_pending": len(pending),
+	}

--- a/nirmaan_stack/api/reminders/write.py
+++ b/nirmaan_stack/api/reminders/write.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Nirmaan (Stratos Infra Technologies Pvt. Ltd.) and contributors
 # See license.txt
 """
-Reminders — WRITE endpoints (complete / reopen a raised reminder instance).
+Reminders — WRITE endpoints (complete / reopen a raised reminder instance, rename a schedule).
 
 The accountant acts on a `Reminder Schedule Log` (the per-cycle instance). Plain
 `Nirmaan Accountant` has READ-ONLY DocPerm on the log, so these run with
@@ -10,12 +10,38 @@ complete a reminder only if its schedule targets their own role profile (the SAM
 the read endpoints, via `_my_schedule_names`). Nothing is ever deleted — completion is a
 status flip; the log is a permanent audit row. `ReminderScheduleLog.validate` stamps /
 clears `completed_by` + `completed_at` on the status change.
+
+`rename_reminder` is the SCHEDULE-level write (see its docstring for why a plain
+`updateDoc({title})` cannot work); it is gated on the same role profiles that own the
+Edit affordance, resolved from `Nirmaan Users.role_profile` exactly like `read.py` does.
 """
 
 import frappe
 from frappe import _
 
 from nirmaan_stack.api.reminders.read import _my_schedule_names
+
+# Role profiles allowed to RENAME a schedule — deliberately NARROWER than the page's
+# `canCreate` set (which also has PMO Executive + Accountant Lead behind the Add/Edit
+# buttons): a rename moves the primary key, so it is Admin-only.
+# Resolved from `Nirmaan Users.role_profile`, NOT `frappe.get_roles` — the reminders
+# module scopes on the PROFILE everywhere else, and the two name spaces differ (the
+# DocPerm role is "Nirmaan Accountant Lead", the profile is "... Lead Profile").
+REMINDER_EDITOR_PROFILES = frozenset({
+	"Nirmaan Admin Profile",
+})
+
+
+def _require_reminder_editor():
+	"""Throw unless the caller may edit a Reminder Schedule (Administrator or an editor profile)."""
+	user = frappe.session.user
+	if user == "Guest":
+		frappe.throw(_("Authentication required."), frappe.PermissionError)
+	if user == "Administrator":
+		return
+	profile = frappe.db.get_value("Nirmaan Users", {"email": user}, "role_profile")
+	if profile not in REMINDER_EDITOR_PROFILES:
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 
 @frappe.whitelist(methods=["POST"])
@@ -55,3 +81,58 @@ def _set_status(log_name, status, remarks):
 		"completed_by": doc.completed_by,
 		"completed_at": doc.completed_at,
 	}
+
+
+@frappe.whitelist(methods=["POST"])
+def rename_reminder(name, new_title):
+	"""Rename a `Reminder Schedule` — the ONLY way its title can actually change.
+
+	`Reminder Schedule` is autonamed ``field:title``, so the document NAME *is* the title,
+	and Frappe's ``BaseDocument._sync_autoname_field`` force-copies name -> title on EVERY
+	save. A plain ``updateDoc({"title": ...})`` is therefore silently reverted during
+	validation: the save succeeds, the title snaps back, nothing is renamed. Only
+	``rename_doc`` moves the name, and it then writes the new value into the title field
+	itself (``rename_doc.update_autoname_field``).
+
+	Renaming is SAFE with linked history: ``rename_doc`` repoints every Link field, so
+	each ``Reminder Schedule Log.reminder_schedule`` follows to the new name and no audit
+	row is orphaned. Returns ``{"name": <new name>, "renamed": bool}``.
+	"""
+	_require_reminder_editor()
+
+	name = (name or "").strip()
+	new_title = (new_title or "").strip()
+
+	if not name:
+		frappe.throw(_("name is required."))
+	if not new_title:
+		frappe.throw(_("Title is required."))
+	if not frappe.db.exists("Reminder Schedule", name):
+		frappe.throw(_("Reminder not found."), frappe.DoesNotExistError)
+
+	# No-op rename: report it honestly instead of round-tripping the whole link rewrite.
+	if new_title == name:
+		return {"name": name, "renamed": False}
+
+	# Guard BEFORE rename_doc so the caller gets a plain message rather than a
+	# DuplicateEntryError traceback (rename_doc would otherwise merge-or-throw).
+	if frappe.db.exists("Reminder Schedule", new_title):
+		frappe.throw(_("A reminder named “{0}” already exists.").format(new_title))
+
+	# Import the MODULE-level rename_doc, not the `frappe.rename_doc` wrapper — the wrapper
+	# does not expose `ignore_permissions`, and we need it: the gate above is on the role
+	# PROFILE, while DocPerm is keyed on ROLE names that do not match one-for-one (profile
+	# "Nirmaan Accountant Lead Profile" vs role "Nirmaan Accountant Lead"). Same
+	# gate-then-bypass pattern the rest of this module uses.
+	from frappe.model.rename_doc import rename_doc
+
+	new_name = rename_doc(
+		doctype="Reminder Schedule",
+		old=name,
+		new=new_title,
+		ignore_permissions=True,
+		show_alert=False,  # this is an API call, not a Desk action — no server-side toast
+	)
+	frappe.db.commit()
+
+	return {"name": new_name, "renamed": True}

--- a/nirmaan_stack/api/vendor/get_vendor_po_invoices.py
+++ b/nirmaan_stack/api/vendor/get_vendor_po_invoices.py
@@ -23,15 +23,18 @@ def get_po_ledger_data(vendor_id):
     start_datetime = get_datetime(start_date)
 
     # --- Step 1: Fetch Purchase Orders ---
+    # Inactive POs ARE included; every transaction linked to one is flagged
+    # `is_inactive` so the ledger can tint those rows red.
     vendor_pos = frappe.get_all(
         "Procurement Orders",
-        filters={"vendor": vendor_id, "status": ("not in", [ "Merged", "Inactive", "PO Amendment"])},
-        fields=["name", "creation", "total_amount", "project_name"]
+        filters={"vendor": vendor_id, "status": ("not in", [ "Merged", "PO Amendment"])},
+        fields=["name", "creation", "total_amount", "project_name", "status"]
     )
     print(f"DEBUG LEDGER: Found {len(vendor_pos)} total historical Purchase Orders.")
 
     doc_names = []
     doc_project_map = {}
+    inactive_doc_names = set()
 
     # Process POs
     for po in vendor_pos:
@@ -39,13 +42,17 @@ def get_po_ledger_data(vendor_id):
         project_name_from_po = po.get("project_name", "N/A")
         doc_names.append(doc_name)
         doc_project_map[doc_name] = project_name_from_po
+        is_inactive = po.get("status") == "Inactive"
+        if is_inactive:
+            inactive_doc_names.add(doc_name)
         all_transactions.append({
             "type": "PO Created",
             "date": get_datetime(po.get("creation")),
             "details": f"PO: {doc_name}",
             "amount": flt(po.get('total_amount', 0)),
             "payment": 0,
-            "project": project_name_from_po
+            "project": project_name_from_po,
+            "is_inactive": is_inactive
         })
         log_counter += 1
 
@@ -82,7 +89,8 @@ def get_po_ledger_data(vendor_id):
             "details": f"SR: {doc_name}",
             "amount": sr_amount_no_gst,
             "payment": 0,
-            "project": resolved_project_name
+            "project": resolved_project_name,
+            "is_inactive": False
         })
         log_counter += 1
 
@@ -119,7 +127,8 @@ def get_po_ledger_data(vendor_id):
                 "details": f"Invoice No: {invoice.get('invoice_no')}\nFor {doc_type_abbr}: {doc_name}",
                 "amount": invoice_amount,
                 "payment": 0,
-                "project": project_name_for_invoice
+                "project": project_name_for_invoice,
+                "is_inactive": doc_name in inactive_doc_names
             })
             log_counter += 1
 
@@ -150,7 +159,8 @@ def get_po_ledger_data(vendor_id):
                 "details": f"UTR: {payment.get('utr', 'N/A')}\nFor {doc_type_abbr}: {linked_doc_name}",
                 "amount": 0,
                 "payment": flt(payment.get("amount", 0)),
-                "project": project_name_for_payment
+                "project": project_name_for_payment,
+                "is_inactive": linked_doc_name in inactive_doc_names
             })
             log_counter += 1
 


### PR DESCRIPTION
1.  Searching a numeric column no longer crashes the table-Typing in the "Invoice Amt" search on Vendor Invoice Recon threw
2.  Rename + delete schedules, Admin-only, and dialog UX fixes
3.  Limit transfer destination to Won projects
4.  Stop Last Modified By overflowing into Invoice Amount
5.  Include Inactive POs in Material Orders and Vendor Ledger
6. Inactive (superseded) POs were filtered out of both tabs entirely. They are now listed with a red row tint, plus a legend that renders only when a tinted row is actually on screen.
