### PR TITLE
Projects – Manual & Customer PO-Driven Project Value

### DIFF
--- a/frontend/.claude/plans/project-value-manual-vs-auto-plan.md
+++ b/frontend/.claude/plans/project-value-manual-vs-auto-plan.md
@@ -1,0 +1,135 @@
+# Plan: Project Value — Manual vs Automatic (+ Add-PO decision step)
+
+> **One line:** A project's headline value can come from one of two places — the **sum of its
+> Customer POs** (Automatic, default, = today) or a **number typed by the team** (Manual, opt-in).
+> One `Check` field decides it, per project. Everything is additive; nothing changes unless someone
+> opts in.
+
+- **Branch:** `man-proj-val` (off `develop`, was 0/0 at start).
+- **Status:** implemented + typechecked. **Not merged. Migrate pending.**
+- **Artifacts:** senior proposal (📋) + dev spec (🏗️). This file is the engineering plan/record.
+
+---
+
+## The fundamentals
+
+Two headline fields on `Projects`: `project_value` (excl. GST), `project_value_gst` (incl. GST),
+plus the `customer_po_details` child table. One new flag decides where the value comes from:
+
+```
+manual_project_value = 0  (default)  ->  value = Σ Customer PO rows, recomputed every save  (AUTOMATIC)
+manual_project_value = 1             ->  value = what the team typed; POs never overwrite it  (MANUAL)
+```
+
+The guard lives in `Projects.before_save` and is written so that **flag = 0 is byte-identical to
+develop's historical behaviour** (including zeroing on an empty PO list):
+
+```python
+def before_save(self):
+    if not self.get("manual_project_value"):          # AUTOMATIC (default) — unchanged from before
+        self.project_value     = sum(flt(d.customer_po_value_exctax) for d in self.get("customer_po_details", []))
+        self.project_value_gst = sum(flt(d.customer_po_value_inctax) for d in self.get("customer_po_details", []))
+    # MANUAL (flag = 1): skip entirely — the typed values stay.
+```
+
+---
+
+## Stage 1 — Manual vs Automatic (base feature)
+
+Lets the team choose the mode at create time and switch it later on the edit form.
+
+| Area | File | Change |
+|---|---|---|
+| Doctype | `doctype/projects/projects.json` | New `manual_project_value` Check (default `"0"`) + field_order + modified bump |
+| Guard | `doctype/projects/projects.py` | `before_save` opt-in guard (above) |
+| Create API | `api/projects/_project_population.py` | Persist `manual_project_value` alongside the value fields |
+| Seed-PO fix | `api/projects/add_customer_po.py` | `save(ignore_permissions=True)` — seed PO runs before User Permissions exist |
+| Type | `types/NirmaanStack/Projects.ts` | `manual_project_value?: 0 \| 1` |
+| Schema | `project-form/schema.ts` | Optional union, **default 0**, non-blocking (existing create flow unchanged) |
+| Create UI | `project-form/steps/ProjectDetailsStep.tsx` | "Enter project value manually" checkbox → reveals enabled value inputs |
+| Submit | `project-form/index.tsx` | Blank the values on the PO-driven path before submit |
+| Review | `project-form/steps/ReviewStep.tsx` | Shows "Manual — … / Auto — from Customer POs" |
+| Edit UI | `edit-project-form.tsx` | Same toggle so an existing project can switch modes (schema/defaults/reset/payload/UI) |
+
+**Behaviour**
+- Add Project: toggle **off** by default → today's flow (value from POs). Tick it → type the value.
+- Edit Project: flip the mode any time. Off → value recomputes from POs on save. On → typed value stays.
+
+---
+
+## Stage 2 — Add-PO decision step (improvement)
+
+When a PO is added to a project that is **already Manual**, don't silently ignore it — ask.
+
+**Flow**
+- **Automatic project** → Add Customer PO is **one step** (unchanged).
+- **Manual project** → **two steps**: Step 1 = PO details (unchanged); Step 2 = a choice:
+  - **Keep my project value as it is** *(default)* — record the PO, leave the value untouched.
+  - **Switch to Customer PO totals** — flip the project to Automatic (`manual_project_value → 0`);
+    value becomes the sum of all POs, now and for future POs.
+  - plus a **← Back to PO details** link.
+
+| Area | File | Change |
+|---|---|---|
+| API | `api/projects/add_customer_po.py` | New `override_manual_value` param; when truthy AND project is manual → set `manual_project_value = 0` before save (so `before_save` recomputes). Default keeps manual. |
+| Hook | `data/tab/financials/useCustomerPOApi.ts` | `createCustomerPO(..., overrideManualValue=false)` sends `override_manual_value`; `CustomerPOProjectsDoc` type gained the field |
+| Dialog | `components/AddCustomerPODialog.tsx` | `manualProjectValue` prop, step/choice state, manual-mode gate in `handleSubmit` (no premature upload), step-2 panel, step-aware header + button label |
+| Card | `components/CustomerPODeatilsCard.tsx` | Passes the project's `manual_project_value` into the dialog |
+
+**Design decision (owner-confirmed):** "override" = **permanent switch to Automatic** ("stops being the
+typed number and instead becomes the total of the POs"), not a one-time recompute. Default choice is
+**Keep** (the safe "just add the PO data" option). Nothing uploads/saves until step 2 is confirmed.
+Scoped to **Add** PO only — editing a PO on a manual project leaves the value alone.
+
+---
+
+## Safety / why it's additive
+
+1. **Off by default** — new field default `0`; every existing + new project starts Automatic (= today).
+2. **`before_save` flag=0 branch is unchanged** from develop — the PO-driven flow is byte-identical.
+3. **No data change on release** — `migrate` only adds a column; it does not re-save existing projects,
+   so every current `project_value` is untouched (data-equivalence by construction).
+4. **Non-manual PO flow unchanged** — Stage 2's step-2 only appears for manual projects.
+5. **Reversible** — a project can move between modes any time (edit form, or the Stage-2 override).
+
+---
+
+## Verification (ran)
+
+- Backend `py_compile`: clean (projects.py, _project_population.py, add_customer_po.py); `projects.json` valid JSON.
+- Full project `tsc --noEmit`: **0 errors in any file this feature touched** (a clean result on
+  `AddCustomerPODialog.tsx` also confirms the step-1/step-2 JSX is balanced). The only errors near the
+  earlier files are 6 pre-existing develop errors (carpet_area ×2, WP-category mapping, setActiveSection,
+  DraftResumeDialog, unused `Form` import) — proven unchanged from HEAD. **Zero new type errors.**
+
+---
+
+## Git state & staging (Stage 1 vs Stage 2)
+
+`git status` in `apps/nirmaan_stack` currently splits along the two stages:
+
+**Stage 1 — already staged (`M `):**
+`projects.json`, `projects.py`, `_project_population.py`, `Projects.ts`, `schema.ts`,
+`ProjectDetailsStep.tsx`, `project-form/index.tsx`, `ReviewStep.tsx`, `edit-project-form.tsx`.
+
+**Stage 2 — unstaged (` M`), plus the Stage-2 half of `add_customer_po.py` (`MM`):**
+`AddCustomerPODialog.tsx`, `CustomerPODeatilsCard.tsx`, `useCustomerPOApi.ts`, `add_customer_po.py`.
+
+To stage the Stage-2 set (run yourself — I don't stage on your behalf):
+```bash
+cd apps/nirmaan_stack
+git add \
+  frontend/src/pages/projects/components/AddCustomerPODialog.tsx \
+  frontend/src/pages/projects/components/CustomerPODeatilsCard.tsx \
+  frontend/src/pages/projects/data/tab/financials/useCustomerPOApi.ts \
+  nirmaan_stack/api/projects/add_customer_po.py
+```
+
+---
+
+## Remaining steps
+
+- [ ] `bench --site localhost migrate` (from the devcontainer) — adds the `manual_project_value` column.
+- [ ] Data-equivalence check: existing `project_value` identical before vs after migrate (DIFF = 0).
+- [ ] E2E: manual create → PO does not change value; manual project + Add PO → Keep vs Switch behave; auto project → single-step PO, value grows.
+- [ ] Merge `man-proj-val` → `develop`.

--- a/frontend/src/pages/projects/components/AddCustomerPODialog.tsx
+++ b/frontend/src/pages/projects/components/AddCustomerPODialog.tsx
@@ -403,13 +403,27 @@ export interface CustomerPODetail {
 interface AddCustomerPODialogProps {
     projectName: string; // Name of the parent Projects doc (e.g., "PROJ/0001")
     refetchProjectData: () => Promise<any>;
+    // 1 when the project's value was entered manually. Drives the step-2 override/keep choice.
+    manualProjectValue?: 0 | 1;
 }
 
 // REMOVED 'none' to enforce selection
 type LinkAttachmentChoice = 'link' | 'attachment'; 
 
-export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projectName, refetchProjectData }) => {
+export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projectName, refetchProjectData, manualProjectValue }) => {
     const [open, setOpen] = useState(false);
+    // Two-step flow ONLY when the project is in Manual value mode: step 1 collects the PO,
+    // step 2 asks whether to keep the manual value or switch to Customer PO totals.
+    const isManualMode = manualProjectValue === 1;
+    const [step, setStep] = useState<1 | 2>(1);
+    const [valueChoice, setValueChoice] = useState<'keep' | 'override'>('keep');
+    // Reset the wizard whenever the dialog closes so it always reopens on step 1 with the safe default.
+    useEffect(() => {
+        if (!open) {
+            setStep(1);
+            setValueChoice('keep');
+        }
+    }, [open]);
     
     // State for Link/Attachment choice - Default to 'link' for initial form state
     const [linkOrAttachmentChoice, setLinkOrAttachmentChoice] = useState<LinkAttachmentChoice>('attachment');
@@ -677,6 +691,8 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
         setProjectMismatch(null);
         setAutofillMeta(null);
         setAttachmentProcessed(false); // fields hidden until the PO is read
+        setStep(1);
+        setValueChoice('keep');
     }, []);
 
     const isLinkAttachmentValid = useMemo(() => {
@@ -752,7 +768,14 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
             toast({ title: "Error", description: "Project Name is missing.", variant: "destructive" });
             return;
         }
-        
+
+        // Manual-mode gate: on step 1 we don't save yet — advance to the value-choice step first.
+        // (No file upload happens until the user confirms on step 2.)
+        if (isManualMode && step === 1) {
+            setStep(2);
+            return;
+        }
+
         let finalAttachmentName = '';
 
         // 1. Handle File Upload if an attachment is selected
@@ -795,8 +818,9 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
             ...(linkOrAttachmentChoice === 'attachment' && autofillMeta ? autofillMeta : {}),
         };
 
-        // 3. Call Custom Frappe API for saving
-        createCustomerPO(projectName, newPODetail)
+        // 3. Call Custom Frappe API for saving.
+        // In manual mode, "override" flips the project to PO-driven; "keep" (default) leaves the value alone.
+        createCustomerPO(projectName, newPODetail, isManualMode && valueChoice === 'override')
         .then((data) => {
             if(data?.message?.status=="Duplicate"){
               toast({title:"Duplicate Po Number",description:"Failed to create Customer Po, Because We already have PO Number in our records. Create a New Po number for Creation.",variant:"destructive"});
@@ -833,11 +857,15 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
             </DialogTrigger>
             <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto overflow-x-hidden">
                 <DialogHeader>
-                    <DialogTitle className="text-xl font-semibold mb-4">
-                        Add Customer Purchase Order
+                    <DialogTitle className="text-xl font-semibold mb-1">
+                        {step === 2 ? "Project value — choose how to handle it" : "Add Customer Purchase Order"}
                     </DialogTitle>
+                    {isManualMode && (
+                        <p className="text-xs text-muted-foreground mb-3">Step {step} of 2</p>
+                    )}
                 </DialogHeader>
                 <form onSubmit={handleSubmit} className="grid gap-6 py-4">
+                    {step === 1 && (<>
                     {/* PO Source FIRST (attachment-first): uploading the PO auto-fills the fields below */}
                     {/* Radio Button Choice for Link or Attachment */}
                     <div className="space-y-2 border p-4 rounded-md">
@@ -1103,6 +1131,48 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
                     </>
                     )}
 
+                    </>)}
+
+                    {step === 2 && (
+                        <div className="grid gap-4">
+                            <button
+                                type="button"
+                                onClick={() => setStep(1)}
+                                className="text-sm text-muted-foreground hover:text-foreground w-fit inline-flex items-center gap-1"
+                            >
+                                ← Back to PO details
+                            </button>
+                            <div className="rounded-md border border-amber-200 bg-amber-50 dark:border-amber-900/40 dark:bg-amber-950/20 p-3">
+                                <p className="text-sm font-medium">This project's value was entered manually.</p>
+                                <p className="text-sm text-muted-foreground mt-1">Choose what should happen now that you're adding a Customer PO. The PO is recorded either way.</p>
+                            </div>
+                            {([
+                                { key: 'keep', title: 'Keep my project value as it is', desc: 'Just record this Customer PO. The manually-entered project value stays unchanged.' },
+                                { key: 'override', title: 'Switch to Customer PO totals', desc: 'The project value will be calculated from all Customer POs — this one and future ones. Your manually-entered value is replaced.' },
+                            ] as const).map((opt) => {
+                                const selected = valueChoice === opt.key;
+                                return (
+                                    <button
+                                        key={opt.key}
+                                        type="button"
+                                        onClick={() => setValueChoice(opt.key)}
+                                        className={`text-left border rounded-lg p-4 transition ${selected ? 'border-primary ring-1 ring-primary bg-primary/5' : 'border-input hover:bg-muted/50'}`}
+                                    >
+                                        <div className="flex items-start gap-3">
+                                            <span className={`mt-0.5 h-4 w-4 rounded-full border flex-none flex items-center justify-center ${selected ? 'border-primary' : 'border-muted-foreground'}`}>
+                                                {selected && <span className="h-2 w-2 rounded-full bg-primary" />}
+                                            </span>
+                                            <div>
+                                                <p className="text-sm font-medium">{opt.title}</p>
+                                                <p className="text-xs text-muted-foreground mt-1">{opt.desc}</p>
+                                            </div>
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    )}
+
                     <div className="flex gap-4">
                         <Button 
                             type="button" 
@@ -1121,7 +1191,7 @@ export const AddCustomerPODialog: React.FC<AddCustomerPODialogProps> = ({ projec
                             )}
                             {updateLoading 
                                 ? (uploadLoading ? "Uploading File..." : "Validating & Saving...") 
-                                : "Create Customer PO"
+                                : (isManualMode && step === 1 ? "Continue" : "Create Customer PO")
                             }
                         </Button>
                     </div>

--- a/frontend/src/pages/projects/components/CustomerPODeatilsCard.tsx
+++ b/frontend/src/pages/projects/components/CustomerPODeatilsCard.tsx
@@ -996,7 +996,8 @@ export const CustomerPODetailsCard: React.FC<CustomerPODetailsCardProps> = ({ pr
                     {projectId && projectNameForDialog && (
                         <AddCustomerPODialog 
                             projectName={projectNameForDialog}
-                            refetchProjectData={handlePoAdded} 
+                            manualProjectValue={projectDataForDialog?.manual_project_value}
+                            refetchProjectData={handlePoAdded}
                         />
                     )}
                     

--- a/frontend/src/pages/projects/data/tab/financials/useCustomerPOApi.ts
+++ b/frontend/src/pages/projects/data/tab/financials/useCustomerPOApi.ts
@@ -28,6 +28,8 @@ interface CustomerPOProjectsDoc {
   name: string;
   project_name?: string;
   customer_po_details?: any[];
+  // 1 when the project's value was entered manually (drives the Add-PO step-2 override/keep choice).
+  manual_project_value?: 0 | 1;
 }
 
 export const useCustomerPOProjectDoc = (projectId?: string) => {
@@ -53,11 +55,18 @@ export const useCustomerPOActions = () => {
   const deleteResponse = useFrappePostCall<{ message: any }>(DELETE_CUSTOMER_PO_METHOD);
   const uploadResponse = useFrappeFileUpload();
 
-  const createCustomerPO = async (projectName: string, newPoDetail: CustomerPOPayload) => {
+  const createCustomerPO = async (
+    projectName: string,
+    newPoDetail: CustomerPOPayload,
+    overrideManualValue: boolean = false
+  ) => {
     try {
       return await createResponse.call({
         project_name: projectName,
         new_po_detail: newPoDetail,
+        // Only meaningful when the project is in Manual value mode: 1 -> switch it to PO-driven
+        // (recompute from POs); 0 -> keep the manual value, just record the PO.
+        override_manual_value: overrideManualValue ? 1 : 0,
       });
     } catch (error) {
       captureApiError({

--- a/frontend/src/pages/projects/edit-project-form.tsx
+++ b/frontend/src/pages/projects/edit-project-form.tsx
@@ -161,7 +161,23 @@ const projectFormSchema = z.object({
   project_gst: z.string().min(1, { message: "Project GST is required" }),
   carpet_area: z.coerce.number().nonnegative().optional(),
 
-});
+})
+  // Manual mode means the value is typed rather than derived, so it must actually be typed.
+  // Blank would be persisted as 0 and — because PO aggregation is skipped in manual mode —
+  // no Customer PO could ever repair it. Mirrors the create form's rule.
+  .superRefine((values, ctx) => {
+    if (values.manual_project_value !== 1) return;
+    (["project_value", "project_value_gst"] as const).forEach((field) => {
+      const raw = values[field];
+      if (!raw || Number(raw) <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [field],
+          message: "Required when the project value is entered manually.",
+        });
+      }
+    });
+  });
 
 type ProjectFormValues = z.infer<typeof projectFormSchema>;
 
@@ -764,7 +780,7 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
                   render={({ field }) => (
                     <FormItem className="md:flex md:items-start gap-4">
                       <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
-                        Project Value (excl. GST)
+                        Project Value (excl. GST)<sup className="pl-1 text-sm text-red-600">*</sup>
                       </FormLabel>
                       <div className="flex flex-col items-start flex-1">
                         <FormControl>
@@ -782,7 +798,7 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
                   render={({ field }) => (
                     <FormItem className="md:flex md:items-start gap-4">
                       <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
-                        Project Value (incl. GST)
+                        Project Value (incl. GST)<sup className="pl-1 text-sm text-red-600">*</sup>
                       </FormLabel>
                       <div className="flex flex-col items-start flex-1">
                         <FormControl>

--- a/frontend/src/pages/projects/edit-project-form.tsx
+++ b/frontend/src/pages/projects/edit-project-form.tsx
@@ -93,6 +93,8 @@ const projectFormSchema = z.object({
   project_type: z.string().optional(),
   project_value: z.string().optional(),
   project_value_gst: z.string().optional(),
+  // 1 -> manual entry (preserved); 0 (default) -> derived from Customer PO rows.
+  manual_project_value: z.union([z.literal(0), z.literal(1)]).optional(),
   cashflow_gap_limit: z.string().optional(),
   address_line_1: z
     .string({
@@ -308,6 +310,7 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
       project_type: data?.project_type || "",
       project_value: data?.project_value || "",
       project_value_gst: data?.project_value_gst || "",
+      manual_project_value: data?.manual_project_value ? 1 : 0,
       cashflow_gap_limit: data?.cashflow_gap_limit?.toString() || "",
       address_line_1: project_address?.address_line1 || "",
       address_line_2: project_address?.address_line2 || "",
@@ -346,6 +349,7 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
         project_type: data?.project_type || "",
         project_value: data?.project_value?.toString() || "",
         project_value_gst: data?.project_value_gst?.toString() || "",
+        manual_project_value: data?.manual_project_value ? 1 : 0,
         cashflow_gap_limit: data?.cashflow_gap_limit?.toString() || "",
         address_line_1: project_address?.address_line1 || "",
         address_line_2: project_address?.address_line2 || "",
@@ -388,6 +392,8 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
   const endDate = form.watch("project_end_date");
   // Watch customer field to show conditional message
   const customerValue = form.watch("customer");
+  // Manual project-value mode: 1 -> user enters value; 0 (default) -> derived from Customer POs
+  const manualProjectValue = form.watch("manual_project_value");
 
   useEffect(() => {
     if (startDate && endDate) {
@@ -529,6 +535,8 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
         project_type: values.project_type,
         project_value: parseNumber(values.project_value).toString(), // Frappe might expect string for Data/Currency
         project_value_gst: parseNumber(values.project_value_gst).toString(),
+        // Manual mode preserves the above; PO-driven mode (0) lets before_save recompute from POs.
+        manual_project_value: values.manual_project_value ? 1 : 0,
         cashflow_gap_limit: parseNumber(values.cashflow_gap_limit),
         // GST and Scopes: Assuming they are still JSON fields and frontend sends them correctly
         project_scopes: typeof values.project_scopes === 'string' ? values.project_scopes : JSON.stringify(values.project_scopes),
@@ -718,55 +726,75 @@ export const EditProjectForm: React.FC<EditProjectFormProps> = ({ toggleEditShee
                 </FormItem>
               )}
             />
-            {/* Project Value fields hidden - auto-calculated from Customer PO details
+            {/* Project Value mode toggle.
+                Unchecked (default) = auto-calculated from Customer PO rows (unchanged behaviour).
+                Checked = the values below are entered manually and preserved as-is. */}
             <FormField
               control={form.control}
-              name="project_value"
-              render={({ field }) => {
-                return (
-                  <FormItem className="md:flex md:items-start gap-4">
-                    <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
-                      Project Value (excl.GST)
-                    </FormLabel>
-                    <div className="flex flex-col items-start flex-1">
+              name="manual_project_value"
+              render={({ field }) => (
+                <FormItem className="md:flex md:items-start gap-4">
+                  <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">Project Value</FormLabel>
+                  <div className="flex flex-col items-start flex-1 gap-2">
+                    <label className="flex items-center gap-2 cursor-pointer">
                       <FormControl>
-                        <Input placeholder="Auto-calculated" disabled={true} {...field} />
+                        <Checkbox
+                          checked={field.value === 1}
+                          onCheckedChange={(checked) => field.onChange(checked ? 1 : 0)}
+                        />
                       </FormControl>
-                      <FormMessage />
-                      <FormDescription className="text-amber-600 flex items-center gap-1">
-                        <Info className="h-3 w-3" />
-                        Auto-calculated from Customer PO details.
-                      </FormDescription>
-                    </div>
-                  </FormItem>
-                );
-              }}
+                      <span className="text-sm">Enter project value manually</span>
+                    </label>
+                    <FormDescription className="flex items-center gap-1">
+                      <Info className="h-3 w-3" />
+                      {field.value === 1
+                        ? "You're entering the value manually — Customer POs will not overwrite it."
+                        : "Leave unchecked to auto-calculate from Customer PO details."}
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
             />
 
-            <FormField
-              control={form.control}
-              name="project_value_gst"
-              render={({ field }) => {
-                return (
-                  <FormItem className="md:flex md:items-start gap-4">
-                    <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
-                      Project Value (incl. GST)
-                    </FormLabel>
-                    <div className="flex flex-col items-start flex-1">
-                      <FormControl>
-                        <Input placeholder="Auto-calculated" disabled={true} {...field} />
-                      </FormControl>
-                      <FormMessage />
-                      <FormDescription className="text-amber-600 flex items-center gap-1">
-                        <Info className="h-3 w-3" />
-                        Auto-calculated from Customer PO details.
-                      </FormDescription>
-                    </div>
-                  </FormItem>
-                );
-              }}
-            />
-            */}
+            {manualProjectValue === 1 && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="project_value"
+                  render={({ field }) => (
+                    <FormItem className="md:flex md:items-start gap-4">
+                      <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
+                        Project Value (excl. GST)
+                      </FormLabel>
+                      <div className="flex flex-col items-start flex-1">
+                        <FormControl>
+                          <Input type="number" placeholder="Enter value excl. GST" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </div>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="project_value_gst"
+                  render={({ field }) => (
+                    <FormItem className="md:flex md:items-start gap-4">
+                      <FormLabel className="md:w-1/4 md:pt-2.5 shrink-0">
+                        Project Value (incl. GST)
+                      </FormLabel>
+                      <div className="flex flex-col items-start flex-1">
+                        <FormControl>
+                          <Input type="number" placeholder="Enter value incl. GST" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </div>
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
 
             {/* // For `project_type` SelectField */}
             <FormField

--- a/frontend/src/pages/projects/project-form/index.tsx
+++ b/frontend/src/pages/projects/project-form/index.tsx
@@ -235,6 +235,13 @@ export const ProjectForm = () => {
                 ...projectValues
             } = values;
 
+            // PO-driven mode (default): never send a project value — Projects.before_save derives it
+            // from the Customer PO rows. Only manual mode keeps the entered values.
+            if (projectValues.manual_project_value !== 1) {
+                projectValues.project_value = "";
+                projectValues.project_value_gst = "";
+            }
+
             // Collect unique users from assignees
             const uniqueUsers = new Set<string>();
             assignees?.project_leads?.forEach((u) => uniqueUsers.add(u.value));

--- a/frontend/src/pages/projects/project-form/schema.ts
+++ b/frontend/src/pages/projects/project-form/schema.ts
@@ -182,7 +182,24 @@ export const projectFormSchema = z.object({
         enabled: z.boolean().default(false),
         selected_categories: z.array(z.string()).default([]),
     }).optional(),
-});
+})
+    // Manual mode means the value is typed rather than derived, so it must actually be typed.
+    // Blank would be persisted as 0 and — because PO aggregation is skipped in manual mode —
+    // no Customer PO could ever repair it. Only fires when the toggle is on; the default
+    // PO-driven path (manual_project_value !== 1) is unaffected.
+    .superRefine((values, ctx) => {
+        if (values.manual_project_value !== 1) return;
+        (["project_value", "project_value_gst"] as const).forEach((field) => {
+            const raw = values[field];
+            if (!raw || Number(raw) <= 0) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: [field],
+                    message: "Required when the project value is entered manually.",
+                });
+            }
+        });
+    });
 
 export type ProjectFormValues = z.infer<typeof projectFormSchema>;
 

--- a/frontend/src/pages/projects/project-form/schema.ts
+++ b/frontend/src/pages/projects/project-form/schema.ts
@@ -28,6 +28,12 @@ export const projectFormSchema = z.object({
     project_value_gst: z
         .string()
         .optional(),
+    // 0 -> project value is derived from Customer PO rows (default, existing behaviour).
+    // 1 -> project value is entered manually and left untouched by PO aggregation.
+    // Optional + defaults to 0 so the existing create flow is unchanged (non-blocking).
+    manual_project_value: z
+        .union([z.literal(0), z.literal(1)])
+        .optional(),
     cashflow_gap_limit: z
         .string()
         .optional(),
@@ -187,6 +193,7 @@ export const defaultFormValues: ProjectFormValues = {
     project_name: "",
     project_value: "",
     project_value_gst: "",
+    manual_project_value: 0,
     cashflow_gap_limit: "",
     project_start_date: new Date(),
     project_end_date: undefined,

--- a/frontend/src/pages/projects/project-form/steps/ProjectDetailsStep.tsx
+++ b/frontend/src/pages/projects/project-form/steps/ProjectDetailsStep.tsx
@@ -216,7 +216,7 @@ export const ProjectDetailsStep: React.FC<ProjectDetailsStepProps> = ({
                         render={({ field }) => (
                             <FormItem className="lg:flex lg:items-center gap-4">
                                 <FormLabel className="md:basis-2/12">
-                                    Project Value (excl. GST)
+                                    Project Value (excl. GST)<sup className="pl-1 text-sm text-red-600">*</sup>
                                 </FormLabel>
                                 <div className="flex flex-col items-start md:basis-2/4">
                                     <FormControl>
@@ -234,7 +234,7 @@ export const ProjectDetailsStep: React.FC<ProjectDetailsStepProps> = ({
                         render={({ field }) => (
                             <FormItem className="lg:flex lg:items-center gap-4">
                                 <FormLabel className="md:basis-2/12">
-                                    Project Value (incl. GST)
+                                    Project Value (incl. GST)<sup className="pl-1 text-sm text-red-600">*</sup>
                                 </FormLabel>
                                 <div className="flex flex-col items-start md:basis-2/4">
                                     <FormControl>

--- a/frontend/src/pages/projects/project-form/steps/ProjectDetailsStep.tsx
+++ b/frontend/src/pages/projects/project-form/steps/ProjectDetailsStep.tsx
@@ -3,6 +3,7 @@ import { UseFormReturn } from "react-hook-form";
 import { CirclePlus, Info, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
     Form,
     FormControl,
@@ -66,6 +67,8 @@ export const ProjectDetailsStep: React.FC<ProjectDetailsStepProps> = ({
     // Watch customer field to show conditional message
     const customerValue = form.watch("customer");
     const projectGstValue = form.watch("project_gst");
+    // Manual project-value mode: 1 -> user enters value; 0 (default) -> derived from Customer POs
+    const manualProjectValue = form.watch("manual_project_value");
 
     // Logic to handle legacy "Bengaluru" string and migrate it to the actual GSTIN record name
     // This ensures the Select component can resolve the value to an option and show the label.
@@ -174,51 +177,76 @@ export const ProjectDetailsStep: React.FC<ProjectDetailsStepProps> = ({
                 )}
             />
 
-            {/* Project Value fields hidden - auto-calculated from Customer PO details
+            {/* Project Value mode toggle.
+                Unchecked (default) = auto-calculated from Customer PO rows (unchanged behaviour).
+                Checked = the values below are entered manually and preserved as-is. */}
             <FormField
                 control={form.control}
-                name="project_value"
+                name="manual_project_value"
                 render={({ field }) => (
-                    <FormItem className="lg:flex lg:items-center gap-4">
-                        <FormLabel className="md:basis-2/12">
-                            Project Value (excl. GST)
-                        </FormLabel>
-                        <div className="flex flex-col items-start md:basis-2/4">
-                            <FormControl>
-                                <Input placeholder="Auto-calculated" disabled={true} {...field} />
-                            </FormControl>
-                            <FormMessage />
-                            <FormDescription className="text-amber-600 flex items-center gap-1">
+                    <FormItem className="lg:flex lg:items-start gap-4">
+                        <FormLabel className="md:basis-2/12">Project Value</FormLabel>
+                        <div className="flex flex-col items-start md:basis-2/4 gap-2">
+                            <label className="flex items-center gap-2 cursor-pointer">
+                                <FormControl>
+                                    <Checkbox
+                                        checked={field.value === 1}
+                                        onCheckedChange={(checked) => field.onChange(checked ? 1 : 0)}
+                                    />
+                                </FormControl>
+                                <span className="text-sm">Enter project value manually</span>
+                            </label>
+                            <FormDescription className="flex items-center gap-1">
                                 <Info className="h-3 w-3" />
-                                Auto-calculated. Update Customer PO after project creation.
+                                {field.value === 1
+                                    ? "You're entering the value manually — Customer POs will not overwrite it."
+                                    : "Leave unchecked to auto-calculate from Customer POs added after project creation."}
                             </FormDescription>
                         </div>
                     </FormItem>
                 )}
             />
 
-            <FormField
-                control={form.control}
-                name="project_value_gst"
-                render={({ field }) => (
-                    <FormItem className="lg:flex lg:items-center gap-4">
-                        <FormLabel className="md:basis-2/12">
-                            Project Value (incl. GST)
-                        </FormLabel>
-                        <div className="flex flex-col items-start md:basis-2/4">
-                            <FormControl>
-                                <Input placeholder="Auto-calculated" disabled={true} {...field} />
-                            </FormControl>
-                            <FormMessage />
-                            <FormDescription className="text-amber-600 flex items-center gap-1">
-                                <Info className="h-3 w-3" />
-                                Auto-calculated. Update Customer PO after project creation.
-                            </FormDescription>
-                        </div>
-                    </FormItem>
-                )}
-            />
-            */}
+            {/* Manual value inputs — shown only when the toggle is on */}
+            {manualProjectValue === 1 && (
+                <>
+                    <FormField
+                        control={form.control}
+                        name="project_value"
+                        render={({ field }) => (
+                            <FormItem className="lg:flex lg:items-center gap-4">
+                                <FormLabel className="md:basis-2/12">
+                                    Project Value (excl. GST)
+                                </FormLabel>
+                                <div className="flex flex-col items-start md:basis-2/4">
+                                    <FormControl>
+                                        <Input type="number" placeholder="Enter value excl. GST" {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="project_value_gst"
+                        render={({ field }) => (
+                            <FormItem className="lg:flex lg:items-center gap-4">
+                                <FormLabel className="md:basis-2/12">
+                                    Project Value (incl. GST)
+                                </FormLabel>
+                                <div className="flex flex-col items-start md:basis-2/4">
+                                    <FormControl>
+                                        <Input type="number" placeholder="Enter value incl. GST" {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+                </>
+            )}
 
             {/* Project Type */}
             <FormField

--- a/frontend/src/pages/projects/project-form/steps/ReviewStep.tsx
+++ b/frontend/src/pages/projects/project-form/steps/ReviewStep.tsx
@@ -67,6 +67,14 @@ export const ReviewStep: React.FC<ReviewStepProps> = ({
                         }
                     />
                     <ReviewDetail
+                        label="Project Value"
+                        value={
+                            form.getValues("manual_project_value") === 1
+                                ? `Manual — ${form.getValues("project_value") || "0"} (excl. GST) / ${form.getValues("project_value_gst") || "0"} (incl. GST)`
+                                : "Auto — from Customer POs"
+                        }
+                    />
+                    <ReviewDetail
                         label="Carpet Area (Sqft)"
                         value={form.getValues("carpet_area")}
                     />

--- a/frontend/src/types/NirmaanStack/Projects.ts
+++ b/frontend/src/types/NirmaanStack/Projects.ts
@@ -110,6 +110,9 @@ export interface Projects {
 
 	project_value_gst?: string
 
+	/**	Manual Project Value : Check - when set, project_value / project_value_gst are entered manually and NOT recomputed from Customer PO rows	*/
+	manual_project_value?: 0 | 1
+
 	/**	Cashflow Gap Limit : Float	*/
 	cashflow_gap_limit?: number
 

--- a/nirmaan_stack/api/projects/_project_population.py
+++ b/nirmaan_stack/api/projects/_project_population.py
@@ -75,6 +75,9 @@ def apply_full_project_details(project_doc, values: dict):
     project_doc.project_type = values.get("project_type")
     project_doc.project_value = frappe.utils.flt(values.get("project_value"))  # Use flt for safe conversion
     project_doc.project_value_gst = frappe.utils.flt(values.get("project_value_gst"))
+    # Manual mode keeps the entered project_value / project_value_gst (Projects.before_save skips
+    # PO aggregation when this flag is set). Default 0 preserves the existing PO-driven behaviour.
+    project_doc.manual_project_value = 1 if values.get("manual_project_value") else 0
     project_doc.carpet_area = frappe.utils.flt(values.get("carpet_area"))
 
     # Set the project_gst Link field

--- a/nirmaan_stack/api/projects/add_customer_po.py
+++ b/nirmaan_stack/api/projects/add_customer_po.py
@@ -51,8 +51,11 @@ def add_customer_po_with_validation(project_name, new_po_detail):
     
     # 4. Save the document
     try:
-        # Saving the document will also save the new child table entry
-        project_doc.save()
+        # Saving the document will also save the new child table entry.
+        # ignore_permissions=True mirrors create_project_with_address — the seed PO can be added
+        # immediately after project creation, before the creator's User Permissions are written,
+        # so a permission-scoped save would otherwise fail.
+        project_doc.save(ignore_permissions=True)
         frappe.db.commit() # Commit the transaction
         
         return {"message": "Customer PO added successfully.", "project_doc": project_doc.as_dict()}

--- a/nirmaan_stack/api/projects/add_customer_po.py
+++ b/nirmaan_stack/api/projects/add_customer_po.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import get_url, cint
 
 # === IMPORTANT: Verify the name of your Child Doctype ===
@@ -20,6 +21,16 @@ def add_customer_po_with_validation(project_name, new_po_detail, override_manual
         from the Customer PO rows. Default 0 keeps Manual mode: the PO is recorded, the value untouched.
     """
     
+    # 0. Permission gate. `frappe.get_doc` does NOT check permissions and the save below runs with
+    # ignore_permissions, so without this an authenticated caller could add a Customer PO to any
+    # project (and, with override_manual_value, overwrite its value). Mirrors `delete_customer_po`.
+    if not frappe.has_permission("Projects", "write", project_name):
+        frappe.throw(
+            _("You do not have permission to add Customer POs to this project."),
+            frappe.PermissionError,
+            title=_("Permission Error"),
+        )
+
     # 1. Fetch the existing Project document
     try:
         project_doc = frappe.get_doc("Projects", project_name)

--- a/nirmaan_stack/api/projects/add_customer_po.py
+++ b/nirmaan_stack/api/projects/add_customer_po.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.utils import get_url
+from frappe.utils import get_url, cint
 
 # === IMPORTANT: Verify the name of your Child Doctype ===
 # This is the name Frappe gives to the child table created by the 'customer_po_details' field.
@@ -8,13 +8,16 @@ CHILD_DOCTYPE_NAME = "Customer PO Child Table"
 # =======================================================
 
 @frappe.whitelist()
-def add_customer_po_with_validation(project_name, new_po_detail):
+def add_customer_po_with_validation(project_name, new_po_detail, override_manual_value=0):
     """
     Adds a new Customer PO to the Projects doctype after checking for duplicate PO Numbers
     globally (across all projects/child table records).
-    
+
     :param project_name: The name of the Projects document (parent).
     :param new_po_detail: A dictionary containing the new PO details to add.
+    :param override_manual_value: Only relevant when the project is in Manual value mode. When truthy,
+        the project is switched to PO-driven (manual_project_value -> 0) so project_value is recomputed
+        from the Customer PO rows. Default 0 keeps Manual mode: the PO is recorded, the value untouched.
     """
     
     # 1. Fetch the existing Project document
@@ -48,7 +51,13 @@ def add_customer_po_with_validation(project_name, new_po_detail):
     # 3. Add the new PO detail to the child table
     # The new_po_detail is a dictionary matching the child doctype fields.
     project_doc.append("customer_po_details", new_po_detail)
-    
+
+    # 3b. Manual-mode "override": when the project's value was entered manually, the caller can opt to
+    # switch it to PO-driven so before_save recomputes project_value from the Customer PO rows. Without
+    # this, Manual mode is preserved and the entered value stays as-is (the PO is still recorded).
+    if cint(override_manual_value) and project_doc.get("manual_project_value"):
+        project_doc.manual_project_value = 0
+
     # 4. Save the document
     try:
         # Saving the document will also save the new child table entry.

--- a/nirmaan_stack/nirmaan_stack/doctype/projects/projects.json
+++ b/nirmaan_stack/nirmaan_stack/doctype/projects/projects.json
@@ -12,6 +12,7 @@
   "project_value",
   "carpet_area",
   "project_value_gst",
+  "manual_project_value",
   "cashflow_gap_limit",
   "project_gst",
   "customer_section",
@@ -222,6 +223,13 @@
    "label": "Project Value with GST"
   },
   {
+   "default": "0",
+   "description": "When set, project_value / project_value_gst are entered manually and NOT recomputed from Customer PO rows.",
+   "fieldname": "manual_project_value",
+   "fieldtype": "Check",
+   "label": "Manual Project Value"
+  },
+  {
    "fieldname": "project_milestone_details_section",
    "fieldtype": "Section Break",
    "label": "Project Milestone Details"
@@ -317,7 +325,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-06-29 18:26:16.525503",
+ "modified": "2026-07-24 00:00:00.000000",
  "modified_by": "nitesh@nirmaan.app",
  "module": "Nirmaan Stack",
  "name": "Projects",

--- a/nirmaan_stack/nirmaan_stack/doctype/projects/projects.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/projects/projects.py
@@ -16,6 +16,24 @@ from nirmaan_stack.constants.authorized_users import (
 class Projects(Document):
 	def validate(self):
 		self._validate_ceo_hold_status()
+		self._validate_manual_project_value()
+
+	def _validate_manual_project_value(self):
+		"""Manual mode claims a human typed the value, so it must actually carry one.
+
+		Without this a project saves with `manual_project_value = 1` and a blank/zero value:
+		before_save then skips PO aggregation for it, so no Customer PO can ever repair the 0.
+		The PO-driven path (flag 0) is untouched — it is derived and may legitimately be 0.
+		"""
+		if not self.get("manual_project_value"):
+			return
+
+		if flt(self.project_value) <= 0 or flt(self.project_value_gst) <= 0:
+			frappe.throw(
+				"Enter both Project Value (excl. GST) and Project Value (incl. GST) when the value is "
+				"entered manually, or untick 'Enter project value manually' to derive them from Customer POs.",
+				title="Missing Project Value",
+			)
 
 	def _validate_ceo_hold_status(self):
 		"""Enforce CEO Hold access rules:

--- a/nirmaan_stack/nirmaan_stack/doctype/projects/projects.py
+++ b/nirmaan_stack/nirmaan_stack/doctype/projects/projects.py
@@ -85,8 +85,13 @@ class Projects(Document):
 			self.ceo_hold_by = None
 
 	def before_save(self):
-		self.project_value = sum(flt(d.customer_po_value_exctax) for d in self.get("customer_po_details", []))
-		self.project_value_gst = sum(flt(d.customer_po_value_inctax) for d in self.get("customer_po_details", []))		
+		# Project value has two modes, decided by the `manual_project_value` flag:
+		#   manual_project_value = 1 -> the values were entered by a human; leave them alone.
+		#   manual_project_value = 0 -> derive them from the Customer PO rows (default; unchanged
+		#                               from the historical behaviour, including zeroing on an empty list).
+		if not self.get("manual_project_value"):
+			self.project_value = sum(flt(d.customer_po_value_exctax) for d in self.get("customer_po_details", []))
+			self.project_value_gst = sum(flt(d.customer_po_value_inctax) for d in self.get("customer_po_details", []))
 		#self.project_duration = (datetime.strptime(self.project_end_date, '%Y-%m-%d %H:%M:%S') - datetime.strptime(self.project_start_date, '%Y-%m-%d %H:%M:%S')).days or 0
 		# self.project_city = self.get_project_address()["city"] or ""
 		# self.project_state = self.get_project_address()["state"] or ""


### PR DESCRIPTION
Project value was previously always calculated automatically from Customer PO totals. The requirement was to support two project-value modes:

PO-Driven Mode – Project value is automatically calculated from Customer POs.
Manual Mode – Project value can be entered and maintained manually.
The implementation also needed to preserve the existing PO-driven behavior by default and safely handle switching between the two modes.