### PR TITLE
BOQ & DPR – Parent DocType and DocName for Attachments

### DIFF
--- a/frontend/src/components/CameraCapture.tsx
+++ b/frontend/src/components/CameraCapture.tsx
@@ -286,10 +286,12 @@ const CameraCapture: React.FC<CameraCaptureProps> = ({
 
       console.log("CameraCapture: Uploading file:", file);
 
-      const fileResponse = await uploadFile(file, { // Use frappeFileUpload object
-        doctype: "Project Progress Report Attachment",
-        fieldname: "image_link", // Ensure this fieldname matches your DocType
-        isPrivate: true // Good practice for personal info
+      // Capture happens BEFORE the report exists, so we upload as a private temp
+      // file with no attach target. The backend `Project Progress Reports`
+      // on_update hook (relink_attachment_files) stamps ownership
+      // (attached_to_doctype/name) onto this File once the report is saved.
+      const fileResponse = await uploadFile(file, {
+        isPrivate: true // DPR photos may carry site / location detail
       });
       const frappeFileUrl = fileResponse.file_url;
 

--- a/nirmaan_stack/api/boq/wizard/upload_file.py
+++ b/nirmaan_stack/api/boq/wizard/upload_file.py
@@ -358,6 +358,20 @@ def _upload_file_worker(project_id, file_url, file_name, user, is_template_sourc
             "Nirmaan Attachments", att_doc.name, "associated_docname", boq_doc.name
         )
 
+        # Step 11b: Give the uploaded workbook File a real owner. save_file() at the
+        # endpoint stores it with an empty attached_to_* (an orphan in "tabFile");
+        # now that the BOQs doc exists, attach the File to it so it shows in the
+        # native attachment panel and is cleaned up when the BoQ is deleted. The
+        # Nirmaan Attachments row stays as the parallel index (unchanged).
+        source_file = frappe.db.get_value("File", {"file_url": file_url}, "name")
+        if source_file:
+            frappe.db.set_value(
+                "File",
+                source_file,
+                {"attached_to_doctype": "BOQs", "attached_to_name": boq_doc.name},
+                update_modified=False,
+            )
+
         frappe.db.commit()
 
         # Step 12: Notify client (realtime) + record outcome for the polling fallback.

--- a/nirmaan_stack/hooks.py
+++ b/nirmaan_stack/hooks.py
@@ -165,6 +165,12 @@ doc_events = {
         # don't list it as a separate doc_event here.
         "on_update": "nirmaan_stack.nirmaan_stack.doctype.projects.projects.on_update"
     },
+    "Project Progress Reports": {
+        # Adopt capture-time DPR photo Files (uploaded before the report existed,
+        # so orphaned) into this report — sets File.attached_to_doctype/name.
+        # on_update fires on both create and edit; the handler is idempotent.
+        "on_update": "nirmaan_stack.integrations.controllers.project_progress_reports.relink_attachment_files"
+    },
     "Vendors": {
         "after_insert": "nirmaan_stack.nirmaan_stack.doctype.vendor_category.vendor_category.generate_vendor_category",
         # IMPLEMENT ON_UPDATE

--- a/nirmaan_stack/integrations/controllers/project_progress_reports.py
+++ b/nirmaan_stack/integrations/controllers/project_progress_reports.py
@@ -1,0 +1,64 @@
+import frappe
+
+PARENT_DOCTYPE = "Project Progress Reports"
+
+
+def relink_attachment_files(doc, method=None):
+    """Adopt capture-time DPR photo Files into their parent report.
+
+    DPR photos are uploaded by the camera (`CameraCapture.tsx`) BEFORE the report
+    exists, so each `File` lands as an orphan — no `attached_to_doctype` /
+    `attached_to_name` — and only its `file_url` is copied into the report's
+    `attachments` child rows (`image_link`). Once the report is saved we finally
+    know the owner, so stamp ownership onto every still-unlinked File here.
+
+    Design notes:
+    - Only UNLINKED files are claimed, so a photo reused by another report via
+      the "Copy Report" feature stays attached to the report that first owned it
+      (a File can belong to exactly one document in Frappe's model).
+    - `frappe.db.set_value(..., update_modified=False)` writes the DB directly: it
+      does NOT re-run File validation or the GCS `after_insert` upload hook, and
+      leaves `file_url` / `content_hash` / the stored bytes untouched. It only
+      repairs the ownership link.
+    - No `frappe.db.commit()` here — this runs inside the report's save
+      transaction and is committed with it.
+    - Idempotent: files already linked to this report are skipped, so it is safe
+      to run on every `on_update` (create and edit).
+    """
+    # Collect this report's photo urls once (deduped) — the work is bounded by
+    # the number of photos on ONE report, and stays 2 queries no matter how many.
+    seen = set()
+    urls = []
+    for row in (getattr(doc, "attachments", None) or []):
+        url = (getattr(row, "image_link", None) or "").strip()
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    if not urls:
+        return
+
+    # One indexed lookup (file_url is indexed) for every photo at once.
+    files = frappe.get_all(
+        "File",
+        filters={"file_url": ["in", urls]},
+        fields=["name", "attached_to_doctype"],
+    )
+    # Only adopt still-unlinked Files, so a photo copied from an earlier report
+    # stays owned by that report.
+    orphan_names = [f.name for f in files if not (f.attached_to_doctype or "").strip()]
+    if not orphan_names:
+        return
+
+    # One UPDATE for all of them. Raw SQL leaves `modified` (audit trail) and the
+    # GCS fields untouched; the COALESCE guard keeps it a no-op for any File that
+    # got owned in the meantime (belt-and-suspenders for the "no steal" rule).
+    frappe.db.sql(
+        """
+        UPDATE "tabFile"
+        SET attached_to_doctype = %(dt)s,
+            attached_to_name    = %(dn)s
+        WHERE name IN %(names)s
+          AND COALESCE(attached_to_doctype, '') = ''
+        """,
+        {"dt": PARENT_DOCTYPE, "dn": doc.name, "names": tuple(orphan_names)},
+    )

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -143,3 +143,4 @@ nirmaan_stack.patches.v3_0.seed_ceo_hold_reasons
 nirmaan_stack.patches.v3_0.backfill_item_linked_tds_item
 nirmaan_stack.patches.v3_0.add_tds_membership_indexes
 nirmaan_stack.patches.v3_0.backfill_tds_member_mirror
+nirmaan_stack.patches.v3_0.backfill_boq_source_file_links

--- a/nirmaan_stack/patches.txt
+++ b/nirmaan_stack/patches.txt
@@ -144,3 +144,4 @@ nirmaan_stack.patches.v3_0.backfill_item_linked_tds_item
 nirmaan_stack.patches.v3_0.add_tds_membership_indexes
 nirmaan_stack.patches.v3_0.backfill_tds_member_mirror
 nirmaan_stack.patches.v3_0.backfill_boq_source_file_links
+nirmaan_stack.patches.v3_0.backfill_progress_report_attachment_links

--- a/nirmaan_stack/patches/v3_0/backfill_boq_source_file_links.py
+++ b/nirmaan_stack/patches/v3_0/backfill_boq_source_file_links.py
@@ -1,0 +1,64 @@
+import frappe
+
+
+def execute():
+    """
+    Backfill File ownership for BoQ source workbooks (.xlsx / .xlsm).
+
+    The BoQ upload endpoint saves the workbook via `save_file(dt=None, dn=None)`,
+    so the File row lands orphaned — empty `attached_to_doctype` / `attached_to_name`.
+    The file <-> BoQ relationship IS captured in `Nirmaan Attachments`
+    (`associated_doctype='BOQs'`, `associated_docname=<boq>`, `attachment=file_url`),
+    but the File itself has no owner, so it never appears in the BOQs attachment
+    panel and is not cleaned up when the BoQ is deleted.
+
+    This stamps `attached_to_doctype='BOQs'` / `attached_to_name=<boq>` onto each
+    orphan source File, resolved through its `Nirmaan Attachments` record. It matches
+    the app's house style (Vendor Invoices / POs / PRs all attach Files to their
+    business doc, with Nirmaan Attachments as a parallel index).
+
+    - Only UNLINKED files are claimed (`COALESCE(attached_to_doctype,'') = ''`); the
+      parallel Nirmaan Attachments index is left untouched.
+    - Attachment records with no `associated_docname` (the upload never produced a
+      BOQs doc — parse-failed / abandoned) cannot be mapped and stay orphaned.
+
+    Only the ownership columns are written; `file_url` / `content_hash` / the GCS
+    bytes are untouched (safe alongside the S3->GCS migration). `modified` is left
+    as-is (raw SQL) to preserve the audit trail. Idempotent — a re-run updates 0
+    rows. PostgreSQL-only (UPDATE ... FROM).
+    """
+    before = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile" WHERE attached_to_doctype = 'BOQs'"""
+    )[0][0]
+
+    frappe.db.sql(
+        """
+        UPDATE "tabFile" f
+        SET attached_to_doctype = 'BOQs',
+            attached_to_name    = na.associated_docname
+        FROM "tabNirmaan Attachments" na
+        WHERE na.attachment = f.file_url
+          AND na.associated_doctype = 'BOQs'
+          AND COALESCE(na.associated_docname, '') <> ''
+          AND COALESCE(f.attached_to_doctype, '') = ''
+        """
+    )
+
+    frappe.db.commit()
+
+    after = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile" WHERE attached_to_doctype = 'BOQs'"""
+    )[0][0]
+
+    remaining = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile"
+           WHERE (file_name ILIKE %s OR file_name ILIKE %s)
+             AND COALESCE(attached_to_doctype, '') = ''""",
+        ("%.xlsx", "%.xlsm"),
+    )[0][0]
+
+    print(
+        f"[backfill_boq_source_file_links] Files attached to 'BOQs': "
+        f"{before} -> {after} (+{after - before}); "
+        f"remaining orphan xlsx/xlsm (unmapped / no BOQs doc): {remaining}"
+    )

--- a/nirmaan_stack/patches/v3_0/backfill_progress_report_attachment_links.py
+++ b/nirmaan_stack/patches/v3_0/backfill_progress_report_attachment_links.py
@@ -1,0 +1,80 @@
+import frappe
+
+PARENT_DOCTYPE = "Project Progress Reports"
+
+
+def execute():
+    """
+    Backfill File ownership for DPR (Daily Progress Report) photos.
+
+    Photos captured for `Project Progress Reports` were uploaded at capture time
+    (before the report existed) targeting a non-existent child doctype with no
+    docname, so every File landed as an orphan — no `attached_to_doctype` /
+    `attached_to_name`. Only the `file_url` was copied into the report's
+    `attachments` child rows (`image_link`), a one-way string pointer.
+
+    This reconnects each orphan File to its parent report by matching
+    `File.file_url == child.image_link`, so the File table knows the owner again
+    (attachment panel, cascade-delete, and migration tooling all work once more).
+
+    Rules:
+    - Only UNLINKED files are claimed (`COALESCE(attached_to_doctype,'') = ''`),
+      so already-linked files and every non-DPR file are never touched.
+    - A photo reused across reports via "Copy Report" is attributed to the
+      EARLIEST report (`DISTINCT ON (image_link) ... ORDER BY creation`), which is
+      deterministic and stable across re-runs.
+    - Photos that were captured but never saved into a report have no child row,
+      so they stay orphaned — correct, they have no owner.
+
+    Only the ownership columns are written; `file_url` / `content_hash` / the
+    stored GCS bytes are untouched, so this is safe alongside the S3->GCS
+    migration. `modified` is intentionally left as-is (raw SQL) to preserve the
+    audit trail. Idempotent — a re-run updates 0 rows.
+
+    PostgreSQL-only (DISTINCT ON, UPDATE ... FROM) — matches the app's DB.
+    """
+    before = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile" WHERE attached_to_doctype = %s""",
+        (PARENT_DOCTYPE,),
+    )[0][0]
+
+    frappe.db.sql(
+        """
+        WITH mapping AS (
+            SELECT DISTINCT ON (c.image_link)
+                   c.image_link AS url,
+                   c.parent     AS report
+            FROM "tabProject Progress Report Attachments" c
+            WHERE c.parenttype = %(parent)s
+              AND c.image_link IS NOT NULL
+              AND c.image_link <> ''
+            ORDER BY c.image_link, c.creation ASC, c.parent ASC
+        )
+        UPDATE "tabFile" f
+        SET attached_to_doctype = %(parent)s,
+            attached_to_name    = m.report
+        FROM mapping m
+        WHERE f.file_url = m.url
+          AND COALESCE(f.attached_to_doctype, '') = ''
+        """,
+        {"parent": PARENT_DOCTYPE},
+    )
+
+    frappe.db.commit()
+
+    after = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile" WHERE attached_to_doctype = %s""",
+        (PARENT_DOCTYPE,),
+    )[0][0]
+
+    remaining_orphans = frappe.db.sql(
+        """SELECT COUNT(*) FROM "tabFile"
+           WHERE file_name LIKE %s AND COALESCE(attached_to_doctype, '') = ''""",
+        ("photo\\_%.jpeg",),
+    )[0][0]
+
+    print(
+        f"[backfill_progress_report_attachment_links] "
+        f"Files attached to '{PARENT_DOCTYPE}': {before} -> {after} (+{after - before}); "
+        f"remaining unlinked photo_*.jpeg files (abandoned captures): {remaining_orphans}"
+    )


### PR DESCRIPTION
# BOQ & DPR – Parent DocType and DocName for Attachments

## Request

We need to ensure that **BOQ and DPR files/attachments** store the correct parent record information.

### Required Information

For every BOQ and DPR attachment/file, we should have:

* **Parent DocType**
* **Parent DocName**

For example:

* `parent_doctype = BOQ`
* `parent_docname = <actual BOQ document name>`

And similarly for DPR:

* `parent_doctype = DPR`
* `parent_docname = <actual DPR document name>`

## Expected Outcome

Once the Parent DocType and Parent DocName are available, we can reliably identify which actual Frappe document each attachment belongs to.

This makes it easy to:

* Find the exact BOQ record associated with a file.
* Find the exact DPR record associated with a file.
* Trace attachments back to their source document.
* Avoid relying only on filenames or other indirect references.
* Build reliable attachment/document lookup and validation workflows.

### Key Requirement

The attachment relationship should always point back to the **actual DocType + DocName combination** that owns the file.

This should be consistent for both **BOQ and DPR** records.
