### PR TITLE
fix(reports): DN/DC pending counts share one definition across every …

### DIFF
--- a/.claude/plans/monthly-wip-plan.md
+++ b/.claude/plans/monthly-wip-plan.md
@@ -291,3 +291,150 @@ Gurugram: 249 DN, 1 DC, Missing 184 — the 64 Non-Billable DNs are invisible). 
 - `Missing DC` subtracts Non-Billable DNs; the subtrahend stays **implicit** (no new column).
 - ITM-parented DNs stay in the `Missing DC` gap.
 - Project facet filter: client-side over the fetched rows, keyed on docname, cleared on month switch.
+
+---
+
+## 9 — `Missing DN` / `Missing DC` become PO counts; DN > DC gains a real DN verdict (2026-08-12)
+
+> **⚠️ SUPERSEDES §8.2 entirely.** The Non-Billable-DN subtrahend it documents is GONE, along
+> with the whole document-subtraction model both `missing_*` columns rested on. §7's G4/G5
+> semantics are superseded for those two columns only; every other column is untouched.
+
+### 9.1 Why the old arithmetic was unsound
+
+Both figures subtracted DOCUMENT counts to answer a per-PO question:
+
+```
+missing_dn = max(0, dispatched_po_count − delivery_note_count)
+missing_dc = max(0, delivery_note_count − non_billable_dn_count − dc_count)
+```
+
+A PO carries an unbounded number of DNs — **431 POs on live data carry more than one, contributing
+571 surplus documents** — so a PO with 3 DNs silently cancels two others that have none. Measured
+before the change:
+
+| | |
+|---|---|
+| `missing_dn` raw value NEGATIVE (clamped to 0) | **56 of 93 projects** |
+| `missing_dc` raw value NEGATIVE | 12 of 93 |
+| `missing_dn` non-zero anywhere | 2 projects — against 6 POs genuinely owing a note |
+| `missing_dc` EXACT vs the predicate | **34 of 85 projects (40%)**; worst +33 / −35 |
+
+The `max(0, …)` clamp rendered that incoherence as a clean, trustworthy zero. `missing_dc`
+additionally counted **322 stub Delivery-Challan rows** as filed challans (the Action-Item
+reconciler has always excluded them), which pushed several projects to 0 while they owed dozens:
+Air India Training Centre read **0 missing** against **35** real; Clutterbot's 38 challans were
+**all stubs**.
+
+### 9.2 The replacement — `api/reports/metrics.py` (NEW)
+
+`pending_counts_by_project()` returns `{project: {dc_pending, dn_pending}}`, computed by calling
+`services/action_items/predicates.py` — **the same predicates the Project Action Item reconciler
+uses**, so the WIP column and the project Overview tile agree BY CONSTRUCTION rather than by
+coincidence. Three bulk queries + a pure-Python pass; ~80–160 ms over 5047 POs / 19,848 items /
+93 projects.
+
+**Load-bearing SQL shape:** every query is raw SQL joining on the PO's status. It must NEVER become
+`frappe.get_all(..., filters={"parent": ["in", po_names]})` — Frappe runs `validate_generated_query`
+→ `sqlparse.parse()`, which raises `Maximum number of tokens exceeded (10000)` past a few thousand
+names. 5047 live POs today, so that form throws in prod and passes on any small dataset.
+
+**DN uses `is_dn_pending`, not a document-existence test (owner ruling).** An earlier revision
+carried a local `_is_dn_missing` ("dispatched, no DN document at all") because `is_dn_pending`
+early-returns on `status == "Delivered"` and 5037 of 5047 live POs are Delivered — pinning it near
+zero. The owner ruled the column must show the SAME NUMBER as the Overview tile, so the shared
+predicate won. **What that trades away, recorded so it is not rediscovered as a bug:** four POs
+(Cinepolis, KVN Prestige Trade Tower, Richa & Mekin Residency, STS Bangalore) carry a recorded
+`received_quantity` with NO delivery-note document. Their status is `Delivered`, so the predicate
+cannot see them. They are a data-integrity signal, not pending work — nobody can file the missing
+note, the delivery already happened.
+
+### 9.3 Billable scoping, then the owner's partial reversal
+
+The whole lifetime block was first scoped to Billable POs (owner: *"don't need non-billable po here
+for DC"*) — 1107 of 5047 POs and 261 of 1631 challans dropped out. **Then reversed for two columns
+only (2026-08-12):** `Disp PO` and `Total DN` count **Billable AND Non-Billable**, each surfacing
+its Billable slice (`dispatched_po_billable` / `total_dn_billable`) purely so the cell can show
+`N Billable · M Non-Billable` on hover. Nothing derives from those two fields.
+
+`Total DC` stays Billable-only, and **`Missing DN` / `Missing DC` MUST stay Billable-only** — a
+Non-Billable PO can never acquire a challan (the upload path rejects it), so counting one as
+non-compliant parks a row that can never clear and breaks agreement with the Overview tiles.
+
+⚠️ **Consequence, and it is the readability gap the Billable scoping was meant to close:** `Disp PO`
+is now a LARGER denominator than the two `missing_*` columns are measured against. The hover and the
+info dialog carry the explanation; the group header dropped its `(Billable)` suffix because it would
+be false for one of its three columns.
+
+### 9.4 New UI
+
+- **`WipFormulaDialog.tsx`** — an ⓘ button after Export opens a per-column reference: unit chip
+  (`days` / `reports` / `documents` / `POs`), source doctype, every filter, and the rule. It renders
+  ENTIRELY from `NUMERIC_COLUMNS` + `COLUMN_GROUPS`, so a rule change updates the table and the help
+  in one edit.
+- **`wipColumns.ts` (NEW)** — the column model moved out of the page. Extracted because the dialog
+  needs it and importing it back from `MonthlyWIPPage` created a cycle.
+- **`Missing DN` / `Missing DC` are deep links** — blue, external-link icon, underline on hover —
+  to `?page=projectdcmir&dcmir_tab=DN_DC&dcmir_parent=PO&dndc_status=<status>`. Only when the value
+  is non-zero. `DNDCQuantityReport` reads `dndc_status` ONCE to seed its Status filter.
+- **Header line** — title + count pill + right-aligned controls on one row, paragraph moved below.
+- **Tablet/mobile** — `min-w-[1100px]` on the table. The colgroup is PERCENTAGES under
+  `table-fixed`, so the table could never exceed its container and the wrapper's `overflow-x-auto`
+  never engaged; it just squeezed every column. The wrapper also became a bounded scroller
+  (`max-h-[70vh] overflow-auto`) so the sticky header has something to stick to.
+
+### 9.5 DN > DC report — `pending_dn` re-defined (`useDNDCQuantityData.ts`)
+
+The card's condition was `dnQty === 0 && dcQty > 0` — a challan recording quantity for an item with
+no delivery behind it. **System-wide exactly ONE item met it** (Test Project). It was not measuring
+a missing delivery note at all, while its name collided with the tile's "DN Pending" and WIP's
+"Missing DN" — three near-identical labels on three different measurements.
+
+It now means **ordered quantity not yet received**, matching the tile. Three parts, all needed:
+
+1. **`deliveryPending` is a FLAG on the item, not a status.** A PO can owe a delivery AND a challan
+   (`PO/218`), and as a status it STOLE the item from `no_dc_update`, dropping that PO off the red
+   card — No DC Update went 77 → 76 and stopped agreeing with the DC Pending tile.
+2. **`status !== "Delivered"` exclusion**, mirroring the predicate. Without it Nagarjuna Olive read
+   **4** against the tile's 2, and **28 vs 5** system-wide.
+3. **Zero-activity filter exempts flagged items.** A dispatched-but-undelivered line has BOTH
+   quantities at 0 — exactly the shape step 7 discards — so `PO/223` (338 dispatched units, nothing
+   received) appeared on no card and no row. The condition change ALONE would still have shown 0.
+
+The **rollup falls back on the FLAG**, ranked below `mismatch` and `no_dc_update` so it can only
+override `matched` — which is where a PO whose delivery gap sits on an already-challaned item was
+hiding (badged green with 24 units outstanding).
+
+⚠️ **Deliberately SIMPLER than `is_dn_pending`:** no `is_dispatched` gate, no 2.5% fractional
+tolerance. Measured — no difference on any project today. If this card ever disagrees with the tile,
+those two are the first place to look.
+
+### 9.6 Verification (2026-08-12)
+
+- **Backend 17/17** (`test_wip_monthly_report`); frontend `tsc` clean on every changed file.
+- **`missing_*` vs an INDEPENDENT recomputation from `predicates.py`: 0 rows differ.** 0 negative
+  values. `dispatched_po` / `total_dn` / `total_dc` verified identical to their raw `COUNT(*)`.
+- **WIP vs the project Overview tiles: 0 mismatches** on every non-suppressed project, both columns.
+- **DN > DC card vs the tile: same PO SET, not merely the same count**, on all 3 projects with a
+  non-zero value.
+- ⚠️ **The projection can be STALE.** Mid-session the tile read 1 where the predicate said 2 —
+  `is_dn_pending` returned True but the stored row was **nine days old**. The doc hook enqueues to
+  the `short` queue with `enqueue_after_commit=True`; with no worker processing it the job never
+  runs and the nightly sweep is the only backstop. **Verify against `_compute_desired`, never
+  against the stored table.**
+- ⚠️ **No browser verification.** No DOM environment in this repo — responsive and hover behaviour
+  are unverified by any test.
+
+### Decision log (2026-08-12)
+
+- `missing_dn` / `missing_dc` are PO counts from the shared predicates; the clamps are gone (a count
+  cannot be negative).
+- `missing_dn` uses `is_dn_pending` — same number as the Overview tile — accepting the loss of the
+  4 Delivered-with-no-DN-document POs.
+- `Disp PO` and `Total DN` count Billable + Non-Billable with a hover split; `Total DC` and both
+  `missing_*` stay Billable-only.
+- DN > DC `pending_dn` re-defined to ordered-vs-received; the old challan-ahead-of-delivery check is
+  retired (1 item system-wide, on a test project).
+- The DN > DC cards now OVERLAP rather than partition — a PO can be counted under both Pending DN
+  and No DC Update, so they do not sum to the PO total. Stated in the report's info banner.
+- ITM DN > DC report is UNCHANGED and still carries the old `pending_dn` rule.

--- a/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
+++ b/frontend/src/pages/monthly-wip/MonthlyWIPPage.tsx
@@ -1,4 +1,10 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -27,6 +33,7 @@ import {
   ChevronRight,
   ChevronUp,
   Download,
+  ExternalLink,
   Search,
 } from "lucide-react";
 import { Fragment, useEffect, useMemo, useState } from "react";
@@ -38,59 +45,18 @@ import {
   WipMonthlyRow,
   WipPeriod,
 } from "./useMonthlyWIPData";
+import { WipFormulaDialog } from "./WipFormulaDialog";
 
-// --------------------------------------------------------------------------- //
-// Column model — the single source of truth for the numeric columns. The header
-// (two-tier), the body cells, sorting and the group dividers all derive from it,
-// so a column is added/renamed/reordered in ONE place.
-// --------------------------------------------------------------------------- //
-
-/** Month-scoped, day-based fields (present on both a project row AND its stints). */
-type ComplianceField = keyof WipCompliance;
-/** Lifetime, project-level fields (present only on the project row). */
-type LifetimeField = "dispatched_po" | "total_dn" | "missing_dn" | "total_dc" | "missing_dc";
-type NumericField = ComplianceField | LifetimeField;
-
-type SortKey = "project_name" | NumericField;
-
-interface NumericColumn {
-  key: NumericField;
-  label: string;
-  /** First column of a group — draws the left divider. */
-  groupStart?: boolean;
-  /** Bold — the "base" figure of its group (Active Days, Dispatched POs). */
-  emphasize?: boolean;
-  /** Lifetime & project-level — stint sub-rows render "—" instead of a value. */
-  lifetime?: boolean;
-  /** A "missing" gap column — a non-zero value is shown red (0 stays muted). */
-  danger?: boolean;
-}
-
-const NUMERIC_COLUMNS: NumericColumn[] = [
-  { key: "active_working_days", label: "Active Days", groupStart: true, emphasize: true },
-  { key: "total_dpr_days", label: "Total DPR" },
-  { key: "missing_dpr_days", label: "Missing DPR", danger: true },
-  { key: "expected_inventory", label: "Expected", groupStart: true },
-  { key: "actual_inventory", label: "Actual" },
-  { key: "missing_inventory", label: "Missing", danger: true },
-  { key: "dispatched_po", label: "Disp.", groupStart: true, emphasize: true, lifetime: true },
-  { key: "total_dn", label: "Total DN", lifetime: true },
-  { key: "missing_dn", label: "Missing DN", lifetime: true, danger: true },
-  { key: "total_dc", label: "Total DC", groupStart: true, lifetime: true },
-  { key: "missing_dc", label: "Missing DC", lifetime: true, danger: true },
-];
-
-interface ColumnGroup {
-  label: string;
-  span: number;
-}
-const COLUMN_GROUPS: ColumnGroup[] = [
-  { label: "Project", span: 3 },
-  { label: "DPR · Daily (excl. Sun)", span: 3 },
-  { label: "Inventory · Weekly (Mon)", span: 3 },
-  { label: "Delivery Notes (ALL)", span: 3 },
-  { label: "Delivery Chellans (All)", span: 2 },
-];
+// Column model lives in wipColumns.ts — shared with WipFormulaDialog, which renders
+// its help text from the SAME arrays that drive this table, so a rule change updates
+// both in one edit. It sits in its own module so the page and the dialog never import
+// each other in a cycle.
+import {
+  COLUMN_GROUPS,
+  NUMERIC_COLUMNS,
+  type NumericColumn,
+  type SortKey,
+} from "./wipColumns";
 
 /** A visible vertical divider between column groups — runs continuously through
  *  the header band and every body row (applied to each group's first column). */
@@ -237,19 +203,92 @@ const EndCell = ({ c, small }: { c: ClampedWip; small?: boolean }) => (
 // Numeric columns are tight (see COL_W.num) — trim shadcn's default p-4 side padding.
 const NUM_CELL = "text-center tabular-nums !px-2";
 
-const NumberCell = ({ value, col, small }: { value: number; col: NumericColumn; small?: boolean }) => (
-  <TableCell
-    className={cn(
-      NUM_CELL,
-      small && "text-sm",
-      col.emphasize && "font-medium",
-      col.danger && value > 0 && "font-semibold text-red-600 dark:text-red-500",
-      col.groupStart ? GROUP_EDGE : LEAN_EDGE,
-    )}
-  >
-    {numFmt(value)}
-  </TableCell>
-);
+/** Deep link into a project's DN > DC report with one status pre-selected.
+ *  `dcmir_tab` / `dcmir_parent` are the params ProjectDCMIRTab already reads on mount;
+ *  `dndc_status` is read by DNDCQuantityReport to seed its Status filter. */
+const dndcReportHref = (project: string, status: string) =>
+  `/projects/${project}?page=projectdcmir&dcmir_tab=DN_DC&dcmir_parent=PO&dndc_status=${status}`;
+
+/** "N Billable · M Non-Billable" for the two columns that count both, else undefined.
+ *  Guarded on the field being a number: an older payload carries neither, and
+ *  "undefined Billable · NaN Non-Billable" is worse than no tooltip at all. */
+const billableSplitHint = (row: WipMonthlyRow, key: NumericColumn["key"]) => {
+  const billable =
+    key === "total_dn"
+      ? row.total_dn_billable
+      : key === "dispatched_po"
+        ? row.dispatched_po_billable
+        : undefined;
+  if (typeof billable !== "number") return undefined;
+  return `${billable} Billable · ${row[key] - billable} Non-Billable`;
+};
+
+const NumberCell = ({
+  value,
+  col,
+  small,
+  project,
+  hint,
+}: {
+  value: number;
+  col: NumericColumn;
+  small?: boolean;
+  /** Hover text for the cell. Used by Total DN to show its Billable split. */
+  hint?: string;
+  /** Present on a project row, absent on a stint sub-row. A cell only links when the
+   *  column declares a `linkStatus` AND the value is non-zero — linking a 0 would land
+   *  the reader on an empty report. */
+  project?: string;
+}) => {
+  const linkable = project && col.linkStatus && value > 0;
+
+  // `inline`, not `inline-flex`: text-decoration does not run across a flex container's
+  // items, so the icon would sit outside the underline. Inline layout puts the number and
+  // the SVG in the same line box, and the hover underline spans both.
+  const body = linkable ? (
+    <Link
+      to={dndcReportHref(project!, col.linkStatus!)}
+      className="inline text-red-600 underline-offset-2 hover:underline dark:text-blue-400"
+    >
+      {numFmt(value)}
+      <ExternalLink className="ml-1 text-blue-600 inline h-3 w-3 align-text-top" aria-hidden="true" />
+    </Link>
+  ) : (
+    numFmt(value)
+  );
+
+  const cell = (
+    <TableCell
+      className={cn(
+        NUM_CELL,
+        // A hover with no visual cue is a feature nobody finds. The dotted underline is
+        // the conventional "there is more here" affordance and costs no row height.
+        hint && "decoration-dotted underline underline-offset-4 decoration-muted-foreground/50",
+        small && "text-sm",
+        col.emphasize && "font-medium",
+        // A linked cell owns its own colour (blue); the danger red would fight it.
+        col.danger && value > 0 && !linkable && "font-semibold text-red-600 dark:text-red-500",
+        col.groupStart ? GROUP_EDGE : LEAN_EDGE,
+      )}
+    >
+      {body}
+    </TableCell>
+  );
+
+  // A real Tooltip rather than a native `title`: the native one waits ~1s, is unstyled and
+  // is easy to miss entirely — which is exactly what happened with the Total DN split.
+  if (!hint) return cell;
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>{cell}</TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {hint}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
 
 /** Lifetime column on a stint row — a muted em-dash (G4/G5 are project-level). */
 const DashCell = ({ col }: { col: NumericColumn }) => (
@@ -303,9 +342,9 @@ const EXPORT_COLUMNS: ColumnDef<ExportRow, any>[] = [
   { accessorKey: "missing_inventory", header: "Missing Inventory", meta: { exportHeaderName: "Missing Inventory" } },
   { accessorKey: "dispatched_po", header: "Dispatched POs", meta: { exportHeaderName: "Dispatched POs (lifetime)" } },
   { accessorKey: "total_dn", header: "Total DN", meta: { exportHeaderName: "Total DN (lifetime)" } },
-  { accessorKey: "missing_dn", header: "Missing DN", meta: { exportHeaderName: "Missing DN (lifetime)" } },
+  { accessorKey: "missing_dn", header: "Missing DN", meta: { exportHeaderName: "Missing DN (POs, lifetime)" } },
   { accessorKey: "total_dc", header: "Total DC", meta: { exportHeaderName: "Total DC (lifetime)" } },
-  { accessorKey: "missing_dc", header: "Missing DC", meta: { exportHeaderName: "Missing DC (lifetime)" } },
+  { accessorKey: "missing_dc", header: "Missing DC", meta: { exportHeaderName: "Missing DC (POs, lifetime)" } },
 ];
 
 /** Group-header row for the CSV (merged-cell style — label at each group's first
@@ -479,15 +518,21 @@ export default function MonthlyWIPPage() {
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      {/* Header + controls */}
+      {/* Header line — title + count pill on the left, controls right-aligned. The
+          explanatory paragraph sits BELOW this row (see next block) so the title and the
+          month picker land on the same line and the eye reaches the controls first. */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
+        <div className="flex flex-wrap items-center gap-2">
           <h1 className="text-xl font-semibold tracking-tight">Monthly WIP &amp; Handover</h1>
-          <p className="text-sm text-muted-foreground">
-            DPR (daily, Sundays excluded) and Inventory (weekly, each active Monday) are scoped to the
-            selected month. PO Dispatch and DC are <span className="font-medium">lifetime</span> totals —
-            unaffected by the month picker. Hover dates for the actuals.
-          </p>
+          {/* Absorbs the old "N projects active during <month>" line. Shows the VISIBLE
+              count when the list is narrowed, so the pill can never contradict the table. */}
+          {!isLoading && !error && (
+            <Badge variant="outline" className="font-normal text-muted-foreground">
+              {displayRows.length === rows.length
+                ? `${rows.length} project${rows.length === 1 ? "" : "s"}`
+                : `${displayRows.length} of ${rows.length} projects`}
+            </Badge>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Select value={month} onValueChange={handleMonthChange} disabled={optionsLoading}>
@@ -506,26 +551,19 @@ export default function MonthlyWIPPage() {
             <Download className="mr-2 h-4 w-4" />
             Export
           </Button>
+          <WipFormulaDialog />
         </div>
       </div>
 
-      {/* Summary line — reports the VISIBLE count when narrowed, so the number never
-          contradicts the table. */}
-      {!isLoading && !error && (
-        <p className="text-sm text-muted-foreground">
-          {displayRows.length === rows.length ? (
-            <>
-              {rows.length} project{rows.length === 1 ? "" : "s"} active during{" "}
-            </>
-          ) : (
-            <>
-              Showing {displayRows.length} of {rows.length} project
-              {rows.length === 1 ? "" : "s"} active during{" "}
-            </>
-          )}
-          <span className="font-medium text-foreground">{monthLabel(options, month)}</span>
-        </p>
-      )}
+      {/* Moved down from beside the title. Carries the active month, which the count
+          pill above deliberately does not repeat. */}
+      <p className="text-sm text-muted-foreground">
+        Active during{" "}
+        <span className="font-medium text-foreground">{monthLabel(options, month)}</span>. DPR
+        (daily, Sundays excluded) and Inventory (weekly, each active Monday) are scoped to the
+        selected month. PO Dispatch and DC are <span className="font-medium">lifetime</span>{" "}
+        totals — unaffected by the month picker. Hover dates for the actuals.
+      </p>
 
       {/* Search + project facet */}
       <div className="flex flex-wrap items-center gap-2">
@@ -548,9 +586,21 @@ export default function MonthlyWIPPage() {
         />
       </div>
 
-      {/* Table */}
-      <div className="rounded-md border overflow-x-auto">
-        <Table className="table-fixed">
+      {/* Table.
+          `max-h` + `overflow-auto` make this a BOUNDED scroll container, which is what
+          lets the header stick (a sticky <thead> has nothing to stick to while the page
+          itself is the scroller — and `overflow-x: auto` alone already computes
+          `overflow-y` to auto, so the sticky was inert either way).
+          Mirrors the DN > DC report's table, which is the established pattern here. */}
+      <div className="rounded-md border overflow-auto max-h-[70vh]">
+        {/* min-w is what fixes tablet/mobile. The colgroup below is PERCENTAGES, so a
+            table-fixed layout can never exceed its container — it just squeezes every
+            column until the whole grid is unreadable, and the wrapper's overflow-x never
+            engages. The floor is those same percentages at their smallest readable size:
+            chevron 22 + project 154 + dates 99x2 + numeric 66x11 = 1100. At any content
+            width at or above that the percentages fill exactly as before, so desktop is
+            unchanged; below it the table holds its width and scrolls sideways instead. */}
+        <Table className="table-fixed min-w-[1100px]">
           <colgroup>
             <col style={{ width: COL_W.chevron }} />
             <col style={{ width: COL_W.project }} />
@@ -560,7 +610,9 @@ export default function MonthlyWIPPage() {
               <col key={col.key} style={{ width: COL_W.num }} />
             ))}
           </colgroup>
-          <TableHeader>
+          {/* Opaque background is load-bearing: the group row's bg-muted/60 is
+              semi-transparent, so rows would scroll through it without this. */}
+          <TableHeader className="sticky top-0 z-20 bg-background">
             {/* Group row — a distinct banded header so each group reads as a block */}
             <TableRow className="border-b-0 bg-muted/60 hover:bg-muted/60">
               <TableHead rowSpan={2} />
@@ -653,7 +705,13 @@ export default function MonthlyWIPPage() {
                       <StartCell c={c} />
                       <EndCell c={c} />
                       {NUMERIC_COLUMNS.map((col) => (
-                        <NumberCell key={col.key} value={row[col.key]} col={col} />
+                        <NumberCell
+                          key={col.key}
+                          value={row[col.key]}
+                          col={col}
+                          project={row.project}
+                          hint={billableSplitHint(row, col.key)}
+                        />
                       ))}
                     </TableRow>
 

--- a/frontend/src/pages/monthly-wip/WipFormulaDialog.tsx
+++ b/frontend/src/pages/monthly-wip/WipFormulaDialog.tsx
@@ -1,0 +1,199 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Info } from "lucide-react";
+import { ColumnUnit, COLUMN_GROUPS, NUMERIC_COLUMNS } from "./wipColumns";
+
+/**
+ * "How these columns are calculated" — the help dialog behind the ⓘ in the toolbar.
+ *
+ * It renders ENTIRELY from `NUMERIC_COLUMNS` + `COLUMN_GROUPS`, the same two arrays
+ * that drive the table header, the body cells and the sorting. That is deliberate:
+ * a help text maintained separately from the column it describes goes stale the first
+ * time a rule changes and nothing fails. Adding or re-scoping a column updates the
+ * table and this dialog in one edit.
+ *
+ * The unit chip is the load-bearing element. A `documents` column sitting beside a
+ * `POs` column is exactly what reads as a subtraction and is not one — every question
+ * this dialog exists to answer traces back to that.
+ */
+
+/** Chip colours per unit. Semantic, and deliberately NOT the page's red/sky accents —
+ *  these classify a column, they do not flag a state. */
+const UNIT_CLASS: Record<ColumnUnit, string> = {
+  days: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  reports: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
+  documents: "bg-violet-50 text-violet-700 dark:bg-violet-950 dark:text-violet-300",
+  POs: "bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300",
+};
+
+/** The first COLUMN_GROUPS entry is "Project" (3 non-numeric columns), so the numeric
+ *  groups start at index 1. Walking the spans keeps the dialog's grouping identical to
+ *  the table header's without a second hand-maintained list. */
+function groupedColumns() {
+  const out: { label: string; lifetime: boolean; columns: typeof NUMERIC_COLUMNS }[] = [];
+  let cursor = 0;
+  COLUMN_GROUPS.slice(1).forEach((g) => {
+    const columns = NUMERIC_COLUMNS.slice(cursor, cursor + g.span);
+    cursor += g.span;
+    out.push({ label: g.label, lifetime: columns.every((c) => c.lifetime), columns });
+  });
+  return out;
+}
+
+export function WipFormulaDialog() {
+  const groups = groupedColumns();
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="px-2.5"
+          aria-label="How these columns are calculated"
+          title="How these columns are calculated"
+        >
+          <Info className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>How these columns are calculated</DialogTitle>
+          <DialogDescription>
+            Every figure in the table, with its source, its filters and the rule behind it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* The two things people get wrong, stated before any column detail. */}
+        <div className="rounded-md border border-l-[3px] border-l-blue-600 bg-muted/50 p-3 text-sm space-y-1.5">
+          <p>
+            <span className="font-semibold">Mind the units.</span>{" "}
+            <span className="italic">Total</span> columns count <span className="font-semibold">documents</span>.{" "}
+            <span className="italic">Missing</span> columns count{" "}
+            <span className="font-semibold">purchase orders</span>. A row is not meant to add up across.
+          </p>
+          <p>
+            <span className="font-semibold">Scope.</span> DPR and Inventory follow the selected month.
+            Delivery Notes and Delivery Challans are <span className="font-semibold">lifetime</span> —
+            unaffected by the month picker.
+          </p>
+          <p>
+            <span className="font-semibold">Billable.</span> A Non-Billable PO can never receive a challan,
+            so it can never be compliant — <span className="font-semibold">Missing DN</span>,{" "}
+            <span className="font-semibold">Missing DC</span> and <span className="font-semibold">Total DC</span>{" "}
+            therefore count Billable POs only. <span className="font-semibold">Disp PO</span> and{" "}
+            <span className="font-semibold">Total DN</span> count both; hover either cell for its split. That
+            makes Disp PO a larger denominator than the two Missing columns are measured against.
+          </p>
+        </div>
+
+        <div className="space-y-6 pt-1">
+          {groups.map((group) => (
+            <section key={group.label}>
+              <h3 className="flex items-center gap-2 border-b pb-1.5 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                {group.label}
+                {group.lifetime && (
+                  <span className="rounded border px-1 py-0 text-[10px] font-normal normal-case tracking-normal">
+                    lifetime
+                  </span>
+                )}
+              </h3>
+
+              <dl className="divide-y">
+                {group.columns.map((col) => (
+                  <div key={col.key} className="grid grid-cols-1 gap-1 py-2.5 sm:grid-cols-[10rem_1fr] sm:gap-4">
+                    <dt>
+                      <div className={cn("text-sm font-semibold", col.danger && "text-destructive")}>
+                        {col.label}
+                      </div>
+                      <span
+                        className={cn(
+                          "mt-1 inline-block rounded px-1.5 py-0 font-mono text-[10px] uppercase tracking-wide",
+                          UNIT_CLASS[col.unit]
+                        )}
+                      >
+                        {col.unit}
+                      </span>
+                    </dt>
+
+                    <dd className="space-y-1.5 text-sm text-muted-foreground">
+                      <p>
+                        <span className="font-medium text-foreground">{col.formula}</span>
+                      </p>
+
+                      <p className="text-xs">
+                        <span className="uppercase tracking-wide text-muted-foreground/70">Source</span>{" "}
+                        <span className="font-mono">{col.source}</span>
+                      </p>
+
+                      {col.conditions.length > 0 && (
+                        <div className="text-xs">
+                          <span className="uppercase tracking-wide text-muted-foreground/70">Conditions</span>
+                          <ul className="mt-0.5 list-disc space-y-0.5 pl-4">
+                            {col.conditions.map((c) => (
+                              <li key={c}>{c}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      {col.note && <p className="text-xs italic">{col.note}</p>}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          ))}
+        </div>
+
+        {/* The question this dialog is most often opened to answer: why one column counts
+            Non-Billable POs and the next one does not. */}
+        <div className="rounded-md border bg-muted/50 p-3">
+          <h4 className="mb-1.5 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+            Which columns include Non-Billable POs
+          </h4>
+          <table className="w-full text-xs">
+            <tbody>
+              <tr className="border-b">
+                <td className="py-1 font-medium">Disp PO</td>
+                <td className="py-1">both — hover for the split</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1 font-medium">Total DN</td>
+                <td className="py-1">both — hover for the split (returns still excluded)</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1 font-medium">Total DC</td>
+                <td className="py-1">Billable only</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-1 font-medium">Missing DN</td>
+                <td className="py-1">Billable only</td>
+              </tr>
+              <tr>
+                <td className="py-1 font-medium">Missing DC</td>
+                <td className="py-1">Billable only</td>
+              </tr>
+            </tbody>
+          </table>
+          <p className="mt-2 text-xs text-muted-foreground">
+            So Total DN can exceed Disp PO (one PO carries several notes), and Total DC can read lower
+            than the DC count on the project&rsquo;s DC &amp; MIR tab, which is not Billable-filtered.
+          </p>
+        </div>
+
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default WipFormulaDialog;

--- a/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
+++ b/frontend/src/pages/monthly-wip/useMonthlyWIPData.ts
@@ -33,17 +33,34 @@ export interface WipMonthlyRow extends WipCompliance {
   active_start: string;   // earliest active entry (ISO)
   active_end: string;     // latest active exit (ISO) or "ongoing"
   stints: number;         // number of real active periods (expander shown when > 1)
-  // G4 — PO dispatch vs delivery (LIFETIME, month-independent):
-  dispatched_po: number;  // POs in Partially Dispatched / Dispatched / Partially Delivered / Delivered
-  total_dn: number;       // Delivery Note docs (returns excluded)
-  missing_dn: number;     // max(0, dispatched_po − total_dn)
-  // G5 — DC compliance (LIFETIME, month-independent):
-  total_dc: number;       // Delivery Challan docs (PO-parented)
-  // max(0, total_dn − DNs whose PO is Non-Billable − total_dc). A Non-Billable PO can
-  // never acquire a DC (the upload path rejects it), so those DNs are subtracted out.
-  // That subtrahend is deliberately NOT surfaced (owner: keep it implicit), so
-  // total_dn − total_dc will NOT equal missing_dc on screen.
-  missing_dc: number;
+  // G4 / G5 (LIFETIME, month-independent).
+  //
+  // MIND THE UNITS: `dispatched_po` / `total_dn` / `total_dc` count DOCUMENTS, while
+  // `missing_dn` / `missing_dc` count PURCHASE ORDERS. The columns therefore do NOT
+  // subtract into one another on screen, by design — that is the whole point of the
+  // change. They previously WERE subtractions (max(0, dispatched_po − total_dn) and
+  // max(0, total_dn − nonBillableDN − total_dc)), which is unsound because one PO
+  // carries any number of DNs: the raw value went negative on 56 (DN) and 12 (DC) of
+  // 93 live projects, and the clamp rendered that incoherence as a trustworthy zero.
+  // Both are now PO counts from api/reports/metrics.py, using the same predicates as
+  // the Action Centre — so a project's "Missing DC" here equals its "DC Pending" tile.
+  // ALL FIVE are restricted to BILLABLE POs. A Non-Billable PO can never acquire a
+  // Delivery Challan (the upload path rejects it), so it can never be compliant and
+  // never enters the missing_* figures — including it in the totals beside them made
+  // the two halves of a row describe different universes.
+  dispatched_po: number;  // POs in Partially Dispatched / Dispatched / Partially Delivered /
+                          // Delivered — ALL POs, Billable or not
+  dispatched_po_billable: number; // the Billable slice, shown only as a hover split
+  total_dn: number;       // Delivery Note DOCUMENTS, returns excluded — ALL POs, Billable
+                          // or not (owner ruling; deliberately unlike the rest of the block)
+  total_dn_billable: number; // the Billable slice, shown only as a hover split
+  // Billable POs with a dispatched item not yet fully received — the SAME rule as the
+  // project Overview tile's "DN Pending" tile, so the two surfaces always agree. NB it
+  // reads ORDERED vs RECEIVED on the PO items and never looks at Delivery Note
+  // documents; a PO whose status is already "Delivered" is excluded by the predicate.
+  missing_dn: number;
+  total_dc: number;       // Delivery Challan DOCUMENTS on a Billable PO (stubs included)
+  missing_dc: number;     // POs: Billable, delivered, with no non-stub Delivery Challan
   periods: WipPeriod[];
 }
 

--- a/frontend/src/pages/monthly-wip/wipColumns.ts
+++ b/frontend/src/pages/monthly-wip/wipColumns.ts
@@ -1,0 +1,194 @@
+import { WipCompliance } from "./useMonthlyWIPData";
+
+
+// --------------------------------------------------------------------------- //
+// Column model — the single source of truth for the numeric columns. The header
+// (two-tier), the body cells, sorting and the group dividers all derive from it,
+// so a column is added/renamed/reordered in ONE place.
+// --------------------------------------------------------------------------- //
+
+/** Month-scoped, day-based fields (present on both a project row AND its stints). */
+export type ComplianceField = keyof WipCompliance;
+/** Lifetime, project-level fields (present only on the project row). */
+export type LifetimeField = "dispatched_po" | "total_dn" | "missing_dn" | "total_dc" | "missing_dc";
+export type NumericField = ComplianceField | LifetimeField;
+
+export type SortKey = "project_name" | NumericField;
+
+/** What one unit of the column counts. Drives the coloured chip in the help dialog —
+ *  the single most load-bearing thing in it, because a `documents` column sitting
+ *  beside a `POs` column is exactly what reads as a subtraction and is not one. */
+export type ColumnUnit = "days" | "reports" | "documents" | "POs";
+
+export interface NumericColumn {
+  key: NumericField;
+  label: string;
+  /** First column of a group — draws the left divider. */
+  groupStart?: boolean;
+  /** Bold — the "base" figure of its group (Active Days, Dispatched POs). */
+  emphasize?: boolean;
+  /** Lifetime & project-level — stint sub-rows render "—" instead of a value. */
+  lifetime?: boolean;
+  /** A "missing" gap column — a non-zero value is shown red (0 stays muted). */
+  danger?: boolean;
+
+  // --- help-dialog metadata (WipFormulaDialog reads these) ------------------ //
+  /** What one unit is. */
+  unit: ColumnUnit;
+  /** The doctype(s) the figure is read from. */
+  source: string;
+  /** Every filter applied, in the order the query applies them. */
+  conditions: string[];
+  /** The rule in one line. */
+  formula: string;
+  /** Optional footnote — a cross-reference or a caveat worth stating outright. */
+  note?: string;
+  /** Makes a non-zero cell a deep link into the project's DN > DC report with this
+   *  status pre-selected. Lives on the column model so the link, the header, the cell
+   *  and the help dialog all still derive from ONE array — a separate key->status map
+   *  is free to drift the moment a column is renamed or reordered. */
+  linkStatus?: "pending_dn" | "no_dc_update";
+}
+
+const LIVE_PO_STATUSES = "Dispatched, Partially Dispatched, Partially Delivered, Delivered";
+
+export const NUMERIC_COLUMNS: NumericColumn[] = [
+  {
+    key: "active_working_days", label: "Active Days", groupStart: true, emphasize: true,
+    unit: "days",
+    source: "Projects — status timeline rebuilt from Frappe's Version history",
+    conditions: [
+      "project status is WIP or Handover",
+      "day falls inside the selected month",
+      "Sundays excluded",
+    ],
+    formula: "count of active working days",
+    note: "Projects.status is free text with no stored start date, so the timeline is derived from the recorded status transitions.",
+  },
+  {
+    key: "total_dpr_days", label: "Total DPR",
+    unit: "days",
+    source: "Project Progress Reports",
+    conditions: ["report_date inside the selected month", "report belongs to this project"],
+    formula: "active working days that have at least one report",
+  },
+  {
+    key: "missing_dpr_days", label: "Missing DPR", danger: true,
+    unit: "days",
+    source: "derived — no query of its own",
+    conditions: [],
+    formula: "Active Days − Total DPR",
+    note: "Active Days = Total DPR + Missing DPR, always. This is the one group that does add up across.",
+  },
+  {
+    key: "expected_inventory", label: "Expected", groupStart: true,
+    unit: "reports",
+    source: "derived from the active-day set",
+    conditions: ["active day", "falls on a Monday"],
+    formula: "count of active Mondays — one inventory expected per active week",
+  },
+  {
+    key: "actual_inventory", label: "Actual",
+    unit: "documents",
+    source: "Remaining Items Report",
+    conditions: ["report_date inside the selected month", "report belongs to this project"],
+    formula: "COUNT of report documents",
+    note: "Counts documents on any weekday, not Mondays covered — so it can exceed Expected.",
+  },
+  {
+    key: "missing_inventory", label: "Missing", danger: true,
+    unit: "reports",
+    source: "derived — no query of its own",
+    conditions: [],
+    formula: "max(0, Expected − Actual)",
+    note: "Clamped at 0 because Actual is an unbounded document count and routinely exceeds Expected.",
+  },
+
+  // MIND THE UNITS: "Disp PO" is a PO count, "Total DN" / "Total DC" are DOCUMENT
+  // counts, and "Missing DN" / "Missing DC" are PO counts again — so the columns do
+  // NOT subtract across the row. See useMonthlyWIPData.ts for the full rationale.
+  {
+    key: "dispatched_po", label: "Disp PO", groupStart: true, emphasize: true, lifetime: true,
+    unit: "POs",
+    source: "Procurement Orders",
+    conditions: [
+      `status is one of: ${LIVE_PO_STATUSES}`,
+      "PO belongs to this project",
+      "no date filter — lifetime",
+    ],
+    formula: "COUNT of purchase orders, Billable and Non-Billable",
+    note: "Counts both, like Total DN. Hover the cell for the split. Missing DN and Missing DC below remain Billable-only, so this is a LARGER denominator than those two are measured against.",
+  },
+  {
+    key: "total_dn", label: "Total DN", lifetime: true,
+    unit: "documents",
+    source: "Delivery Notes",
+    conditions: [
+      "is_return = 0 — a return is not a delivery",
+      "note belongs to this project",
+      "no date filter — lifetime",
+    ],
+    formula: "COUNT of delivery note documents, Billable and Non-Billable",
+    note: "The ONE column in this block that is not Billable-only — a Non-Billable PO still receives goods. Hover the cell for the split. One PO can carry several notes, so this normally exceeds Disp PO.",
+  },
+  {
+    key: "missing_dn", label: "Missing DN", lifetime: true, danger: true,
+    // The report's "Pending DN" card is the same rule — both count POs with a
+    // dispatched item not yet fully received.
+    linkStatus: "pending_dn",
+    unit: "POs",
+    source: "Procurement Orders + Purchase Order Item",
+    conditions: [
+      "billing_status is not 'Non-Billable'",
+      `status is one of: ${LIVE_PO_STATUSES}`,
+      "status is NOT 'Delivered' — a fully delivered PO owes nothing",
+    ],
+    formula:
+      "count POs having at least one item where category ≠ 'Additional Charges' AND is_dispatched = 1 AND received_quantity < quantity (2.5% tolerance on fractional quantities, exact on whole numbers)",
+    note: "Compares ORDERED against RECEIVED on the PO's own items — it never looks at Delivery Note documents. Same number as the project's \"DN Pending\" tile.",
+  },
+  {
+    key: "total_dc", label: "Total DC", groupStart: true, lifetime: true,
+    unit: "documents",
+    source: "PO Delivery Documents",
+    conditions: [
+      "type = 'Delivery Challan' — Material Inspection Reports excluded",
+      "parent_doctype = 'Procurement Orders' — ITM-parented challans excluded",
+      "the challan's parent PO (parent_docname) is Billable",
+      "challan belongs to this project",
+      "no date filter — lifetime",
+    ],
+    formula: "COUNT of challan documents",
+    note: "Placeholder (stub) challans ARE counted here, but are ignored by Missing DC.",
+  },
+  {
+    key: "missing_dc", label: "Missing DC", lifetime: true, danger: true,
+    // The report's "No DC Update" card is the same rule — delivered, no challan.
+    linkStatus: "no_dc_update",
+    unit: "POs",
+    source: "Procurement Orders + Purchase Order Item + PO Delivery Documents",
+    conditions: [
+      "billing_status is not 'Non-Billable'",
+      `status is one of: ${LIVE_PO_STATUSES}`,
+      "the PO has NO non-stub Delivery Challan",
+    ],
+    formula:
+      "count POs having at least one item where category ≠ 'Additional Charges' AND received_quantity > 0",
+    note: "Any one challan clears the whole PO — a challan covering only part of the delivery still counts as filed. Same number as the project's \"DC Pending\" tile.",
+  },
+];
+
+export interface ColumnGroup {
+  label: string;
+  span: number;
+}
+export const COLUMN_GROUPS: ColumnGroup[] = [
+  { label: "Project", span: 3 },
+  { label: "DPR · Daily (excl. Sun)", span: 3 },
+  { label: "Inventory · Weekly (Mon)", span: 3 },
+  // NOT "(Billable)" any more: Disp PO and Missing DN are Billable-only but Total DN
+  // counts both, so a blanket suffix on the group would be false for one of the three.
+  // The per-column truth lives in the info dialog and the Total DN hover.
+  { label: "Delivery Notes", span: 3 },
+  { label: "Delivery Challans (Billable)", span: 2 },
+];

--- a/frontend/src/pages/reports/ReportsContainer.tsx
+++ b/frontend/src/pages/reports/ReportsContainer.tsx
@@ -250,10 +250,28 @@ export default function ReportsContainer() {
             // console.log("Current selection invalid, resetting to default for tab:", activeTab, "role:", role);
             setDefaultReportType(activeTab, role);
         } else if (!selectedReportType && currentReportOptions.length > 0) {
-            // If no report is selected but there are options, set to default
-            // This happens on initial load or if selection became null
-            // console.log("No report selected but options exist, setting to default for tab:", activeTab, "role:", role);
-            setDefaultReportType(activeTab, role);
+            // No report selected but options exist — initial load, or the selection
+            // became null.
+            //
+            // A report named in the URL WINS over the tab default. This branch used to
+            // call setDefaultReportType() unconditionally, which silently clobbered a
+            // deep link on every refresh: the URL-restoring effect above and this one
+            // run in the SAME commit, so `selectedReportType` here is still the stale
+            // pre-update value (null) even though that effect has already set it. This
+            // effect ran last and won, so /reports?report=Monthly+WIP reloaded as Cash
+            // Sheet while the address bar still read Monthly WIP — setDefaultReportType
+            // touches only the store, never the URL, which is why it never looked like
+            // a redirect. Reading the param here removes the dependency on effect order
+            // entirely; an absent or tab-invalid URL report still falls to the default.
+            // urlStateManager.getParam, not getUrlStringParam("report", null): the
+            // helper is `getParam(key) ?? defaultValue` and declares its default as
+            // `string`, so passing null is the same call with a type error attached.
+            const urlReport = urlStateManager.getParam("report") as ReportType | null;
+            if (urlReport && currentReportOptions.some(opt => opt.value === urlReport)) {
+                setSelectedReportType(urlReport);
+            } else {
+                setDefaultReportType(activeTab, role);
+            }
         }
 
     }, [currentReportOptions, selectedReportType, setSelectedReportType, setDefaultReportType, activeTab, role]);

--- a/frontend/src/pages/reports/components/DNDCQuantityReport.tsx
+++ b/frontend/src/pages/reports/components/DNDCQuantityReport.tsx
@@ -41,6 +41,7 @@ import LoadingFallback from "@/components/layout/loaders/LoadingFallback";
 import { AlertDestructive } from "@/components/layout/alert-banner/error-alert";
 import { SimpleFacetedFilter } from "@/pages/projects/components/SimpleFacetedFilter";
 import { exportToCsv } from "@/utils/exportToCsv";
+import { urlStateManager } from "@/utils/urlStateManager";
 import { toast } from "@/components/ui/use-toast";
 import { useProjectAssignees } from "@/hooks/useProjectAssignees";
 import type { ProjectAssignee } from "@/hooks/useProjectAssignees";
@@ -399,9 +400,18 @@ function DNDCQuantityReportContent({
   const [billingFilter, setBillingFilter] = useState<Set<string>>(
     new Set(["Billable"])
   );
-  const [statusFilter, setStatusFilter] = useState<Set<string>>(
-    new Set(["mismatch", "no_dc_update", "pending_dn"])
-  );
+  // Seeded from `dndc_status` when present, so the Monthly WIP report's Missing DN /
+  // Missing DC counts can deep-link straight to the matching rows. Read ONCE as the
+  // initial value — after mount the user's own filter clicks own this state, and the
+  // stale param in the address bar is harmless.
+  const [statusFilter, setStatusFilter] = useState<Set<string>>(() => {
+    const fromUrl = urlStateManager.getParam("dndc_status");
+    if (fromUrl) {
+      const wanted = fromUrl.split(",").map((v) => v.trim()).filter(Boolean);
+      if (wanted.length) return new Set(wanted);
+    }
+    return new Set(["mismatch", "no_dc_update", "pending_dn"]);
+  });
 
   // --- Sort state ---
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
@@ -971,8 +981,9 @@ export default function DNDCQuantityReport({ projectId: propProjectId, projectNa
         <AlertDescription className="text-sm text-blue-800">
           Compares Delivery Note (DN) vs Delivery Challan (DC) quantities for
           POs with dispatch or delivery status. Flags mismatches where DN
-          exceeds DC, items with no DC update, and items with DCs but no DN
-          yet (Pending DN).
+          exceeds DC, items with no DC update, and items ordered but not yet
+          received (Pending DN). A PO can be counted under both Pending DN and
+          No DC Update, so the four cards do not add up to the PO total.
         </AlertDescription>
       </Alert>
 

--- a/frontend/src/pages/reports/hooks/useDNDCQuantityData.ts
+++ b/frontend/src/pages/reports/hooks/useDNDCQuantityData.ts
@@ -20,6 +20,10 @@ export interface DNDCItemRow {
   dcQty: number; // sum of DC item quantities for this PO+item
   difference: number; // dnQty - dcQty
   status: ReconcileStatus;
+  /** Ordered quantity not yet received, on a PO that is not already Delivered.
+   *  SEPARATE from `status` on purpose — an item can be delivery-pending AND missing a
+   *  challan, and the single-status model cannot hold both. Drives the Pending DN card. */
+  deliveryPending: boolean;
 }
 
 export interface DNDCPORow {
@@ -33,6 +37,11 @@ export interface DNDCPORow {
   itemsMatched: number;
   itemsTotal: number;
   reconcileStatus: ReconcileStatus;
+  /** ANY billable item on this PO is delivery-pending. Separate from `reconcileStatus`
+   *  because a PO can be both — PO/218 owes a delivery AND a challan, and the rollup can
+   *  only report one. This is what the Pending DN card counts, and what the table's
+   *  status filter and badge must ALSO read, or a PO the card counts is unfindable. */
+  hasDeliveryPending: boolean;
   items: DNDCItemRow[];
 }
 
@@ -250,15 +259,41 @@ export function useDNDCQuantityData(projectId: string | null) {
         const dnQty = itemData.dnQty;
         const difference = dnQty - dcQty;
 
+        // "Pending DN" — ordered quantity not yet received. It is carried as its OWN
+        // FLAG, not as a status, and that is load-bearing: an item can be short on
+        // delivery AND missing a challan at the same time (PO/218 on Nagarjuna Olive
+        // is), so making it a status let it STEAL the item from `no_dc_update` and drop
+        // that PO off the red card — 77 became 76 and stopped agreeing with the
+        // project's DC Pending tile. As a flag it adds a signal without removing one.
+        //
+        // The `Delivered` exclusion mirrors `predicates.is_dn_pending`: a fully
+        // delivered PO has no outstanding delivery obligation by definition. Without it
+        // this project reads 4 against the Overview tile's 2, and 28 vs 5 system-wide.
+        //
+        // Still simpler than that predicate, which also requires `is_dispatched = 1`
+        // and allows a 2.5% tolerance on fractional quantities. Measured on live data
+        // those two make no difference here; if this card ever disagrees with the tile,
+        // they are the first place to look.
+        const deliveryPending =
+          poStatusMap.get(poNumber) !== "Delivered" && itemData.orderedQty > dnQty;
+
+        // The three quantity verdicts are UNTOUCHED — every item keeps exactly the
+        // status it had before this flag existed.
         let status: ReconcileStatus;
-        if (dnQty === 0 && dcQty > 0) {
-          status = "pending_dn";
-        } else if (dcQty >= dnQty) {
+        if (dcQty >= dnQty) {
           status = "matched";
         } else if (dnQty > 0 && dcQty === 0) {
           status = "no_dc_update";
         } else {
           status = "mismatch";
+        }
+
+        // ...with ONE exception. An item with nothing on either side has no meaningful
+        // DC verdict — "matched" at 0 vs 0 is vacuous — and it is exactly the shape the
+        // zero-activity filter used to discard, which is why a PO dispatched with
+        // nothing received appeared nowhere in this report. Label it for what it is.
+        if (deliveryPending && dnQty === 0 && dcQty === 0) {
+          status = "pending_dn";
         }
 
         itemRows.push({
@@ -272,6 +307,7 @@ export function useDNDCQuantityData(projectId: string | null) {
           dcQty,
           difference,
           status,
+          deliveryPending,
         });
       }
 
@@ -293,13 +329,18 @@ export function useDNDCQuantityData(projectId: string | null) {
             dcQty: dcData.qty,
             difference: 0 - dcData.qty,
             status: "matched",
+            deliveryPending: false,
           });
         }
       }
 
-      // 9. Filter zero-activity items
+      // 9. Filter zero-activity items. A pending_dn line is EXEMPT: it has ordered
+      // quantity outstanding, so "nothing has happened here" is false even though both
+      // the DN and DC columns read 0. Without the exemption a PO dispatched with
+      // nothing received is discarded before any verdict runs and appears nowhere in
+      // the report at all — which is what used to happen.
       const activeItems = itemRows.filter(
-        (item) => !(item.dnQty === 0 && item.dcQty === 0)
+        (item) => !(item.dnQty === 0 && item.dcQty === 0) || item.deliveryPending
       );
 
       if (activeItems.length === 0) continue;
@@ -319,18 +360,26 @@ export function useDNDCQuantityData(projectId: string | null) {
 
       const hasMismatch = billableItems.some((i) => i.status === "mismatch");
       const hasNoDCUpdate = billableItems.some((i) => i.status === "no_dc_update");
-      const hasPendingDN = billableItems.some((i) => i.status === "pending_dn");
+      const hasDeliveryPending = billableItems.some((i) => i.deliveryPending);
+      // The FLAG, not the status. A PO whose delivery gap sits on an item that IS
+      // challaned carries no `pending_dn` STATUS anywhere (its items read "matched"
+      // against the DC), so a status-based test badged it Fully Matched while the
+      // Pending DN card counted it — the card and the badge disagreeing about the same
+      // row. PO/218 on Nagarjuna Olive is exactly that: 36 ordered, 12 received, the 12
+      // fully challaned. Ranked BELOW mismatch and no_dc_update, so it can only override
+      // "matched" — it never takes a PO off the No DC Update card.
 
       let reconcileStatus: ReconcileStatus;
       if (hasMismatch) {
         reconcileStatus = "mismatch";
       } else if (hasNoDCUpdate) {
         reconcileStatus = "no_dc_update";
-      } else if (hasPendingDN) {
+      } else if (hasDeliveryPending) {
         reconcileStatus = "pending_dn";
       } else {
         reconcileStatus = "matched";
       }
+
 
       resultRows.push({
         poNumber,
@@ -343,6 +392,7 @@ export function useDNDCQuantityData(projectId: string | null) {
         itemsMatched: matchedItems,
         itemsTotal: billableItems.length,
         reconcileStatus,
+        hasDeliveryPending,
         items: activeItems,
       });
     }
@@ -359,11 +409,16 @@ export function useDNDCQuantityData(projectId: string | null) {
           itemName: dcData.itemName,
           category: dcData.category,
           unit: dcData.unit,
+          // Pre-existing omission, surfaced once the summary began reading this field:
+          // DNDCItemRow requires billingStatus and this DC-only branch never set it.
+          // "Billable" matches the sibling orphan-item branch above.
+          billingStatus: "Billable",
           orderedQty: 0,
           dnQty: 0,
           dcQty: dcData.qty,
           difference: 0 - dcData.qty,
           status: "matched",
+          deliveryPending: false,
         });
       }
 
@@ -379,6 +434,8 @@ export function useDNDCQuantityData(projectId: string | null) {
 
       resultRows.push({
         poNumber,
+        // A DC-only PO has no PO items at all, so nothing can be delivery-pending.
+        hasDeliveryPending: false,
         vendorName: dcDoc?.vendor ?? "",
         billingStatus: poBillingMap.get(poNumber) ?? "",
         totalOrderedQty: 0,
@@ -400,7 +457,15 @@ export function useDNDCQuantityData(projectId: string | null) {
     const matchedPOs = billableRows.filter((r) => r.reconcileStatus === "matched").length;
     const mismatchPOs = billableRows.filter((r) => r.reconcileStatus === "mismatch").length;
     const noDCUpdatePOs = billableRows.filter((r) => r.reconcileStatus === "no_dc_update").length;
-    const pendingDNPOs = billableRows.filter((r) => r.reconcileStatus === "pending_dn").length;
+    // Counted from the ITEMS, not from `reconcileStatus`. A PO can owe both a delivery
+    // and a challan — PO/218 on Nagarjuna Olive does — and the rollup gives each PO one
+    // verdict, so counting by rollup would drop such a PO off this card (it ranks below
+    // no_dc_update). Ranking pending_dn higher instead would move it OFF "No DC Update",
+    // breaking that card's agreement with the project's DC Pending tile. So this card
+    // OVERLAPS the other three rather than partitioning with them, exactly as the
+    // Overview page shows DC Pending and DN Pending as two independent tiles.
+    // Consequence: the four cards no longer sum to the PO total.
+    const pendingDNPOs = billableRows.filter((r) => r.hasDeliveryPending).length;
 
     return {
       poRows: resultRows,

--- a/nirmaan_stack/api/reports/metrics.py
+++ b/nirmaan_stack/api/reports/metrics.py
@@ -1,0 +1,150 @@
+"""
+Shared PO-level delivery-paperwork metrics for the reports layer.
+
+ONE definition of "this PO still owes a DN / a DC", reused by every surface that
+prints such a count, so the Monthly WIP report and the Action Centre / project
+tiles can never disagree by construction.
+
+WHY THIS EXISTS
+---------------
+The Monthly WIP report used to derive both numbers by subtracting DOCUMENT counts:
+
+    missing_dn = max(0, dispatched_po_count - delivery_note_count)
+    missing_dc = max(0, delivery_note_count - non_billable_dn_count - dc_count)
+
+Both are unsound, because a PO carries an unbounded number of DNs (431 POs on live
+data carry more than one, contributing 571 surplus documents). A PO with 3 DNs
+silently cancels two other POs that have none, so the raw value went NEGATIVE on 56
+of 93 projects for ``missing_dn`` and 12 of 93 for ``missing_dc`` — and the
+``max(0, ...)`` clamp then rendered that incoherence as a clean, trustworthy-looking
+zero. The DC form additionally counted 322 STUB Delivery-Challan rows as filed
+challans (the reconciler has always excluded them), which pushed several projects to
+0 while they genuinely owed dozens of challans.
+
+The fix is to stop subtracting documents and COUNT POs against the same predicates
+the Project Action Item reconciler uses (``services/action_items/predicates.py``).
+
+CONTRACT
+--------
+  * PURE READ. No writes, no commits, not whitelisted — an internal helper.
+  * Counts POs, never documents. Every value is a non-negative PO count, so no
+    clamping is required or performed.
+  * Uses the SAME predicates as ``services/action_items/reconcile._compute_desired``
+    (including its ``is_stub = 0`` Delivery-Challan filter), so on a project the
+    reconciler does not suppress, BOTH counts here EQUAL the project tile.
+  * NOT project-status aware. The reconciler force-resolves every open row on
+    Completed / Halted projects; this helper does not, because chasing outstanding
+    paperwork on a finished project is exactly what a compliance report is for.
+    Callers that want the Action-Centre view must apply that gate themselves.
+
+DN: WHY THIS CALLS ``is_dn_pending`` AND NOT A DOCUMENT-EXISTENCE TEST
+----------------------------------------------------------------------
+An earlier revision of this module carried its own ``_is_dn_missing`` predicate —
+"dispatched, and no Delivery Note document exists for the PO" — because
+``is_dn_pending`` early-returns on ``status == "Delivered"`` and 5037 of the 5047
+live POs are Delivered, which pins it near zero (5 system-wide, max 2 on any one
+project). Owner ruling: the WIP column must show the SAME NUMBER as the project
+Overview tile, so the shared predicate wins and the local one is gone.
+
+What that trades away, recorded so it is not rediscovered as a bug: four POs
+(Cinepolis, KVN Prestige Trade Tower, Richa & Mekin Residency, STS Bangalore) carry
+a recorded ``received_quantity`` with NO delivery-note document at all — goods logged
+without paperwork, or a note deleted afterwards. Their status is ``Delivered``, so
+``is_dn_pending`` cannot see them. They are a DATA-INTEGRITY signal rather than
+pending work (nobody can file the missing note — the delivery already happened), so
+they belong in a separate audit, not in a compliance column.
+
+SQL SHAPE (load-bearing — do not "simplify" this)
+-------------------------------------------------
+Every query is raw SQL that JOINs on the PO's status. It must NEVER be rewritten as
+``frappe.get_all(..., filters={"parent": ["in", po_names]})``: Frappe runs
+``validate_generated_query`` -> ``sqlparse.parse()``, which raises
+``Maximum number of tokens exceeded (10000)`` once the IN-list grows past a few
+thousand names. There are 5047 live POs on production today, so that form throws in
+prod while passing on any small dataset.
+"""
+
+import frappe
+
+from nirmaan_stack.services.action_items.predicates import (
+    LIVE_STATUSES,
+    is_dc_pending,
+    is_dn_pending,
+)
+
+# Tuple form for psycopg2 ``IN %(s)s`` binding. Sorted for a stable query string
+# (so Postgres can reuse its plan cache across calls).
+_LIVE = tuple(sorted(LIVE_STATUSES))
+
+_Q_POS = '''
+    SELECT name, project, status, billing_status
+    FROM "tabProcurement Orders"
+    WHERE status IN %(s)s
+'''
+
+_Q_ITEMS = '''
+    SELECT i.parent, i.category, i.is_dispatched, i.quantity, i.received_quantity
+    FROM "tabPurchase Order Item" i
+    JOIN "tabProcurement Orders" po ON po.name = i.parent
+    WHERE po.status IN %(s)s
+'''
+
+# `is_stub = 0` is MANDATORY and mirrors reconcile._compute_desired. A stub row is a
+# placeholder with no items; treating it as a filed challan is what made Air India
+# Training Centre report 0 missing challans against 35 real ones.
+_Q_DC = '''
+    SELECT DISTINCT d.parent_docname
+    FROM "tabPO Delivery Documents" d
+    JOIN "tabProcurement Orders" po ON po.name = d.parent_docname
+    WHERE d.parent_doctype = 'Procurement Orders'
+      AND d.type = 'Delivery Challan'
+      AND d.is_stub = 0
+      AND po.status IN %(s)s
+'''
+
+def pending_counts_by_project():
+    """Per-project counts of POs that still owe delivery paperwork.
+
+    Returns ``{project_docname: {"dc_pending": int, "dn_pending": int}}`` covering
+    every project that has at least one PO in a live delivery status. A project with
+    live POs but nothing outstanding is present with both counts at 0; a project with
+    no live POs at all is ABSENT, so callers must use ``.get(pid, ...)`` with a zero
+    default rather than assuming a key exists.
+
+    THREE bulk queries + a pure-Python pass; no N+1 and no per-project round-trip.
+    (It was four while DN was a document-existence test; ``is_dn_pending`` reads only
+    the PO's own items, so the Delivery-Notes fetch is gone.) Measured on
+    production-scale data (5047 POs / 19,848 items / 93 projects): ~80-160 ms.
+    """
+    pos = frappe.db.sql(_Q_POS, {"s": _LIVE}, as_dict=True)
+    if not pos:
+        return {}
+
+    item_rows = frappe.db.sql(_Q_ITEMS, {"s": _LIVE}, as_dict=True)
+    items_by_po = {}
+    for row in item_rows:
+        items_by_po.setdefault(row["parent"], []).append(row)
+
+    has_dc = {row[0] for row in frappe.db.sql(_Q_DC, {"s": _LIVE})}
+
+    counts = {}
+    for po in pos:
+        project = po.get("project")
+        if not project:
+            # A PO with no project cannot be attributed to a report row.
+            continue
+
+        bucket = counts.setdefault(project, {"dc_pending": 0, "dn_pending": 0})
+        name = po["name"]
+        status = po["status"]
+        billing = po.get("billing_status")
+        items = items_by_po.get(name, [])
+
+        if is_dc_pending(status, billing, items, name in has_dc):
+            bucket["dc_pending"] += 1
+        # No document lookup: is_dn_pending compares each dispatched item's ordered
+        # quantity against what has been received, on the PO's own item rows.
+        if is_dn_pending(status, billing, items):
+            bucket["dn_pending"] += 1
+
+    return counts

--- a/nirmaan_stack/api/reports/wip_monthly_report.py
+++ b/nirmaan_stack/api/reports/wip_monthly_report.py
@@ -12,10 +12,28 @@ For a selected month, list every project that was ACTIVE (in ``WIP`` OR
     (active Mondays), the Mondays actually filled, and the missing ones.
 
 Two further groups are LIFETIME (whole-project, NOT scoped to the month — the
-same regardless of which month is picked), shown only on the project row:
+same regardless of which month is picked) and BILLABLE-ONLY, shown only on the
+project row:
   - PO dispatch: dispatched POs (status in DISPATCHED_PO_STATUSES), total DNs
-    (deliveries, returns excluded), and missing DN = dispatched − DN (clamped ≥0),
-  - DC compliance: total Delivery Challans and missing DC = total DN − total DC.
+    (deliveries, returns excluded), and missing DN,
+  - DC compliance: total Delivery Challans and missing DC.
+
+Every column in both groups is restricted to Billable POs. A Non-Billable PO cannot
+acquire a Delivery Challan at all, so it can never be compliant and never enters the
+``missing_*`` figures; leaving it in the totals beside them meant the two halves of a
+row described different universes.
+
+``missing_dn`` / ``missing_dc`` are PO COUNTS from ``reports/metrics.py`` — the same
+predicates the Project Action Item reconciler uses — NOT arithmetic over the document
+totals beside them. They used to be ``max(0, dispatched_po − total_dn)`` and
+``max(0, total_dn − non_billable_dn − total_dc)``; both subtracted document counts to
+answer a per-PO question, which is unsound because one PO carries any number of DNs.
+The raw values went negative on 56 / 12 of 93 projects respectively and the clamp
+rendered that as a clean zero. See reports/metrics.py for the full rationale.
+
+CONSEQUENCE, and it is intended: ``total_dn`` / ``total_dc`` are DOCUMENT counts while
+``missing_dn`` / ``missing_dc`` are PO counts, so the columns do NOT reconcile
+arithmetically on screen. They are answering different questions in different units.
 
 There is no stored status-start date on Projects (``status`` is a free-text Data
 field). Duration is derived purely from the recorded ``-> WIP`` / ``-> Handover``
@@ -38,6 +56,7 @@ from frappe.utils import (
 )
 
 from nirmaan_stack.api.pmo_dashboard import _extract_status_change_value_pairs
+from nirmaan_stack.api.reports.metrics import pending_counts_by_project
 from nirmaan_stack.api.seven_days_planning.get_projects_material_plan_stats import (
     _get_allowed_projects,
     _get_user_role,
@@ -179,8 +198,10 @@ def _compliance_metrics(active_days, dpr_days, inv_report_count):
 
     The clamp is required, not cosmetic — ``actual`` is an unbounded document count and
     routinely exceeds ``expected`` on live data (a project filing 6 reports against 5
-    active Mondays would otherwise render −1). Same reason ``missing_dn`` /
-    ``missing_dc`` are clamped.
+    active Mondays would otherwise render −1). ``missing_dn`` / ``missing_dc`` used to
+    be clamped for the same reason; they no longer are, because they are now PO counts
+    from reports/metrics.py rather than a subtraction of document totals, and a count
+    cannot go negative. Inventory keeps its clamp because it IS still a subtraction.
 
     NOTE (owner ruling): ``actual_inventory`` counts DOCUMENTS, not covered Mondays. It
     deliberately no longer keys on the report landing on its Monday, so a project filing
@@ -257,25 +278,40 @@ def _report_dates_by_project(table, date_col, project_ids, month_start, month_en
     return out
 
 
-# A Delivery Note whose PO is Non-Billable can NEVER acquire a DC — the DC/MIR upload
-# path rejects Non-Billable POs outright (see api/delivery_challans_data.py). Counting
-# such DNs as "missing a DC" is permanently unclearable, so they are subtracted out of
-# the G5 gap. Two joins-worth of care:
-#   * matched on the legacy ``procurement_order`` Link, NOT ``parent_docname`` — the DN
-#     polymorphism migration is only partly applied, so ``parent_docname`` is NULL on
-#     every row while ``procurement_order`` is reliably set.
-#   * only the EXPLICIT 'Non-Billable' string counts; a blank billing_status means
-#     Billable (procurement_orders.py leaves it empty for an item-less PO), matching
-#     the frontend convention everywhere.
-# ITM-parented DNs have no PO, so they do not match and stay in the gap (owner call).
-_NON_BILLABLE_DN_CLAUSE = '''
-          AND is_return = 0
+# NOTE: the old ``_NON_BILLABLE_DN_CLAUSE`` lived here. It subtracted DNs belonging to
+# Non-Billable POs out of the missing-DC gap, because such a PO can never acquire a DC
+# (the DC/MIR upload path rejects it — see api/delivery_challans_data.py). It is gone
+# because ``missing_dc`` no longer subtracts anything: reports/metrics.py counts POs
+# through ``predicates.is_dc_pending``, which already returns False for a Non-Billable
+# PO. The correction is now explicit in the predicate instead of an invisible term.
+
+
+# A blank / NULL ``billing_status`` counts as BILLABLE — the same convention as
+# predicates.is_billable and the frontend. procurement_orders.py leaves the field empty
+# on an item-less PO, so an ``!= 'Non-Billable'`` test alone would wrongly drop those
+# rows on Postgres (NULL != 'x' is NULL, not TRUE).
+_BILLABLE = "(po.billing_status IS NULL OR po.billing_status != 'Non-Billable')"
+
+
+def _billable_po_clause(table, link_column):
+    """``AND EXISTS(...)`` restricting ``table`` to rows whose parent PO is Billable.
+
+    ``_lifetime_counts_by_project`` does not alias its FROM table, so the correlation
+    has to name the table in full (``"tabDelivery Notes".procurement_order``) rather
+    than use an alias — Postgres rejects the aliased form with "invalid reference to
+    FROM-clause entry".
+
+    A row whose ``link_column`` is blank (an ITM-parented DN, of which there are 4 on
+    live data) matches no PO and is therefore EXCLUDED — correct here, since the whole
+    lifetime block is scoped to the Billable PO universe.
+    """
+    return f'''
           AND EXISTS (
               SELECT 1 FROM "tabProcurement Orders" po
-              WHERE po.name = "tabDelivery Notes".procurement_order
-                AND po.billing_status = 'Non-Billable'
+              WHERE po.name = "{table}".{link_column}
+                AND {_BILLABLE}
           )
-'''
+    '''
 
 
 def _lifetime_counts_by_project(table, project_ids, extra=""):
@@ -383,21 +419,55 @@ def get_wip_monthly_report(month=None):
 
     # PO-dispatch (G4) + DC (G5): LIFETIME totals, NOT month-scoped. DISPATCHED_PO_STATUSES
     # is a code constant (no user input) so its literals are safe to inline.
+    #
+    # THE WHOLE LIFETIME BLOCK IS SCOPED TO BILLABLE POs. A Non-Billable PO can never
+    # acquire a Delivery Challan (the upload path rejects it), so it can never be
+    # "compliant" and never appears in `missing_dn` / `missing_dc` either — counting its
+    # POs and documents in the totals beside them made the row unreadable (a project
+    # would show 35 dispatched POs against 25 missing DCs with no visible explanation
+    # for the 10-PO gap). Every column in this block now describes the same Billable
+    # universe. On live data this drops 1107 of 5047 POs and 261 of 1631 challans.
     status_in = ", ".join(f"'{s}'" for s in DISPATCHED_PO_STATUSES)
+    # Disp PO counts EVERY live PO, Billable or not — the same owner ruling as Total DN
+    # below. A Non-Billable PO is still a dispatched PO. The Billable subset rides along
+    # so the cell can show the split on hover.
     dispatched_po = _lifetime_counts_by_project(
         "tabProcurement Orders", active_ids, f"AND status IN ({status_in})"
     )
-    total_dn = _lifetime_counts_by_project("tabDelivery Notes", active_ids, "AND is_return = 0")
-    # Subtracted out of the G5 gap only — `total_dn` above stays the FULL count, so the
-    # displayed Total DN / Total DC / Missing DC do not visibly reconcile (owner chose
-    # to keep this subtraction implicit rather than add a column).
-    non_billable_dn = _lifetime_counts_by_project(
-        "tabDelivery Notes", active_ids, _NON_BILLABLE_DN_CLAUSE
+    dispatched_po_billable = _lifetime_counts_by_project(
+        "tabProcurement Orders", active_ids,
+        f"AND status IN ({status_in}) "
+        "AND (billing_status IS NULL OR billing_status != 'Non-Billable')",
+    )
+    # Total DN counts EVERY non-return delivery note, Billable or not — owner ruling,
+    # and DELIBERATELY unlike the rest of this block. A Non-Billable PO still receives
+    # goods and still produces delivery notes; hiding them made the column disagree with
+    # the Delivery Notes list for no reason a reader could see. The Billable subset rides
+    # alongside so the cell can show the split on hover.
+    #
+    # It does NOT change `missing_dn` / `missing_dc`, which stay Billable-only: a
+    # Non-Billable PO can never acquire a challan (the upload path rejects it), so
+    # counting one as non-compliant would put a row in those columns that can never
+    # clear. Nor does it change Total DC — the ruling is delivery notes only.
+    total_dn = _lifetime_counts_by_project(
+        "tabDelivery Notes", active_ids, "AND is_return = 0"
+    )
+    total_dn_billable = _lifetime_counts_by_project(
+        "tabDelivery Notes", active_ids,
+        "AND is_return = 0" + _billable_po_clause("tabDelivery Notes", "procurement_order"),
     )
     total_dc = _lifetime_counts_by_project(
         "tabPO Delivery Documents", active_ids,
-        "AND type = 'Delivery Challan' AND parent_doctype = 'Procurement Orders'",
+        "AND type = 'Delivery Challan' AND parent_doctype = 'Procurement Orders'"
+        + _billable_po_clause("tabPO Delivery Documents", "parent_docname"),
     )
+
+    # The two "missing" figures — PO counts, NOT arithmetic over the totals above. One
+    # bulk call covering every project; a project with no live POs is simply absent, so
+    # every read below defaults to 0. Deliberately NOT filtered to `active_ids`: the
+    # helper's queries join on PO status rather than taking an IN-list of project names,
+    # which is what keeps them clear of the sqlparse 10k-token cap in production.
+    pending = pending_counts_by_project()
 
     rows = []
     for pid, periods in proj_periods.items():
@@ -432,6 +502,7 @@ def get_wip_monthly_report(month=None):
         n_dispatched = dispatched_po.get(pid, 0)
         n_dn = total_dn.get(pid, 0)
         n_dc = total_dc.get(pid, 0)
+        p_pending = pending.get(pid) or {}
         rows.append(
             {
                 "project": pid,
@@ -442,17 +513,28 @@ def get_wip_monthly_report(month=None):
                 "active_start": periods[0]["start"].isoformat(),
                 "active_end": "ongoing" if periods[-1]["end"] is None else periods[-1]["end"].isoformat(),
                 "stints": len(periods),
-                # G4 — PO dispatch vs delivery (lifetime). Missing clamped at 0: a PO can
-                # carry several DNs, so raw (dispatched − dn) can go negative.
+                # G4 — PO dispatch vs delivery (lifetime). `dispatched_po` / `total_dn`
+                # are DOCUMENT counts; `missing_dn` is a PO count — Billable POs with a
+                # dispatched item that is not yet fully received (predicates.is_dn_pending,
+                # the SAME rule as the project Overview tile's "DN Pending", so the two
+                # surfaces always print the same number). The three do NOT subtract into
+                # one another. No clamp — a count cannot be negative.
                 "dispatched_po": n_dispatched,
+                # Billable slice, surfaced ONLY for the hover split. Nothing derives from
+                # it — `missing_dn` / `missing_dc` still come from the predicates, which
+                # apply their own Billable rule.
+                "dispatched_po_billable": dispatched_po_billable.get(pid, 0),
                 "total_dn": n_dn,
-                "missing_dn": max(0, n_dispatched - n_dn),
-                # G5 — DC compliance (lifetime). Missing = total DN − Non-Billable DN −
-                # total DC, clamped at 0. The Non-Billable term removes DNs that can
-                # never acquire a DC (see _NON_BILLABLE_DN_CLAUSE); the clamp still does
-                # real work — several live projects go negative before it.
+                # The Billable slice of `total_dn`, surfaced ONLY so the cell can show
+                # "N Billable / M Non-Billable" on hover. Nothing derives from it.
+                "total_dn_billable": total_dn_billable.get(pid, 0),
+                "missing_dn": p_pending.get("dn_pending", 0),
+                # G5 — DC compliance (lifetime). Same unit split: `total_dc` counts
+                # challan DOCUMENTS (stubs included, as a raw total should), while
+                # `missing_dc` counts POs that owe one via predicates.is_dc_pending
+                # (which excludes stubs and Non-Billable POs).
                 "total_dc": n_dc,
-                "missing_dc": max(0, n_dn - non_billable_dn.get(pid, 0) - n_dc),
+                "missing_dc": p_pending.get("dc_pending", 0),
                 "periods": child_periods,
             }
         )


### PR DESCRIPTION
…surface

Monthly WIP derived both `missing_*` columns by subtracting DOCUMENT counts to answer a per-PO question:

    missing_dn = max(0, dispatched_po_count - delivery_note_count)
    missing_dc = max(0, delivery_note_count - non_billable_dn_count - dc_count)

A PO carries an unbounded number of DNs (431 live POs carry more than one, contributing 571 surplus documents), so a PO with 3 DNs silently cancels two others that have none. The raw value went NEGATIVE on 56 of 93 projects for missing_dn and 12 of 93 for missing_dc, and the max(0, ...) clamp rendered that incoherence as a clean zero. missing_dc additionally counted 322 STUB challan rows as filed: Air India Training Centre read 0 missing against 35 real, and Clutterbot's 38 challans were all stubs. Only 34 of 85 projects were exact.

Both now COUNT POs through services/action_items/predicates.py -- the same predicates the Project Action Item reconciler uses -- so the WIP column and the project Overview tile agree by construction rather than by coincidence.

  * NEW api/reports/metrics.py -- pending_counts_by_project(), 3 bulk queries, ~80-160ms over 5047 POs / 19,848 items / 93 projects. Every query is raw SQL joining on PO status and must never become filters={"parent": ["in", ...]}: sqlparse's 10k-token cap throws in prod and passes on small data.
  * Clamps removed -- a count cannot be negative.
  * Disp PO and Total DN count Billable AND Non-Billable, each carrying its Billable slice for a hover split. Total DC and both missing_* stay Billable-only: a Non-Billable PO can never acquire a challan, so counting one as non-compliant parks a row that can never clear.

DN > DC report -- "Pending DN" re-defined. Its condition was `dnQty === 0 && dcQty > 0` (a challan with no delivery behind it), which ONE item system-wide met, on a test project. It now means ordered-not-yet-received, the same question the tile asks. Three parts were all required: the flag is carried separately from `status` (as a status it stole items from no_dc_update and dropped a PO off that card, 77 -> 76); the Delivered exclusion mirrors the predicate (without it 4 vs the tile's 2, and 28 vs 5 system-wide); and the zero-activity filter exempts flagged items, since a dispatched-but-undelivered line reads 0 on both quantities and was discarded before any verdict ran.

New UI: an info dialog rendering per-column source/conditions/formula from the same arrays that drive the table; Missing DN/DC deep-link into the DN > DC report with the status pre-filtered; header line reflowed; min-w-[1100px] so tablet and mobile scroll sideways instead of squashing every column to nothing.

Verified: missing_* vs an INDEPENDENT recomputation from predicates.py -- 0 rows differ, 0 negatives, the three Total columns identical to their raw COUNT(*). WIP vs the Overview tiles -- 0 mismatches. DN > DC card vs the tile -- same PO SET, not merely the same count. Backend 17/17, frontend tsc clean.

NOT browser-verified: this repo has no DOM test environment, so the responsive and hover behaviour rest on review.